### PR TITLE
Make "go test -gcflags=-d=checkptr" passes

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -85,7 +85,7 @@ func (d *Decoder) decode(src []byte, header *interfaceHeader) error {
 	typeptr := uintptr(unsafe.Pointer(typ))
 
 	// noescape trick for header.typ ( reflect.*rtype )
-	copiedType := (*rtype)(unsafe.Pointer(typeptr))
+	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
 	ptr := uintptr(header.ptr)
 
 	if err := d.validateType(copiedType, ptr); err != nil {
@@ -150,7 +150,7 @@ func (d *Decoder) Decode(v interface{}) error {
 	ptr := uintptr(header.ptr)
 	typeptr := uintptr(unsafe.Pointer(typ))
 	// noescape trick for header.typ ( reflect.*rtype )
-	copiedType := (*rtype)(unsafe.Pointer(typeptr))
+	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
 
 	if err := d.validateType(copiedType, ptr); err != nil {
 		return err

--- a/decode_bool.go
+++ b/decode_bool.go
@@ -66,13 +66,13 @@ func (d *boolDecoder) decodeStream(s *stream, p uintptr) error {
 			if err := trueBytes(s); err != nil {
 				return err
 			}
-			*(*bool)(unsafe.Pointer(p)) = true
+			**(**bool)(unsafe.Pointer(&p)) = true
 			return nil
 		case 'f':
 			if err := falseBytes(s); err != nil {
 				return err
 			}
-			*(*bool)(unsafe.Pointer(p)) = false
+			**(**bool)(unsafe.Pointer(&p)) = false
 			return nil
 		case nul:
 			if s.read() {
@@ -104,7 +104,7 @@ func (d *boolDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error)
 			return 0, errInvalidCharacter(buf[cursor+3], "bool(true)", cursor)
 		}
 		cursor += 4
-		*(*bool)(unsafe.Pointer(p)) = true
+		**(**bool)(unsafe.Pointer(&p)) = true
 		return cursor, nil
 	case 'f':
 		if cursor+4 >= buflen {
@@ -123,7 +123,7 @@ func (d *boolDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error)
 			return 0, errInvalidCharacter(buf[cursor+4], "bool(false)", cursor)
 		}
 		cursor += 5
-		*(*bool)(unsafe.Pointer(p)) = false
+		**(**bool)(unsafe.Pointer(&p)) = false
 		return cursor, nil
 	}
 	return 0, errUnexpectedEndOfJSON("bool", cursor)

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -89,73 +89,73 @@ func (d *Decoder) compilePtr(typ *rtype) (decoder, error) {
 
 func (d *Decoder) compileInt() (decoder, error) {
 	return newIntDecoder(func(p uintptr, v int64) {
-		*(*int)(unsafe.Pointer(p)) = int(v)
+		**(**int)(unsafe.Pointer(&p)) = int(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt8() (decoder, error) {
 	return newIntDecoder(func(p uintptr, v int64) {
-		*(*int8)(unsafe.Pointer(p)) = int8(v)
+		**(**int8)(unsafe.Pointer(&p)) = int8(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt16() (decoder, error) {
 	return newIntDecoder(func(p uintptr, v int64) {
-		*(*int16)(unsafe.Pointer(p)) = int16(v)
+		**(**int16)(unsafe.Pointer(&p)) = int16(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt32() (decoder, error) {
 	return newIntDecoder(func(p uintptr, v int64) {
-		*(*int32)(unsafe.Pointer(p)) = int32(v)
+		**(**int32)(unsafe.Pointer(&p)) = int32(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt64() (decoder, error) {
 	return newIntDecoder(func(p uintptr, v int64) {
-		*(*int64)(unsafe.Pointer(p)) = v
+		**(**int64)(unsafe.Pointer(&p)) = v
 	}), nil
 }
 
 func (d *Decoder) compileUint() (decoder, error) {
 	return newUintDecoder(func(p uintptr, v uint64) {
-		*(*uint)(unsafe.Pointer(p)) = uint(v)
+		**(**uint)(unsafe.Pointer(&p)) = uint(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint8() (decoder, error) {
 	return newUintDecoder(func(p uintptr, v uint64) {
-		*(*uint8)(unsafe.Pointer(p)) = uint8(v)
+		**(**uint8)(unsafe.Pointer(&p)) = uint8(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint16() (decoder, error) {
 	return newUintDecoder(func(p uintptr, v uint64) {
-		*(*uint16)(unsafe.Pointer(p)) = uint16(v)
+		**(**uint16)(unsafe.Pointer(&p)) = uint16(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint32() (decoder, error) {
 	return newUintDecoder(func(p uintptr, v uint64) {
-		*(*uint32)(unsafe.Pointer(p)) = uint32(v)
+		**(**uint32)(unsafe.Pointer(&p)) = uint32(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint64() (decoder, error) {
 	return newUintDecoder(func(p uintptr, v uint64) {
-		*(*uint64)(unsafe.Pointer(p)) = v
+		**(**uint64)(unsafe.Pointer(&p)) = v
 	}), nil
 }
 
 func (d *Decoder) compileFloat32() (decoder, error) {
 	return newFloatDecoder(func(p uintptr, v float64) {
-		*(*float32)(unsafe.Pointer(p)) = float32(v)
+		**(**float32)(unsafe.Pointer(&p)) = float32(v)
 	}), nil
 }
 
 func (d *Decoder) compileFloat64() (decoder, error) {
 	return newFloatDecoder(func(p uintptr, v float64) {
-		*(*float64)(unsafe.Pointer(p)) = v
+		**(**float64)(unsafe.Pointer(&p)) = v
 	}), nil
 }
 

--- a/decode_interface.go
+++ b/decode_interface.go
@@ -19,11 +19,11 @@ func newInterfaceDecoder(typ *rtype) *interfaceDecoder {
 func (d *interfaceDecoder) numDecoder(s *stream) decoder {
 	if s.useNumber {
 		return newNumberDecoder(func(p uintptr, v Number) {
-			*(*interface{})(unsafe.Pointer(p)) = v
+			**(**interface{})(unsafe.Pointer(&p)) = v
 		})
 	}
 	return newFloatDecoder(func(p uintptr, v float64) {
-		*(*interface{})(unsafe.Pointer(p)) = v
+		**(**interface{})(unsafe.Pointer(&p)) = v
 	})
 }
 
@@ -48,7 +48,7 @@ func (d *interfaceDecoder) decodeStream(s *stream, p uintptr) error {
 			).decodeStream(s, uintptr(ptr)); err != nil {
 				return err
 			}
-			*(*interface{})(unsafe.Pointer(p)) = v
+			**(**interface{})(unsafe.Pointer(&p)) = v
 			return nil
 		case '[':
 			var v []interface{}
@@ -61,7 +61,7 @@ func (d *interfaceDecoder) decodeStream(s *stream, p uintptr) error {
 			).decodeStream(s, uintptr(ptr)); err != nil {
 				return err
 			}
-			*(*interface{})(unsafe.Pointer(p)) = v
+			**(**interface{})(unsafe.Pointer(&p)) = v
 			return nil
 		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			return d.numDecoder(s).decodeStream(s, p)
@@ -77,7 +77,7 @@ func (d *interfaceDecoder) decodeStream(s *stream, p uintptr) error {
 				case '"':
 					literal := s.buf[start:s.cursor]
 					s.cursor++
-					*(*interface{})(unsafe.Pointer(p)) = *(*string)(unsafe.Pointer(&literal))
+					**(**interface{})(unsafe.Pointer(&p)) = *(*string)(unsafe.Pointer(&literal))
 					return nil
 				case nul:
 					if s.read() {
@@ -92,19 +92,19 @@ func (d *interfaceDecoder) decodeStream(s *stream, p uintptr) error {
 			if err := trueBytes(s); err != nil {
 				return err
 			}
-			*(*interface{})(unsafe.Pointer(p)) = true
+			**(**interface{})(unsafe.Pointer(&p)) = true
 			return nil
 		case 'f':
 			if err := falseBytes(s); err != nil {
 				return err
 			}
-			*(*interface{})(unsafe.Pointer(p)) = false
+			**(**interface{})(unsafe.Pointer(&p)) = false
 			return nil
 		case 'n':
 			if err := nullBytes(s); err != nil {
 				return err
 			}
-			*(*interface{})(unsafe.Pointer(p)) = nil
+			**(**interface{})(unsafe.Pointer(&p)) = nil
 			return nil
 		case nul:
 			if s.read() {
@@ -132,7 +132,7 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, e
 		if err != nil {
 			return 0, err
 		}
-		*(*interface{})(unsafe.Pointer(p)) = v
+		**(**interface{})(unsafe.Pointer(&p)) = v
 		return cursor, nil
 	case '[':
 		var v []interface{}
@@ -147,11 +147,11 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, e
 		if err != nil {
 			return 0, err
 		}
-		*(*interface{})(unsafe.Pointer(p)) = v
+		**(**interface{})(unsafe.Pointer(&p)) = v
 		return cursor, nil
 	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 		return newFloatDecoder(func(p uintptr, v float64) {
-			*(*interface{})(unsafe.Pointer(p)) = v
+			**(**interface{})(unsafe.Pointer(&p)) = v
 		}).decode(buf, cursor, p)
 	case '"':
 		cursor++
@@ -163,7 +163,7 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, e
 			case '"':
 				literal := buf[start:cursor]
 				cursor++
-				*(*interface{})(unsafe.Pointer(p)) = *(*string)(unsafe.Pointer(&literal))
+				**(**interface{})(unsafe.Pointer(&p)) = *(*string)(unsafe.Pointer(&literal))
 				return cursor, nil
 			case nul:
 				return 0, errUnexpectedEndOfJSON("string", cursor)
@@ -185,7 +185,7 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, e
 			return 0, errInvalidCharacter(buf[cursor+3], "bool(true)", cursor)
 		}
 		cursor += 4
-		*(*interface{})(unsafe.Pointer(p)) = true
+		**(**interface{})(unsafe.Pointer(&p)) = true
 		return cursor, nil
 	case 'f':
 		if cursor+4 >= int64(len(buf)) {
@@ -204,7 +204,7 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, e
 			return 0, errInvalidCharacter(buf[cursor+4], "bool(false)", cursor)
 		}
 		cursor += 5
-		*(*interface{})(unsafe.Pointer(p)) = false
+		**(**interface{})(unsafe.Pointer(&p)) = false
 		return cursor, nil
 	case 'n':
 		if cursor+3 >= int64(len(buf)) {
@@ -220,7 +220,7 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, e
 			return 0, errInvalidCharacter(buf[cursor+3], "null", cursor)
 		}
 		cursor += 4
-		*(*interface{})(unsafe.Pointer(p)) = nil
+		**(**interface{})(unsafe.Pointer(&p)) = nil
 		return cursor, nil
 	}
 	return cursor, errNotAtBeginningOfValue(cursor)

--- a/decode_map.go
+++ b/decode_map.go
@@ -65,7 +65,7 @@ func (d *mapDecoder) decodeStream(s *stream, p uintptr) error {
 	s.skipWhiteSpace()
 	mapValue := makemap(d.mapType, 0)
 	if s.buf[s.cursor+1] == '}' {
-		*(*unsafe.Pointer)(unsafe.Pointer(p)) = mapValue
+		**(**unsafe.Pointer)(unsafe.Pointer(&p)) = mapValue
 		s.cursor++
 		return nil
 	}
@@ -96,7 +96,7 @@ func (d *mapDecoder) decodeStream(s *stream, p uintptr) error {
 			s.read()
 		}
 		if s.char() == '}' {
-			*(*unsafe.Pointer)(unsafe.Pointer(p)) = mapValue
+			**(**unsafe.Pointer)(unsafe.Pointer(&p)) = mapValue
 			s.cursor++
 			return nil
 		}
@@ -137,7 +137,7 @@ func (d *mapDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) 
 	cursor = skipWhiteSpace(buf, cursor)
 	mapValue := makemap(d.mapType, 0)
 	if buf[cursor] == '}' {
-		*(*unsafe.Pointer)(unsafe.Pointer(p)) = mapValue
+		**(**unsafe.Pointer)(unsafe.Pointer(&p)) = mapValue
 		cursor++
 		return cursor, nil
 	}
@@ -165,7 +165,7 @@ func (d *mapDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) 
 		mapassign(d.mapType, mapValue, unsafe.Pointer(&key), unsafe.Pointer(&value))
 		cursor = skipWhiteSpace(buf, valueCursor)
 		if buf[cursor] == '}' {
-			*(*unsafe.Pointer)(unsafe.Pointer(p)) = mapValue
+			**(**unsafe.Pointer)(unsafe.Pointer(&p)) = mapValue
 			cursor++
 			return cursor, nil
 		}

--- a/decode_ptr.go
+++ b/decode_ptr.go
@@ -21,7 +21,7 @@ func (d *ptrDecoder) decodeStream(s *stream, p uintptr) error {
 	if err := d.dec.decodeStream(s, newptr); err != nil {
 		return err
 	}
-	*(*uintptr)(unsafe.Pointer(p)) = newptr
+	**(**uintptr)(unsafe.Pointer(&p)) = newptr
 	return nil
 }
 
@@ -32,6 +32,6 @@ func (d *ptrDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) 
 		return 0, err
 	}
 	cursor = c
-	*(*uintptr)(unsafe.Pointer(p)) = newptr
+	**(**uintptr)(unsafe.Pointer(&p)) = newptr
 	return cursor, nil
 }

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -70,7 +70,7 @@ func (d *sliceDecoder) decodeStream(s *stream, p uintptr) error {
 			s.cursor++
 			s.skipWhiteSpace()
 			if s.char() == ']' {
-				*(*sliceHeader)(unsafe.Pointer(p)) = sliceHeader{
+				**(**sliceHeader)(unsafe.Pointer(&p)) = sliceHeader{
 					data: newArray(d.elemType, 0),
 					len:  0,
 					cap:  0,
@@ -111,7 +111,7 @@ func (d *sliceDecoder) decodeStream(s *stream, p uintptr) error {
 						len:  slice.len,
 						cap:  slice.cap,
 					})
-					*(*sliceHeader)(unsafe.Pointer(p)) = dst
+					**(**sliceHeader)(unsafe.Pointer(&p)) = dst
 					d.releaseSlice(slice)
 					s.cursor++
 					return nil
@@ -170,7 +170,7 @@ func (d *sliceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error
 			cursor++
 			cursor = skipWhiteSpace(buf, cursor)
 			if buf[cursor] == ']' {
-				*(*sliceHeader)(unsafe.Pointer(p)) = sliceHeader{
+				**(**sliceHeader)(unsafe.Pointer(&p)) = sliceHeader{
 					data: newArray(d.elemType, 0),
 					len:  0,
 					cap:  0,
@@ -212,7 +212,7 @@ func (d *sliceDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error
 						len:  slice.len,
 						cap:  slice.cap,
 					})
-					*(*sliceHeader)(unsafe.Pointer(p)) = dst
+					**(**sliceHeader)(unsafe.Pointer(&p)) = dst
 					d.releaseSlice(slice)
 					cursor++
 					return cursor, nil

--- a/decode_string.go
+++ b/decode_string.go
@@ -16,7 +16,7 @@ func (d *stringDecoder) decodeStream(s *stream, p uintptr) error {
 	if err != nil {
 		return err
 	}
-	*(*string)(unsafe.Pointer(p)) = *(*string)(unsafe.Pointer(&bytes))
+	**(**string)(unsafe.Pointer(&p)) = *(*string)(unsafe.Pointer(&bytes))
 	return nil
 }
 
@@ -26,7 +26,7 @@ func (d *stringDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, erro
 		return 0, err
 	}
 	cursor = c
-	*(*string)(unsafe.Pointer(p)) = *(*string)(unsafe.Pointer(&bytes))
+	**(**string)(unsafe.Pointer(&p)) = *(*string)(unsafe.Pointer(&bytes))
 	return cursor, nil
 }
 

--- a/decode_unmarshal_json.go
+++ b/decode_unmarshal_json.go
@@ -21,7 +21,7 @@ func (d *unmarshalJSONDecoder) decodeStream(s *stream, p uintptr) error {
 	src := s.buf[start:s.cursor]
 	v := *(*interface{})(unsafe.Pointer(&interfaceHeader{
 		typ: d.typ,
-		ptr: unsafe.Pointer(p),
+		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&p)),
 	}))
 	if err := v.(Unmarshaler).UnmarshalJSON(src); err != nil {
 		return err
@@ -39,7 +39,7 @@ func (d *unmarshalJSONDecoder) decode(buf []byte, cursor int64, p uintptr) (int6
 	src := buf[start:end]
 	v := *(*interface{})(unsafe.Pointer(&interfaceHeader{
 		typ: d.typ,
-		ptr: unsafe.Pointer(p),
+		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&p)),
 	}))
 	if err := v.(Unmarshaler).UnmarshalJSON(src); err != nil {
 		return 0, err

--- a/decode_unmarshal_text.go
+++ b/decode_unmarshal_text.go
@@ -28,7 +28,7 @@ func (d *unmarshalTextDecoder) decodeStream(s *stream, p uintptr) error {
 	}
 	v := *(*interface{})(unsafe.Pointer(&interfaceHeader{
 		typ: d.typ,
-		ptr: unsafe.Pointer(p),
+		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&p)),
 	}))
 	if err := v.(encoding.TextUnmarshaler).UnmarshalText(src); err != nil {
 		return err
@@ -49,7 +49,7 @@ func (d *unmarshalTextDecoder) decode(buf []byte, cursor int64, p uintptr) (int6
 	}
 	v := *(*interface{})(unsafe.Pointer(&interfaceHeader{
 		typ: d.typ,
-		ptr: unsafe.Pointer(p),
+		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&p)),
 	}))
 	if err := v.(encoding.TextUnmarshaler).UnmarshalText(src); err != nil {
 		return 0, err

--- a/encode.go
+++ b/encode.go
@@ -191,7 +191,7 @@ func (e *Encoder) encode(v interface{}) error {
 	}
 
 	// noescape trick for header.typ ( reflect.*rtype )
-	copiedType := (*rtype)(unsafe.Pointer(typeptr))
+	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
 
 	codeIndent, err := e.compileHead(&encodeCompileContext{
 		typ:        copiedType,

--- a/encode_context.go
+++ b/encode_context.go
@@ -1,7 +1,6 @@
 package json
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -95,6 +94,6 @@ func (c *encodeRuntimeContext) init(p uintptr) {
 }
 
 func (c *encodeRuntimeContext) ptr() uintptr {
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&c.ptrs))
-	return header.Data
+	header := (*sliceHeader)(unsafe.Pointer(&c.ptrs))
+	return uintptr(header.data)
 }

--- a/encode_vm.go
+++ b/encode_vm.go
@@ -175,8 +175,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 			code = code.next
 		case opBytes:
 			ptr := load(ctxptr, code.idx)
-			header := (*reflect.SliceHeader)(unsafe.Pointer(ptr))
-			if ptr == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(ptr))
+			if ptr == 0 || uintptr(header.data) == 0 {
 				e.encodeNull()
 			} else {
 				e.encodeByteSlice(e.ptrToBytes(ptr))
@@ -498,19 +498,19 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 			code = code.next
 		case opSliceHead:
 			p := load(ctxptr, code.idx)
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				e.encodeNull()
 				e.encodeByte(',')
 				code = code.end.next
 			} else {
 				store(ctxptr, code.elemIdx, 0)
-				store(ctxptr, code.length, uintptr(header.Len))
-				store(ctxptr, code.idx, header.Data)
-				if header.Len > 0 {
+				store(ctxptr, code.length, uintptr(header.len))
+				store(ctxptr, code.idx, uintptr(header.data))
+				if header.len > 0 {
 					e.encodeByte('[')
 					code = code.next
-					store(ctxptr, code.idx, header.Data)
+					store(ctxptr, code.idx, uintptr(header.data))
 				} else {
 					e.encodeBytes([]byte{'[', ']', ','})
 					code = code.end.next
@@ -540,15 +540,15 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 				e.encodeBytes([]byte{',', '\n'})
 				code = code.end.next
 			} else {
-				header := (*reflect.SliceHeader)(unsafe.Pointer(p))
+				header := (*sliceHeader)(unsafe.Pointer(p))
 				store(ctxptr, code.elemIdx, 0)
-				store(ctxptr, code.length, uintptr(header.Len))
-				store(ctxptr, code.idx, header.Data)
-				if header.Len > 0 {
+				store(ctxptr, code.length, uintptr(header.len))
+				store(ctxptr, code.idx, uintptr(header.data))
+				if header.len > 0 {
 					e.encodeBytes([]byte{'[', '\n'})
 					e.encodeIndent(code.indent + 1)
 					code = code.next
-					store(ctxptr, code.idx, header.Data)
+					store(ctxptr, code.idx, uintptr(header.data))
 				} else {
 					e.encodeIndent(code.indent)
 					e.encodeBytes([]byte{'[', ']', '\n'})
@@ -563,15 +563,15 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 				e.encodeBytes([]byte{',', '\n'})
 				code = code.end.next
 			} else {
-				header := (*reflect.SliceHeader)(unsafe.Pointer(p))
+				header := (*sliceHeader)(unsafe.Pointer(p))
 				store(ctxptr, code.elemIdx, 0)
-				store(ctxptr, code.length, uintptr(header.Len))
-				store(ctxptr, code.idx, header.Data)
-				if header.Len > 0 {
+				store(ctxptr, code.length, uintptr(header.len))
+				store(ctxptr, code.idx, uintptr(header.data))
+				if header.len > 0 {
 					e.encodeBytes([]byte{'[', '\n'})
 					e.encodeIndent(code.indent + 1)
 					code = code.next
-					store(ctxptr, code.idx, header.Data)
+					store(ctxptr, code.idx, uintptr(header.data))
 				} else {
 					e.encodeIndent(code.indent)
 					e.encodeBytes([]byte{'[', ']', ',', '\n'})
@@ -5229,8 +5229,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 			e.encodeByte(' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				e.encodeNull()
 				e.encodeBytes([]byte{',', '\n'})
 				code = code.nextField
@@ -5243,8 +5243,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 			e.encodeByte(' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				e.encodeNull()
 				e.encodeBytes([]byte{',', '\n'})
 				code = code.nextField
@@ -5509,8 +5509,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 		case opStructFieldOmitEmptyArray:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				code = code.nextField
 			} else {
 				code = code.next
@@ -5518,8 +5518,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 		case opStructFieldOmitEmptySlice:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				code = code.nextField
 			} else {
 				code = code.next
@@ -5740,8 +5740,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 		case opStructFieldOmitEmptyArrayIndent:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				code = code.nextField
 			} else {
 				e.encodeIndent(code.indent)
@@ -5752,8 +5752,8 @@ func (e *Encoder) run(ctx *encodeRuntimeContext, code *opcode) error {
 		case opStructFieldOmitEmptySliceIndent:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			header := (*reflect.SliceHeader)(unsafe.Pointer(p))
-			if p == 0 || header.Data == 0 {
+			header := (*sliceHeader)(unsafe.Pointer(p))
+			if p == 0 || uintptr(header.data) == 0 {
 				code = code.nextField
 			} else {
 				e.encodeIndent(code.indent)


### PR DESCRIPTION
Most of the invalid usages due to the conversion from uintptr to
unsafe.Pointer. In general, unsafe.Pointer(p) where p of type uintptr is
considered unsafe.

To fix that, use &p instead of p, then introduce another dereference.
Example, the invalid usage:

```
*(*int)(unsafe.Pointer(p)) = int(v)
```

wil become:

```
**(**int)(unsafe.Pointer(&p)) = int(v)
```

While at it, also removing all usages of reflect.SliceHeader.

There're some problem with current usage of reflect.SliceHeader.

First, it violates the unsafe pointer conversion (rule 6th), that said,
reflect.SliceHeader must not used as plain struct.

Second, the lowest version that go-json supports, go1.12, reflect
package did not use SliceHeader in typedslicecopy, but use the safety
version. There's no reason that go-json continue using them.

See:

 - https://golang.org/pkg/unsafe/#Pointer
 - https://github.com/golang/go/blob/release-branch.go1.12/src/reflect/value.go#L2702