### PR TITLE
Fix race data for decoder

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -16,8 +16,8 @@ func (d Delim) String() string {
 }
 
 type decoder interface {
-	decode([]byte, int64, uintptr) (int64, error)
-	decodeStream(*stream, uintptr) error
+	decode([]byte, int64, unsafe.Pointer) (int64, error)
+	decodeStream(*stream, unsafe.Pointer) error
 }
 
 type Decoder struct {
@@ -101,7 +101,7 @@ func (d *Decoder) decode(src []byte, header *interfaceHeader) error {
 		cachedDecoder.set(typeptr, compiledDec)
 		dec = compiledDec
 	}
-	if _, err := dec.decode(src, 0, ptr); err != nil {
+	if _, err := dec.decode(src, 0, header.ptr); err != nil {
 		return err
 	}
 	return nil
@@ -170,7 +170,7 @@ func (d *Decoder) Decode(v interface{}) error {
 		return err
 	}
 	s := d.s
-	if err := dec.decodeStream(s, ptr); err != nil {
+	if err := dec.decodeStream(s, header.ptr); err != nil {
 		return err
 	}
 	return nil

--- a/decode_array.go
+++ b/decode_array.go
@@ -1,5 +1,7 @@
 package json
 
+import "unsafe"
+
 type arrayDecoder struct {
 	elemType     *rtype
 	size         uintptr
@@ -16,7 +18,7 @@ func newArrayDecoder(dec decoder, elemType *rtype, alen int) *arrayDecoder {
 	}
 }
 
-func (d *arrayDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *arrayDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	for {
 		switch s.char() {
 		case ' ', '\n', '\t', '\r':
@@ -29,7 +31,8 @@ func (d *arrayDecoder) decodeStream(s *stream, p uintptr) error {
 			idx := 0
 			for {
 				s.cursor++
-				if err := d.valueDecoder.decodeStream(s, p+uintptr(idx)*d.size); err != nil {
+				addr := uintptr(p) + uintptr(idx)*d.size
+				if err := d.valueDecoder.decodeStream(s, unsafe.Pointer(addr)); err != nil {
 					return err
 				}
 				s.skipWhiteSpace()
@@ -62,7 +65,7 @@ ERROR:
 	return errUnexpectedEndOfJSON("array", s.totalOffset())
 }
 
-func (d *arrayDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *arrayDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	buflen := int64(len(buf))
 	for ; cursor < buflen; cursor++ {
 		switch buf[cursor] {
@@ -88,7 +91,8 @@ func (d *arrayDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error
 			idx := 0
 			for {
 				cursor++
-				c, err := d.valueDecoder.decode(buf, cursor, p+uintptr(idx)*d.size)
+				addr := uintptr(p) + uintptr(idx)*d.size
+				c, err := d.valueDecoder.decode(buf, cursor, unsafe.Pointer(addr))
 				if err != nil {
 					return 0, err
 				}

--- a/decode_bool.go
+++ b/decode_bool.go
@@ -58,7 +58,7 @@ func falseBytes(s *stream) error {
 	return nil
 }
 
-func (d *boolDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *boolDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	s.skipWhiteSpace()
 	for {
 		switch s.char() {
@@ -86,7 +86,7 @@ ERROR:
 	return errUnexpectedEndOfJSON("bool", s.totalOffset())
 }
 
-func (d *boolDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *boolDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	buflen := int64(len(buf))
 	cursor = skipWhiteSpace(buf, cursor)
 	switch buf[cursor] {

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -88,74 +88,74 @@ func (d *Decoder) compilePtr(typ *rtype) (decoder, error) {
 }
 
 func (d *Decoder) compileInt() (decoder, error) {
-	return newIntDecoder(func(p uintptr, v int64) {
-		**(**int)(unsafe.Pointer(&p)) = int(v)
+	return newIntDecoder(func(p unsafe.Pointer, v int64) {
+		*(*int)(p) = int(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt8() (decoder, error) {
-	return newIntDecoder(func(p uintptr, v int64) {
-		**(**int8)(unsafe.Pointer(&p)) = int8(v)
+	return newIntDecoder(func(p unsafe.Pointer, v int64) {
+		*(*int8)(p) = int8(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt16() (decoder, error) {
-	return newIntDecoder(func(p uintptr, v int64) {
-		**(**int16)(unsafe.Pointer(&p)) = int16(v)
+	return newIntDecoder(func(p unsafe.Pointer, v int64) {
+		*(*int16)(p) = int16(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt32() (decoder, error) {
-	return newIntDecoder(func(p uintptr, v int64) {
-		**(**int32)(unsafe.Pointer(&p)) = int32(v)
+	return newIntDecoder(func(p unsafe.Pointer, v int64) {
+		*(*int32)(p) = int32(v)
 	}), nil
 }
 
 func (d *Decoder) compileInt64() (decoder, error) {
-	return newIntDecoder(func(p uintptr, v int64) {
-		**(**int64)(unsafe.Pointer(&p)) = v
+	return newIntDecoder(func(p unsafe.Pointer, v int64) {
+		*(*int64)(p) = v
 	}), nil
 }
 
 func (d *Decoder) compileUint() (decoder, error) {
-	return newUintDecoder(func(p uintptr, v uint64) {
-		**(**uint)(unsafe.Pointer(&p)) = uint(v)
+	return newUintDecoder(func(p unsafe.Pointer, v uint64) {
+		*(*uint)(p) = uint(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint8() (decoder, error) {
-	return newUintDecoder(func(p uintptr, v uint64) {
-		**(**uint8)(unsafe.Pointer(&p)) = uint8(v)
+	return newUintDecoder(func(p unsafe.Pointer, v uint64) {
+		*(*uint8)(p) = uint8(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint16() (decoder, error) {
-	return newUintDecoder(func(p uintptr, v uint64) {
-		**(**uint16)(unsafe.Pointer(&p)) = uint16(v)
+	return newUintDecoder(func(p unsafe.Pointer, v uint64) {
+		*(*uint16)(p) = uint16(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint32() (decoder, error) {
-	return newUintDecoder(func(p uintptr, v uint64) {
-		**(**uint32)(unsafe.Pointer(&p)) = uint32(v)
+	return newUintDecoder(func(p unsafe.Pointer, v uint64) {
+		*(*uint32)(p) = uint32(v)
 	}), nil
 }
 
 func (d *Decoder) compileUint64() (decoder, error) {
-	return newUintDecoder(func(p uintptr, v uint64) {
-		**(**uint64)(unsafe.Pointer(&p)) = v
+	return newUintDecoder(func(p unsafe.Pointer, v uint64) {
+		*(*uint64)(p) = v
 	}), nil
 }
 
 func (d *Decoder) compileFloat32() (decoder, error) {
-	return newFloatDecoder(func(p uintptr, v float64) {
-		**(**float32)(unsafe.Pointer(&p)) = float32(v)
+	return newFloatDecoder(func(p unsafe.Pointer, v float64) {
+		*(*float32)(p) = float32(v)
 	}), nil
 }
 
 func (d *Decoder) compileFloat64() (decoder, error) {
-	return newFloatDecoder(func(p uintptr, v float64) {
-		**(**float64)(unsafe.Pointer(&p)) = v
+	return newFloatDecoder(func(p unsafe.Pointer, v float64) {
+		*(*float64)(p) = v
 	}), nil
 }
 

--- a/decode_float.go
+++ b/decode_float.go
@@ -6,10 +6,10 @@ import (
 )
 
 type floatDecoder struct {
-	op func(uintptr, float64)
+	op func(unsafe.Pointer, float64)
 }
 
-func newFloatDecoder(op func(uintptr, float64)) *floatDecoder {
+func newFloatDecoder(op func(unsafe.Pointer, float64)) *floatDecoder {
 	return &floatDecoder{op: op}
 }
 
@@ -107,7 +107,7 @@ func (d *floatDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, erro
 	return nil, 0, errUnexpectedEndOfJSON("float", cursor)
 }
 
-func (d *floatDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *floatDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	bytes, err := d.decodeStreamByte(s)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func (d *floatDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *floatDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *floatDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	bytes, c, err := d.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err

--- a/decode_int.go
+++ b/decode_int.go
@@ -1,10 +1,12 @@
 package json
 
+import "unsafe"
+
 type intDecoder struct {
-	op func(uintptr, int64)
+	op func(unsafe.Pointer, int64)
 }
 
-func newIntDecoder(op func(uintptr, int64)) *intDecoder {
+func newIntDecoder(op func(unsafe.Pointer, int64)) *intDecoder {
 	return &intDecoder{op: op}
 }
 
@@ -128,7 +130,7 @@ func (d *intDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, error)
 	return nil, 0, errUnexpectedEndOfJSON("number(integer)", cursor)
 }
 
-func (d *intDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *intDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	bytes, err := d.decodeStreamByte(s)
 	if err != nil {
 		return err
@@ -137,7 +139,7 @@ func (d *intDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *intDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *intDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	bytes, c, err := d.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err

--- a/decode_interface.go
+++ b/decode_interface.go
@@ -6,8 +6,7 @@ import (
 )
 
 type interfaceDecoder struct {
-	typ   *rtype
-	dummy unsafe.Pointer // for escape value
+	typ *rtype
 }
 
 func newInterfaceDecoder(typ *rtype) *interfaceDecoder {
@@ -40,7 +39,6 @@ func (d *interfaceDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 		case '{':
 			var v map[string]interface{}
 			ptr := unsafe.Pointer(&v)
-			d.dummy = ptr
 			if err := newMapDecoder(
 				interfaceMapType,
 				newStringDecoder(),
@@ -53,7 +51,6 @@ func (d *interfaceDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 		case '[':
 			var v []interface{}
 			ptr := unsafe.Pointer(&v)
-			d.dummy = ptr // escape ptr
 			if err := newSliceDecoder(
 				newInterfaceDecoder(d.typ),
 				d.typ,
@@ -122,7 +119,6 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (i
 	case '{':
 		var v map[string]interface{}
 		ptr := unsafe.Pointer(&v)
-		d.dummy = ptr
 		dec := newMapDecoder(
 			interfaceMapType,
 			newStringDecoder(),
@@ -137,7 +133,6 @@ func (d *interfaceDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (i
 	case '[':
 		var v []interface{}
 		ptr := unsafe.Pointer(&v)
-		d.dummy = ptr // escape ptr
 		dec := newSliceDecoder(
 			newInterfaceDecoder(d.typ),
 			d.typ,

--- a/decode_map.go
+++ b/decode_map.go
@@ -29,28 +29,28 @@ func mapassign(t *rtype, m unsafe.Pointer, key, val unsafe.Pointer)
 func (d *mapDecoder) setKey(buf []byte, cursor int64, key interface{}) (int64, error) {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
 	d.dummy = header
-	return d.keyDecoder.decode(buf, cursor, uintptr(header.ptr))
+	return d.keyDecoder.decode(buf, cursor, header.ptr)
 }
 
 func (d *mapDecoder) setValue(buf []byte, cursor int64, key interface{}) (int64, error) {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
 	d.dummy = header
-	return d.valueDecoder.decode(buf, cursor, uintptr(header.ptr))
+	return d.valueDecoder.decode(buf, cursor, header.ptr)
 }
 
 func (d *mapDecoder) setKeyStream(s *stream, key interface{}) error {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
 	d.dummy = header
-	return d.keyDecoder.decodeStream(s, uintptr(header.ptr))
+	return d.keyDecoder.decodeStream(s, header.ptr)
 }
 
 func (d *mapDecoder) setValueStream(s *stream, key interface{}) error {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
 	d.dummy = header
-	return d.valueDecoder.decodeStream(s, uintptr(header.ptr))
+	return d.valueDecoder.decodeStream(s, header.ptr)
 }
 
-func (d *mapDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *mapDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	s.skipWhiteSpace()
 	switch s.char() {
 	case 'n':
@@ -107,7 +107,7 @@ func (d *mapDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *mapDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *mapDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	cursor = skipWhiteSpace(buf, cursor)
 	buflen := int64(len(buf))
 	if buflen < 2 {

--- a/decode_map.go
+++ b/decode_map.go
@@ -8,7 +8,6 @@ type mapDecoder struct {
 	mapType      *rtype
 	keyDecoder   decoder
 	valueDecoder decoder
-	dummy        *interfaceHeader
 }
 
 func newMapDecoder(mapType *rtype, keyDec decoder, valueDec decoder) *mapDecoder {
@@ -28,25 +27,21 @@ func mapassign(t *rtype, m unsafe.Pointer, key, val unsafe.Pointer)
 
 func (d *mapDecoder) setKey(buf []byte, cursor int64, key interface{}) (int64, error) {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
-	d.dummy = header
 	return d.keyDecoder.decode(buf, cursor, header.ptr)
 }
 
 func (d *mapDecoder) setValue(buf []byte, cursor int64, key interface{}) (int64, error) {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
-	d.dummy = header
 	return d.valueDecoder.decode(buf, cursor, header.ptr)
 }
 
 func (d *mapDecoder) setKeyStream(s *stream, key interface{}) error {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
-	d.dummy = header
 	return d.keyDecoder.decodeStream(s, header.ptr)
 }
 
 func (d *mapDecoder) setValueStream(s *stream, key interface{}) error {
 	header := (*interfaceHeader)(unsafe.Pointer(&key))
-	d.dummy = header
 	return d.valueDecoder.decodeStream(s, header.ptr)
 }
 

--- a/decode_number.go
+++ b/decode_number.go
@@ -6,17 +6,17 @@ import (
 
 type numberDecoder struct {
 	*floatDecoder
-	op func(uintptr, Number)
+	op func(unsafe.Pointer, Number)
 }
 
-func newNumberDecoder(op func(uintptr, Number)) *numberDecoder {
+func newNumberDecoder(op func(unsafe.Pointer, Number)) *numberDecoder {
 	return &numberDecoder{
 		floatDecoder: newFloatDecoder(nil),
 		op:           op,
 	}
 }
 
-func (d *numberDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *numberDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	bytes, err := d.floatDecoder.decodeStreamByte(s)
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func (d *numberDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *numberDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *numberDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	bytes, c, err := d.floatDecoder.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err

--- a/decode_ptr.go
+++ b/decode_ptr.go
@@ -14,24 +14,24 @@ func newPtrDecoder(dec decoder, typ *rtype) *ptrDecoder {
 }
 
 //go:linkname unsafe_New reflect.unsafe_New
-func unsafe_New(*rtype) uintptr
+func unsafe_New(*rtype) unsafe.Pointer
 
-func (d *ptrDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *ptrDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	newptr := unsafe_New(d.typ)
+	*(*unsafe.Pointer)(p) = newptr
 	if err := d.dec.decodeStream(s, newptr); err != nil {
 		return err
 	}
-	**(**uintptr)(unsafe.Pointer(&p)) = newptr
 	return nil
 }
 
-func (d *ptrDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *ptrDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	newptr := unsafe_New(d.typ)
+	*(*unsafe.Pointer)(p) = newptr
 	c, err := d.dec.decode(buf, cursor, newptr)
 	if err != nil {
 		return 0, err
 	}
 	cursor = c
-	**(**uintptr)(unsafe.Pointer(&p)) = newptr
 	return cursor, nil
 }

--- a/decode_string.go
+++ b/decode_string.go
@@ -11,7 +11,7 @@ func newStringDecoder() *stringDecoder {
 	return &stringDecoder{}
 }
 
-func (d *stringDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *stringDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	bytes, err := d.decodeStreamByte(s)
 	if err != nil {
 		return err
@@ -20,7 +20,7 @@ func (d *stringDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *stringDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *stringDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	bytes, c, err := d.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err

--- a/decode_uint.go
+++ b/decode_uint.go
@@ -1,10 +1,12 @@
 package json
 
+import "unsafe"
+
 type uintDecoder struct {
-	op func(uintptr, uint64)
+	op func(unsafe.Pointer, uint64)
 }
 
-func newUintDecoder(op func(uintptr, uint64)) *uintDecoder {
+func newUintDecoder(op func(unsafe.Pointer, uint64)) *uintDecoder {
 	return &uintDecoder{op: op}
 }
 
@@ -81,7 +83,7 @@ func (d *uintDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, error
 	return nil, 0, errUnexpectedEndOfJSON("number(unsigned integer)", cursor)
 }
 
-func (d *uintDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *uintDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	bytes, err := d.decodeStreamByte(s)
 	if err != nil {
 		return err
@@ -90,7 +92,7 @@ func (d *uintDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *uintDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *uintDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	bytes, c, err := d.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err

--- a/decode_unmarshal_json.go
+++ b/decode_unmarshal_json.go
@@ -12,7 +12,7 @@ func newUnmarshalJSONDecoder(typ *rtype) *unmarshalJSONDecoder {
 	return &unmarshalJSONDecoder{typ: typ}
 }
 
-func (d *unmarshalJSONDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *unmarshalJSONDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	s.skipWhiteSpace()
 	start := s.cursor
 	if err := s.skipValue(); err != nil {
@@ -29,7 +29,7 @@ func (d *unmarshalJSONDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *unmarshalJSONDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *unmarshalJSONDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	cursor = skipWhiteSpace(buf, cursor)
 	start := cursor
 	end, err := skipValue(buf, cursor)

--- a/decode_unmarshal_text.go
+++ b/decode_unmarshal_text.go
@@ -16,7 +16,7 @@ func newUnmarshalTextDecoder(typ *rtype) *unmarshalTextDecoder {
 	return &unmarshalTextDecoder{typ: typ}
 }
 
-func (d *unmarshalTextDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *unmarshalTextDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	s.skipWhiteSpace()
 	start := s.cursor
 	if err := s.skipValue(); err != nil {
@@ -36,7 +36,7 @@ func (d *unmarshalTextDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *unmarshalTextDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *unmarshalTextDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	cursor = skipWhiteSpace(buf, cursor)
 	start := cursor
 	end, err := skipValue(buf, cursor)

--- a/decode_wrapped_string.go
+++ b/decode_wrapped_string.go
@@ -1,5 +1,7 @@
 package json
 
+import "unsafe"
+
 type wrappedStringDecoder struct {
 	dec           decoder
 	stringDecoder *stringDecoder
@@ -12,7 +14,7 @@ func newWrappedStringDecoder(dec decoder) *wrappedStringDecoder {
 	}
 }
 
-func (d *wrappedStringDecoder) decodeStream(s *stream, p uintptr) error {
+func (d *wrappedStringDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	bytes, err := d.stringDecoder.decodeStreamByte(s)
 	if err != nil {
 		return err
@@ -39,7 +41,7 @@ func (d *wrappedStringDecoder) decodeStream(s *stream, p uintptr) error {
 	return nil
 }
 
-func (d *wrappedStringDecoder) decode(buf []byte, cursor int64, p uintptr) (int64, error) {
+func (d *wrappedStringDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64, error) {
 	bytes, c, err := d.stringDecoder.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Pass `unsafe.Pointer` instead of `uintptr` to `decode()` .
So, currently `UnmarshalNoEscape` doesn't work ... ( can't reduce allocation count )