### PR TITLE
Change uintptrSize to constant

### DIFF
--- a/encode_opcode.go
+++ b/encode_opcode.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-var uintptrSize = unsafe.Sizeof(uintptr(0))
+const uintptrSize = 4 << (^uintptr(0) >> 63) // unsafe.Sizeof(uintptr(0)) but an ideal const
 
 type opcode struct {
 	op           opType // operation type


### PR DESCRIPTION
Like Go runtime, change `uintptrSize` to constant.