### PR TITLE
Use noescape to decoder

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -73,8 +73,8 @@ func (d *Decoder) Buffered() io.Reader {
 	return d.s.buffered()
 }
 
-func (d *Decoder) validateType(typ *rtype, p uintptr) error {
-	if typ.Kind() != reflect.Ptr || p == 0 {
+func (d *Decoder) validateType(typ *rtype, p unsafe.Pointer) error {
+	if typ.Kind() != reflect.Ptr || uintptr(p) == 0 {
 		return &InvalidUnmarshalError{Type: rtype2type(typ)}
 	}
 	return nil
@@ -86,7 +86,7 @@ func (d *Decoder) decode(src []byte, header *interfaceHeader) error {
 
 	// noescape trick for header.typ ( reflect.*rtype )
 	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
-	ptr := uintptr(header.ptr)
+	ptr := noescape(header.ptr)
 
 	if err := d.validateType(copiedType, ptr); err != nil {
 		return err
@@ -101,7 +101,7 @@ func (d *Decoder) decode(src []byte, header *interfaceHeader) error {
 		cachedDecoder.set(typeptr, compiledDec)
 		dec = compiledDec
 	}
-	if _, err := dec.decode(src, 0, header.ptr); err != nil {
+	if _, err := dec.decode(src, 0, ptr); err != nil {
 		return err
 	}
 	return nil
@@ -147,7 +147,7 @@ func (d *Decoder) prepareForDecode() error {
 func (d *Decoder) Decode(v interface{}) error {
 	header := (*interfaceHeader)(unsafe.Pointer(&v))
 	typ := header.typ
-	ptr := uintptr(header.ptr)
+	ptr := noescape(header.ptr)
 	typeptr := uintptr(unsafe.Pointer(typ))
 	// noescape trick for header.typ ( reflect.*rtype )
 	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
@@ -170,7 +170,7 @@ func (d *Decoder) Decode(v interface{}) error {
 		return err
 	}
 	s := d.s
-	if err := dec.decodeStream(s, header.ptr); err != nil {
+	if err := dec.decodeStream(s, ptr); err != nil {
 		return err
 	}
 	return nil

--- a/rtype.go
+++ b/rtype.go
@@ -262,3 +262,9 @@ type interfaceHeader struct {
 func type2rtype(t reflect.Type) *rtype {
 	return (*rtype)(((*interfaceHeader)(unsafe.Pointer(&t))).ptr)
 }
+
+//go:nosplit
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0)
+}


### PR DESCRIPTION
Use `noescape` to the decoder.

In #61, `UnmarshalNoEscape` became doesn't work, but works again use the `noescape` trick.