### PR TITLE
Fix checkptr validation error on decode

### DIFF
--- a/decode_array.go
+++ b/decode_array.go
@@ -32,7 +32,7 @@ func (d *arrayDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 			for {
 				s.cursor++
 				addr := uintptr(p) + uintptr(idx)*d.size
-				if err := d.valueDecoder.decodeStream(s, unsafe.Pointer(addr)); err != nil {
+				if err := d.valueDecoder.decodeStream(s, *(*unsafe.Pointer)(unsafe.Pointer(&addr))); err != nil {
 					return err
 				}
 				s.skipWhiteSpace()
@@ -92,7 +92,7 @@ func (d *arrayDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64
 			for {
 				cursor++
 				addr := uintptr(p) + uintptr(idx)*d.size
-				c, err := d.valueDecoder.decode(buf, cursor, unsafe.Pointer(addr))
+				c, err := d.valueDecoder.decode(buf, cursor, *(*unsafe.Pointer)(unsafe.Pointer(&addr)))
 				if err != nil {
 					return 0, err
 				}

--- a/decode_array.go
+++ b/decode_array.go
@@ -31,8 +31,7 @@ func (d *arrayDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 			idx := 0
 			for {
 				s.cursor++
-				addr := uintptr(p) + uintptr(idx)*d.size
-				if err := d.valueDecoder.decodeStream(s, *(*unsafe.Pointer)(unsafe.Pointer(&addr))); err != nil {
+				if err := d.valueDecoder.decodeStream(s, unsafe.Pointer(uintptr(p)+uintptr(idx)*d.size)); err != nil {
 					return err
 				}
 				s.skipWhiteSpace()
@@ -91,8 +90,7 @@ func (d *arrayDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64
 			idx := 0
 			for {
 				cursor++
-				addr := uintptr(p) + uintptr(idx)*d.size
-				c, err := d.valueDecoder.decode(buf, cursor, *(*unsafe.Pointer)(unsafe.Pointer(&addr)))
+				c, err := d.valueDecoder.decode(buf, cursor, unsafe.Pointer(uintptr(p)+uintptr(idx)*d.size))
 				if err != nil {
 					return 0, err
 				}

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -90,8 +90,7 @@ func (d *sliceDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 					dst := sliceHeader{data: data, len: idx, cap: cap}
 					copySlice(d.elemType, dst, src)
 				}
-				addr := uintptr(data) + uintptr(idx)*d.size
-				if err := d.valueDecoder.decodeStream(s, *(*unsafe.Pointer)(unsafe.Pointer(&addr))); err != nil {
+				if err := d.valueDecoder.decodeStream(s, unsafe.Pointer(uintptr(data)+uintptr(idx)*d.size)); err != nil {
 					return err
 				}
 				s.skipWhiteSpace()
@@ -191,8 +190,7 @@ func (d *sliceDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64
 					dst := sliceHeader{data: data, len: idx, cap: cap}
 					copySlice(d.elemType, dst, src)
 				}
-				addr := uintptr(data) + uintptr(idx)*d.size
-				c, err := d.valueDecoder.decode(buf, cursor, *(*unsafe.Pointer)(unsafe.Pointer(&addr)))
+				c, err := d.valueDecoder.decode(buf, cursor, unsafe.Pointer(uintptr(data)+uintptr(idx)*d.size))
 				if err != nil {
 					return 0, err
 				}

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -91,7 +91,7 @@ func (d *sliceDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 					copySlice(d.elemType, dst, src)
 				}
 				addr := uintptr(data) + uintptr(idx)*d.size
-				if err := d.valueDecoder.decodeStream(s, unsafe.Pointer(addr)); err != nil {
+				if err := d.valueDecoder.decodeStream(s, *(*unsafe.Pointer)(unsafe.Pointer(&addr))); err != nil {
 					return err
 				}
 				s.skipWhiteSpace()
@@ -192,7 +192,7 @@ func (d *sliceDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int64
 					copySlice(d.elemType, dst, src)
 				}
 				addr := uintptr(data) + uintptr(idx)*d.size
-				c, err := d.valueDecoder.decode(buf, cursor, unsafe.Pointer(addr))
+				c, err := d.valueDecoder.decode(buf, cursor, *(*unsafe.Pointer)(unsafe.Pointer(&addr)))
 				if err != nil {
 					return 0, err
 				}

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -54,8 +54,7 @@ func (d *structDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 		k := *(*string)(unsafe.Pointer(&key))
 		field, exists := d.fieldMap[k]
 		if exists {
-			addr := uintptr(p) + field.offset
-			if err := field.dec.decodeStream(s, *(*unsafe.Pointer)(unsafe.Pointer(&addr))); err != nil {
+			if err := field.dec.decodeStream(s, unsafe.Pointer(uintptr(p)+field.offset)); err != nil {
 				return err
 			}
 		} else if s.disallowUnknownFields {
@@ -109,8 +108,7 @@ func (d *structDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int6
 		k := *(*string)(unsafe.Pointer(&key))
 		field, exists := d.fieldMap[k]
 		if exists {
-			addr := uintptr(p) + field.offset
-			c, err := field.dec.decode(buf, cursor, *(*unsafe.Pointer)(unsafe.Pointer(&addr)))
+			c, err := field.dec.decode(buf, cursor, unsafe.Pointer(uintptr(p)+field.offset))
 			if err != nil {
 				return 0, err
 			}

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -55,7 +55,7 @@ func (d *structDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 		field, exists := d.fieldMap[k]
 		if exists {
 			addr := uintptr(p) + field.offset
-			if err := field.dec.decodeStream(s, unsafe.Pointer(addr)); err != nil {
+			if err := field.dec.decodeStream(s, *(*unsafe.Pointer)(unsafe.Pointer(&addr))); err != nil {
 				return err
 			}
 		} else if s.disallowUnknownFields {
@@ -110,7 +110,7 @@ func (d *structDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int6
 		field, exists := d.fieldMap[k]
 		if exists {
 			addr := uintptr(p) + field.offset
-			c, err := field.dec.decode(buf, cursor, unsafe.Pointer(addr))
+			c, err := field.dec.decode(buf, cursor, *(*unsafe.Pointer)(unsafe.Pointer(&addr)))
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
Fix checkptr validation error on decode side.
Maybe forgot to fix it in ~https://github.com/goccy/go-json/commit/6b1d701387077a61dadc929782195a3cbd3867a9~
**EDIT**: I'm misunderstood, actually https://github.com/goccy/go-json/commit/fd7a72c0b8d127969557247fa3c8258151bb13b0

```console
$ go1.15.5 vet -unsafeptr github.com/goccy/go-json
# github.com/goccy/go-json
./decode_array.go:35:46: possible misuse of unsafe.Pointer
./decode_array.go:95:50: possible misuse of unsafe.Pointer
./decode_slice.go:94:46: possible misuse of unsafe.Pointer
./decode_slice.go:195:50: possible misuse of unsafe.Pointer
./decode_struct.go:58:40: possible misuse of unsafe.Pointer
./decode_struct.go:113:44: possible misuse of unsafe.Pointer
```