### PR TITLE
Clean encode context before putting to pool

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -186,6 +186,7 @@ func (e *Encoder) encode(v interface{}) error {
 		p := uintptr(header.ptr)
 		ctx.init(p)
 		err := e.run(ctx, code)
+		ctx.done()
 		codeSet.ctx.Put(ctx)
 		return err
 	}
@@ -236,12 +237,10 @@ func (e *Encoder) encode(v interface{}) error {
 		c = code
 	}
 
-	if err := e.run(ctx, c); err != nil {
-		codeSet.ctx.Put(ctx)
-		return err
-	}
+	err = e.run(ctx, c)
+	ctx.done()
 	codeSet.ctx.Put(ctx)
-	return nil
+	return err
 }
 
 func (e *Encoder) encodeInt(v int) {

--- a/encode_context.go
+++ b/encode_context.go
@@ -93,6 +93,17 @@ func (c *encodeRuntimeContext) init(p uintptr) {
 	c.keepRefs = c.keepRefs[:0]
 }
 
+// done cleans c.keepRefs, so it can be garbage collected.
+//
+// It is important to call c.done() once it's not used anymore. Otherwise,
+// c.keepRefs maybe kept longer than expected, so if the garbage collector
+// run, it will see an invalid pointer.
+func (c *encodeRuntimeContext) done() {
+	for i := range c.keepRefs {
+		c.keepRefs[i] = nil
+	}
+}
+
 func (c *encodeRuntimeContext) ptr() uintptr {
 	header := (*sliceHeader)(unsafe.Pointer(&c.ptrs))
 	return uintptr(header.data)


### PR DESCRIPTION
Currently, once encode runtime context is done, we put it back to pool
to reuse later. The unsafe pointers in context keepRefs are also kept alive,
but its underlying object maybe cleaned already. So if the garbage
collector run, it will see an invalid pointer, the runtime crashes.

To fix it, we add encodeRuntimeContext.done method, to clean the keepRefs
once we finish using the context.

Fixes #63