### PR TITLE
Refactor the encoder to fix a bug where streaming encoders can't reuse buffer

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 2%
+    patch: off
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header,diff"
+  behavior: default
+  require_changes: no

--- a/benchmarks/encode_test.go
+++ b/benchmarks/encode_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -560,6 +561,51 @@ func Benchmark_Encode_Interface_GoJson(b *testing.B) {
 
 func Benchmark_Encode_Bool_EncodingJson(b *testing.B) {
 	b.ReportAllocs()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for i := 0; i < b.N; i++ {
+		if err := enc.Encode(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Encode_Bool_JsonIter(b *testing.B) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	b.ReportAllocs()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for i := 0; i < b.N; i++ {
+		if err := enc.Encode(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Encode_Bool_SegmentioJson(b *testing.B) {
+	b.ReportAllocs()
+	var buf bytes.Buffer
+	enc := segmentiojson.NewEncoder(&buf)
+	for i := 0; i < b.N; i++ {
+		if err := enc.Encode(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Encode_Bool_GoJson(b *testing.B) {
+	b.ReportAllocs()
+	var buf bytes.Buffer
+	enc := gojson.NewEncoder(&buf)
+	for i := 0; i < b.N; i++ {
+		if err := enc.Encode(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Marshal_Bool_EncodingJson(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := json.Marshal(true); err != nil {
 			b.Fatal(err)
@@ -567,7 +613,7 @@ func Benchmark_Encode_Bool_EncodingJson(b *testing.B) {
 	}
 }
 
-func Benchmark_Encode_Bool_JsonIter(b *testing.B) {
+func Benchmark_Marshal_Bool_JsonIter(b *testing.B) {
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -577,7 +623,7 @@ func Benchmark_Encode_Bool_JsonIter(b *testing.B) {
 	}
 }
 
-func Benchmark_Encode_Bool_Jettison(b *testing.B) {
+func Benchmark_Marshal_Bool_Jettison(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := jettison.Marshal(true); err != nil {
@@ -586,7 +632,7 @@ func Benchmark_Encode_Bool_Jettison(b *testing.B) {
 	}
 }
 
-func Benchmark_Encode_Bool_SegmentioJson(b *testing.B) {
+func Benchmark_Marshal_Bool_SegmentioJson(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := segmentiojson.Marshal(true); err != nil {
@@ -595,7 +641,7 @@ func Benchmark_Encode_Bool_SegmentioJson(b *testing.B) {
 	}
 }
 
-func Benchmark_Encode_Bool_GoJson(b *testing.B) {
+func Benchmark_Marshal_Bool_GoJson(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := gojson.Marshal(true); err != nil {

--- a/encode.go
+++ b/encode.go
@@ -2,154 +2,58 @@ package json
 
 import (
 	"bytes"
-	"encoding"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"math"
-	"reflect"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"unsafe"
 )
 
 // An Encoder writes JSON values to an output stream.
 type Encoder struct {
 	w                 io.Writer
-	ctx               *encodeRuntimeContext
-	ptr               unsafe.Pointer
-	buf               []byte
 	enabledIndent     bool
 	enabledHTMLEscape bool
-	unorderedMap      bool
-	baseIndent        int
-	prefix            []byte
-	indentStr         []byte
-}
-
-type compiledCode struct {
-	code    *opcode
-	linked  bool // whether recursive code already have linked
-	curLen  uintptr
-	nextLen uintptr
+	prefix            string
+	indentStr         string
 }
 
 const (
-	bufSize                    = 1024
-	maxAcceptableTypeAddrRange = 1024 * 1024 * 2 // 2 Mib
+	bufSize = 1024
 )
+
+type EncodeOption int
 
 const (
-	opCodeEscapedType = iota
-	opCodeEscapedIndentType
-	opCodeNoEscapeType
-	opCodeNoEscapeIndentType
+	EncodeOptionHTMLEscape EncodeOption = 1 << iota
+	EncodeOptionIndent
+	EncodeOptionUnorderedMap
 )
-
-type opcodeSet struct {
-	code       *opcode
-	codeLength int
-}
-
-func loadOpcodeMap() map[uintptr]*opcodeSet {
-	p := atomic.LoadPointer(&cachedOpcode)
-	return *(*map[uintptr]*opcodeSet)(unsafe.Pointer(&p))
-}
-
-func storeOpcodeSet(typ uintptr, set *opcodeSet, m map[uintptr]*opcodeSet) {
-	newOpcodeMap := make(map[uintptr]*opcodeSet, len(m)+1)
-	newOpcodeMap[typ] = set
-
-	for k, v := range m {
-		newOpcodeMap[k] = v
-	}
-
-	atomic.StorePointer(&cachedOpcode, *(*unsafe.Pointer)(unsafe.Pointer(&newOpcodeMap)))
-}
 
 var (
-	encPool          sync.Pool
-	codePool         sync.Pool
-	cachedOpcode     unsafe.Pointer // map[uintptr]*opcodeSet
-	marshalJSONType  reflect.Type
-	marshalTextType  reflect.Type
-	baseTypeAddr     uintptr
-	cachedOpcodeSets []*opcodeSet
-)
-
-//go:linkname typelinks reflect.typelinks
-func typelinks() ([]unsafe.Pointer, [][]int32)
-
-//go:linkname rtypeOff reflect.rtypeOff
-func rtypeOff(unsafe.Pointer, int32) unsafe.Pointer
-
-func setupOpcodeSets() error {
-	sections, offsets := typelinks()
-	if len(sections) != 1 {
-		return fmt.Errorf("failed to get sections")
-	}
-	if len(offsets) != 1 {
-		return fmt.Errorf("failed to get offsets")
-	}
-	section := sections[0]
-	offset := offsets[0]
-	var (
-		min uintptr = uintptr(^uint(0))
-		max uintptr = 0
-	)
-	for i := 0; i < len(offset); i++ {
-		addr := uintptr(rtypeOff(section, offset[i]))
-		if min > addr {
-			min = addr
-		}
-		if max < addr {
-			max = addr
-		}
-	}
-	addrRange := uintptr(max) - uintptr(min)
-	if addrRange == 0 {
-		return fmt.Errorf("failed to get address range of types")
-	}
-	if addrRange > maxAcceptableTypeAddrRange {
-		return fmt.Errorf("too big address range %d", addrRange)
-	}
-	cachedOpcodeSets = make([]*opcodeSet, addrRange)
-	baseTypeAddr = min
-	return nil
-}
-
-func init() {
-	encPool = sync.Pool{
+	encRuntimeContextPool = sync.Pool{
 		New: func() interface{} {
-			return &Encoder{
-				ctx: &encodeRuntimeContext{
-					ptrs:     make([]uintptr, 128),
-					keepRefs: make([]unsafe.Pointer, 0, 8),
-				},
-				buf: make([]byte, 0, bufSize),
+			return &encodeRuntimeContext{
+				buf:      make([]byte, 0, bufSize),
+				ptrs:     make([]uintptr, 128),
+				keepRefs: make([]unsafe.Pointer, 0, 8),
 			}
 		},
 	}
-	marshalJSONType = reflect.TypeOf((*Marshaler)(nil)).Elem()
-	marshalTextType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
-	if err := setupOpcodeSets(); err != nil {
-		// fallback to slow path
-	}
+)
+
+func takeEncodeRuntimeContext() *encodeRuntimeContext {
+	return encRuntimeContextPool.Get().(*encodeRuntimeContext)
+}
+
+func releaseEncodeRuntimeContext(ctx *encodeRuntimeContext) {
+	encRuntimeContextPool.Put(ctx)
 }
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	enc := encPool.Get().(*Encoder)
-	enc.w = w
-	enc.reset()
-	return enc
-}
-
-func newEncoder() *Encoder {
-	enc := encPool.Get().(*Encoder)
-	enc.reset()
-	return enc
+	return &Encoder{w: w, enabledHTMLEscape: true}
 }
 
 // Encode writes the JSON encoding of v to the stream, followed by a newline character.
@@ -160,15 +64,23 @@ func (e *Encoder) Encode(v interface{}) error {
 }
 
 // EncodeWithOption call Encode with EncodeOption.
-func (e *Encoder) EncodeWithOption(v interface{}, opts ...EncodeOption) error {
-	for _, opt := range opts {
-		if err := opt(e); err != nil {
-			return err
-		}
+func (e *Encoder) EncodeWithOption(v interface{}, optFuncs ...EncodeOptionFunc) error {
+	var opt EncodeOption
+	if e.enabledHTMLEscape {
+		opt |= EncodeOptionHTMLEscape
 	}
-	header := (*interfaceHeader)(unsafe.Pointer(&v))
-	e.ptr = header.ptr
-	buf, err := e.encode(header, v == nil)
+	for _, optFunc := range optFuncs {
+		opt = optFunc(opt)
+	}
+	var (
+		buf []byte
+		err error
+	)
+	if e.enabledIndent {
+		buf, err = encodeIndentWithOpt(v, e.prefix, e.indentStr, opt)
+	} else {
+		buf, err = encodeWithOpt(v, opt)
+	}
 	if err != nil {
 		return err
 	}
@@ -181,7 +93,6 @@ func (e *Encoder) EncodeWithOption(v interface{}, opts ...EncodeOption) error {
 	if _, err := e.w.Write(buf); err != nil {
 		return err
 	}
-	e.buf = buf[:0]
 	return nil
 }
 
@@ -200,38 +111,15 @@ func (e *Encoder) SetIndent(prefix, indent string) {
 		e.enabledIndent = false
 		return
 	}
-	e.prefix = []byte(prefix)
-	e.indentStr = []byte(indent)
+	e.prefix = prefix
+	e.indentStr = indent
 	e.enabledIndent = true
 }
 
-func (e *Encoder) release() {
-	e.w = nil
-	encPool.Put(e)
-}
-
-func (e *Encoder) reset() {
-	e.baseIndent = 0
-	e.enabledHTMLEscape = true
-	e.enabledIndent = false
-	e.unorderedMap = false
-}
-
-func (e *Encoder) encodeForMarshal(header *interfaceHeader, isNil bool) ([]byte, error) {
-	buf, err := e.encode(header, isNil)
+func marshal(v interface{}, opt EncodeOption) ([]byte, error) {
+	buf, err := encodeWithOpt(v, EncodeOptionHTMLEscape)
 	if err != nil {
 		return nil, err
-	}
-
-	e.buf = buf
-
-	if e.enabledIndent {
-		// this line's description is the below.
-		buf = buf[:len(buf)-2]
-
-		copied := make([]byte, len(buf))
-		copy(copied, buf)
-		return copied, nil
 	}
 
 	// this line exists to escape call of `runtime.makeslicecopy` .
@@ -245,95 +133,98 @@ func (e *Encoder) encodeForMarshal(header *interfaceHeader, isNil bool) ([]byte,
 	return copied, nil
 }
 
-func (e *Encoder) encode(header *interfaceHeader, isNil bool) ([]byte, error) {
-	b := e.buf[:0]
-	if isNil {
+func marshalIndent(v interface{}, prefix, indent string, opt EncodeOption) ([]byte, error) {
+	buf, err := encodeIndentWithOpt(v, prefix, indent, EncodeOptionHTMLEscape)
+	if err != nil {
+		return nil, err
+	}
+	buf = buf[:len(buf)-2]
+
+	copied := make([]byte, len(buf))
+	copy(copied, buf)
+	return copied, nil
+}
+
+func encodeWithOpt(v interface{}, opt EncodeOption) ([]byte, error) {
+	ctx := takeEncodeRuntimeContext()
+	b := ctx.buf[:0]
+	if v == nil {
 		b = encodeNull(b)
-		if e.enabledIndent {
-			b = encodeIndentComma(b)
-		} else {
-			b = encodeComma(b)
-		}
+		b = encodeComma(b)
 		return b, nil
 	}
+	header := (*interfaceHeader)(unsafe.Pointer(&v))
 	typ := header.typ
 
 	typeptr := uintptr(unsafe.Pointer(typ))
-	codeSet, err := e.compileToGetCodeSet(typeptr)
+	codeSet, err := encodeCompileToGetCodeSet(typeptr)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx := e.ctx
 	p := uintptr(header.ptr)
 	ctx.init(p, codeSet.codeLength)
-	if e.enabledIndent {
-		if e.enabledHTMLEscape {
-			return e.runEscapedIndent(ctx, b, codeSet)
-		} else {
-			return e.runIndent(ctx, b, codeSet)
-		}
+	buf, err := encodeRunCode(ctx, b, codeSet, opt)
+
+	ctx.keepRefs = append(ctx.keepRefs, header.ptr)
+
+	if err != nil {
+		releaseEncodeRuntimeContext(ctx)
+		return nil, err
 	}
-	if e.enabledHTMLEscape {
-		return e.runEscaped(ctx, b, codeSet)
-	}
-	return e.run(ctx, b, codeSet)
+
+	ctx.buf = buf
+	releaseEncodeRuntimeContext(ctx)
+	return buf, nil
 }
 
-func (e *Encoder) compileToGetCodeSet(typeptr uintptr) (*opcodeSet, error) {
-	if cachedOpcodeSets == nil {
-		return e.compileToGetCodeSetSlowPath(typeptr)
+func encodeIndentWithOpt(v interface{}, prefix, indent string, opt EncodeOption) ([]byte, error) {
+	ctx := takeEncodeRuntimeContext()
+	b := ctx.buf[:0]
+	if v == nil {
+		b = encodeNull(b)
+		b = encodeIndentComma(b)
+		return b, nil
 	}
-	if codeSet := cachedOpcodeSets[typeptr-baseTypeAddr]; codeSet != nil {
-		return codeSet, nil
-	}
+	header := (*interfaceHeader)(unsafe.Pointer(&v))
+	typ := header.typ
 
-	// noescape trick for header.typ ( reflect.*rtype )
-	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
-
-	code, err := e.compileHead(&encodeCompileContext{
-		typ:                      copiedType,
-		root:                     true,
-		structTypeToCompiledCode: map[uintptr]*compiledCode{},
-	})
+	typeptr := uintptr(unsafe.Pointer(typ))
+	codeSet, err := encodeCompileToGetCodeSet(typeptr)
 	if err != nil {
 		return nil, err
 	}
-	code = copyOpcode(code)
-	codeLength := code.totalLength()
-	codeSet := &opcodeSet{
-		code:       code,
-		codeLength: codeLength,
-	}
-	cachedOpcodeSets[int(typeptr-baseTypeAddr)] = codeSet
-	return codeSet, nil
-}
 
-func (e *Encoder) compileToGetCodeSetSlowPath(typeptr uintptr) (*opcodeSet, error) {
-	opcodeMap := loadOpcodeMap()
-	if codeSet, exists := opcodeMap[typeptr]; exists {
-		return codeSet, nil
-	}
+	p := uintptr(header.ptr)
+	ctx.init(p, codeSet.codeLength)
+	buf, err := encodeRunIndentCode(ctx, b, codeSet, prefix, indent, opt)
 
-	// noescape trick for header.typ ( reflect.*rtype )
-	copiedType := *(**rtype)(unsafe.Pointer(&typeptr))
+	ctx.keepRefs = append(ctx.keepRefs, header.ptr)
 
-	code, err := e.compileHead(&encodeCompileContext{
-		typ:                      copiedType,
-		root:                     true,
-		structTypeToCompiledCode: map[uintptr]*compiledCode{},
-	})
 	if err != nil {
+		releaseEncodeRuntimeContext(ctx)
 		return nil, err
 	}
-	code = copyOpcode(code)
-	codeLength := code.totalLength()
-	codeSet := &opcodeSet{
-		code:       code,
-		codeLength: codeLength,
+
+	ctx.buf = buf
+	releaseEncodeRuntimeContext(ctx)
+	return buf, nil
+}
+
+func encodeRunCode(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt EncodeOption) ([]byte, error) {
+	if (opt & EncodeOptionHTMLEscape) != 0 {
+		return encodeRunEscaped(ctx, b, codeSet, opt)
 	}
-	storeOpcodeSet(typeptr, codeSet, opcodeMap)
-	return codeSet, nil
+	return encodeRun(ctx, b, codeSet, opt)
+}
+
+func encodeRunIndentCode(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, prefix, indent string, opt EncodeOption) ([]byte, error) {
+	ctx.prefix = []byte(prefix)
+	ctx.indentStr = []byte(indent)
+	if (opt & EncodeOptionHTMLEscape) != 0 {
+		return encodeRunEscapedIndent(ctx, b, codeSet, opt)
+	}
+	return encodeRunIndent(ctx, b, codeSet, opt)
 }
 
 func encodeFloat32(b []byte, v float32) []byte {
@@ -389,10 +280,10 @@ func appendStructEnd(b []byte) []byte {
 	return append(b, '}', ',')
 }
 
-func (e *Encoder) appendStructEndIndent(b []byte, indent int) []byte {
+func appendStructEndIndent(ctx *encodeRuntimeContext, b []byte, indent int) []byte {
 	b = append(b, '\n')
-	b = append(b, e.prefix...)
-	b = append(b, bytes.Repeat(e.indentStr, e.baseIndent+indent)...)
+	b = append(b, ctx.prefix...)
+	b = append(b, bytes.Repeat(ctx.indentStr, ctx.baseIndent+indent)...)
 	return append(b, '}', ',', '\n')
 }
 
@@ -411,7 +302,7 @@ func encodeByteSlice(b []byte, src []byte) []byte {
 	return append(append(b, buf...), '"')
 }
 
-func (e *Encoder) encodeIndent(b []byte, indent int) []byte {
-	b = append(b, e.prefix...)
-	return append(b, bytes.Repeat(e.indentStr, e.baseIndent+indent)...)
+func encodeIndent(ctx *encodeRuntimeContext, b []byte, indent int) []byte {
+	b = append(b, ctx.prefix...)
+	return append(b, bytes.Repeat(ctx.indentStr, ctx.baseIndent+indent)...)
 }

--- a/encode_context.go
+++ b/encode_context.go
@@ -142,9 +142,13 @@ func (c *encodeCompileContext) decPtrIndex() {
 }
 
 type encodeRuntimeContext struct {
-	ptrs     []uintptr
-	keepRefs []unsafe.Pointer
-	seenPtr  []uintptr
+	buf        []byte
+	ptrs       []uintptr
+	keepRefs   []unsafe.Pointer
+	seenPtr    []uintptr
+	baseIndent int
+	prefix     []byte
+	indentStr  []byte
 }
 
 func (c *encodeRuntimeContext) init(p uintptr, codelen int) {
@@ -154,6 +158,7 @@ func (c *encodeRuntimeContext) init(p uintptr, codelen int) {
 	c.ptrs[0] = p
 	c.keepRefs = c.keepRefs[:0]
 	c.seenPtr = c.seenPtr[:0]
+	c.baseIndent = 0
 }
 
 func (c *encodeRuntimeContext) ptr() uintptr {

--- a/encode_opcode.go
+++ b/encode_opcode.go
@@ -327,7 +327,7 @@ func nextField(code *opcode, removedFields map[*opcode]struct{}) *opcode {
 	return code
 }
 
-func linkPrevToNextField(cur *opcode, removedFields map[*opcode]struct{}) {
+func encodeLinkPrevToNextField(cur *opcode, removedFields map[*opcode]struct{}) {
 	prev := prevField(cur.prevField, removedFields)
 	prev.nextField = nextField(cur.nextField, removedFields)
 	code := prev

--- a/encode_vm.go
+++ b/encode_vm.go
@@ -88,7 +88,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 	for {
 		switch code.op {
 		default:
-			return nil, fmt.Errorf("failed to handle opcode. doesn't implement %s", code.op)
+			return nil, fmt.Errorf("encoder: opcode %s has not been implemented", code.op)
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next

--- a/encode_vm_escaped.go
+++ b/encode_vm_escaped.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet) ([]byte, error) {
+func encodeRunEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt EncodeOption) ([]byte, error) {
 	recursiveLevel := 0
 	ptrOffset := uintptr(0)
 	ctxptr := ctx.ptr()
@@ -25,113 +25,113 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next
-			store(ctxptr, code.idx, e.ptrToPtr(ptr))
+			store(ctxptr, code.idx, ptrToPtr(ptr))
 		case opInt:
-			b = appendInt(b, int64(e.ptrToInt(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opInt8:
-			b = appendInt(b, int64(e.ptrToInt8(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opInt16:
-			b = appendInt(b, int64(e.ptrToInt16(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opInt32:
-			b = appendInt(b, int64(e.ptrToInt32(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opInt64:
-			b = appendInt(b, e.ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
 			b = encodeComma(b)
 			code = code.next
 		case opUint:
-			b = appendUint(b, uint64(e.ptrToUint(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opUint8:
-			b = appendUint(b, uint64(e.ptrToUint8(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opUint16:
-			b = appendUint(b, uint64(e.ptrToUint16(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opUint32:
-			b = appendUint(b, uint64(e.ptrToUint32(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
 			b = encodeComma(b)
 			code = code.next
 		case opUint64:
-			b = appendUint(b, e.ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
 			b = encodeComma(b)
 			code = code.next
 		case opIntString:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opInt8String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt8(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opInt16String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt16(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opInt32String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt32(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opInt64String:
 			b = append(b, '"')
-			b = appendInt(b, e.ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opUintString:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opUint8String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint8(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opUint16String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint16(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opUint32String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint32(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opUint64String:
 			b = append(b, '"')
-			b = appendUint(b, e.ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opFloat32:
-			b = encodeFloat32(b, e.ptrToFloat32(load(ctxptr, code.idx)))
+			b = encodeFloat32(b, ptrToFloat32(load(ctxptr, code.idx)))
 			b = encodeComma(b)
 			code = code.next
 		case opFloat64:
-			v := e.ptrToFloat64(load(ctxptr, code.idx))
+			v := ptrToFloat64(load(ctxptr, code.idx))
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -139,20 +139,20 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = encodeComma(b)
 			code = code.next
 		case opString:
-			b = encodeEscapedString(b, e.ptrToString(load(ctxptr, code.idx)))
+			b = encodeEscapedString(b, ptrToString(load(ctxptr, code.idx)))
 			b = encodeComma(b)
 			code = code.next
 		case opBool:
-			b = encodeBool(b, e.ptrToBool(load(ctxptr, code.idx)))
+			b = encodeBool(b, ptrToBool(load(ctxptr, code.idx)))
 			b = encodeComma(b)
 			code = code.next
 		case opBytes:
 			ptr := load(ctxptr, code.idx)
-			slice := e.ptrToSlice(ptr)
+			slice := ptrToSlice(ptr)
 			if ptr == 0 || uintptr(slice.data) == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeByteSlice(b, e.ptrToBytes(ptr))
+				b = encodeByteSlice(b, ptrToBytes(ptr))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -170,7 +170,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				}
 			}
 			ctx.seenPtr = append(ctx.seenPtr, ptr)
-			iface := (*interfaceHeader)(e.ptrToUnsafePtr(ptr))
+			iface := (*interfaceHeader)(ptrToUnsafePtr(ptr))
 			if iface == nil || iface.ptr == nil {
 				b = encodeNull(b)
 				b = encodeComma(b)
@@ -178,7 +178,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(iface))
-			ifaceCodeSet, err := e.compileToGetCodeSet(uintptr(unsafe.Pointer(iface.typ)))
+			ifaceCodeSet, err := encodeCompileToGetCodeSet(uintptr(unsafe.Pointer(iface.typ)))
 			if err != nil {
 				return nil, err
 			}
@@ -200,7 +200,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 
 			ctx.ptrs = newPtrs
 
-			bb, err := e.runEscaped(ctx, b, ifaceCodeSet)
+			bb, err := encodeRunEscaped(ctx, b, ifaceCodeSet, opt)
 			if err != nil {
 				return nil, err
 			}
@@ -219,7 +219,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.next
 				break
 			}
-			v := e.ptrToInterface(code, ptr)
+			v := ptrToInterface(code, ptr)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -241,7 +241,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opMarshalText:
 			ptr := load(ctxptr, code.idx)
 			isPtr := code.typ.Kind() == reflect.Ptr
-			p := e.ptrToUnsafePtr(ptr)
+			p := ptrToUnsafePtr(ptr)
 			if p == nil || isPtr && *(*unsafe.Pointer)(p) == nil {
 				b = append(b, '"', '"', ',')
 			} else {
@@ -259,7 +259,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opSliceHead:
 			p := load(ctxptr, code.idx)
-			slice := e.ptrToSlice(p)
+			slice := ptrToSlice(p)
 			if p == 0 || uintptr(slice.data) == 0 {
 				b = encodeNull(b)
 				b = encodeComma(b)
@@ -332,7 +332,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeComma(b)
 				code = code.end.next
 			} else {
-				uptr := e.ptrToUnsafePtr(ptr)
+				uptr := ptrToUnsafePtr(ptr)
 				mlen := maplen(uptr)
 				if mlen > 0 {
 					b = append(b, '{')
@@ -341,7 +341,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					store(ctxptr, code.elemIdx, 0)
 					store(ctxptr, code.length, uintptr(mlen))
 					store(ctxptr, code.mapIter, uintptr(iter))
-					if !e.unorderedMap {
+					if (opt & EncodeOptionUnorderedMap) == 0 {
 						mapCtx := newMapContext(mlen)
 						mapCtx.pos = append(mapCtx.pos, len(b))
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
@@ -363,8 +363,8 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				// load pointer
-				ptr = e.ptrToPtr(ptr)
-				uptr := e.ptrToUnsafePtr(ptr)
+				ptr = ptrToPtr(ptr)
+				uptr := ptrToUnsafePtr(ptr)
 				if ptr == 0 {
 					b = encodeNull(b)
 					b = encodeComma(b)
@@ -381,9 +381,10 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					store(ctxptr, code.mapIter, uintptr(iter))
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
-					if !e.unorderedMap {
+					if (opt & EncodeOptionUnorderedMap) == 0 {
 						mapCtx := newMapContext(mlen)
 						mapCtx.pos = append(mapCtx.pos, len(b))
+						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					}
 					code = code.next
@@ -396,10 +397,10 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			idx := load(ctxptr, code.elemIdx)
 			length := load(ctxptr, code.length)
 			idx++
-			if e.unorderedMap {
+			if (opt & EncodeOptionUnorderedMap) != 0 {
 				if idx < length {
 					ptr := load(ctxptr, code.mapIter)
-					iter := e.ptrToUnsafePtr(ptr)
+					iter := ptrToUnsafePtr(ptr)
 					store(ctxptr, code.elemIdx, idx)
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
@@ -412,11 +413,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				}
 			} else {
 				ptr := load(ctxptr, code.end.mapPos)
-				mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+				mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 				mapCtx.pos = append(mapCtx.pos, len(b))
 				if idx < length {
 					ptr := load(ctxptr, code.mapIter)
-					iter := e.ptrToUnsafePtr(ptr)
+					iter := ptrToUnsafePtr(ptr)
 					store(ctxptr, code.elemIdx, idx)
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
@@ -426,16 +427,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				}
 			}
 		case opMapValue:
-			if e.unorderedMap {
+			if (opt & EncodeOptionUnorderedMap) != 0 {
 				last := len(b) - 1
 				b[last] = ':'
 			} else {
 				ptr := load(ctxptr, code.end.mapPos)
-				mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+				mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 				mapCtx.pos = append(mapCtx.pos, len(b))
 			}
 			ptr := load(ctxptr, code.mapIter)
-			iter := e.ptrToUnsafePtr(ptr)
+			iter := ptrToUnsafePtr(ptr)
 			value := mapitervalue(iter)
 			store(ctxptr, code.next.idx, uintptr(value))
 			mapiternext(iter)
@@ -444,7 +445,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			// this operation only used by sorted map.
 			length := int(load(ctxptr, code.length))
 			ptr := load(ctxptr, code.mapPos)
-			mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+			mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 			pos := mapCtx.pos
 			for i := 0; i < length; i++ {
 				startKey := pos[i*2]
@@ -475,7 +476,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			releaseMapContext(mapCtx)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadRecursive:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadRecursive:
 			fallthrough
@@ -516,7 +517,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ctx.seenPtr = ctx.seenPtr[:len(ctx.seenPtr)-1]
 
 			codePtr := load(ctxptr, code.elemIdx)
-			code = (*opcode)(e.ptrToUnsafePtr(codePtr))
+			code = (*opcode)(ptrToUnsafePtr(codePtr))
 			ctxptr = ctx.ptr() + offset
 			ptrOffset = offset
 		case opStructFieldPtrHead:
@@ -526,7 +527,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHead:
 			ptr := load(ctxptr, code.idx)
@@ -546,7 +547,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmpty:
@@ -597,7 +598,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmpty:
@@ -615,7 +616,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				}
 			}
 		case opStructFieldPtrHeadInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt:
 			ptr := load(ctxptr, code.idx)
@@ -626,14 +627,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt:
@@ -644,7 +645,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -657,7 +658,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt:
@@ -670,7 +671,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -679,13 +680,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt(p)))
+			b = appendInt(b, int64(ptrToInt(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntOnly, opStructFieldHeadOmitEmptyIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := int64(e.ptrToInt(p))
+			v := int64(ptrToInt(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -697,12 +698,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt(p)))
+			b = appendInt(b, int64(ptrToInt(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadIntPtr:
 			p := load(ctxptr, code.idx)
@@ -714,17 +715,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyIntPtr:
 			p := load(ctxptr, code.idx)
@@ -734,16 +735,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendInt(b, int64(e.ptrToInt(p)))
+					b = appendInt(b, int64(ptrToInt(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagIntPtr:
 			p := load(ctxptr, code.idx)
@@ -755,12 +756,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -774,7 +775,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -783,7 +784,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -795,14 +796,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyIntPtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -814,7 +815,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -824,7 +825,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -840,18 +841,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt:
 			ptr := load(ctxptr, code.idx)
@@ -859,14 +860,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt:
@@ -874,7 +875,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -887,7 +888,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt:
@@ -897,7 +898,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -908,7 +909,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -917,7 +918,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -934,13 +935,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtr:
 			p := load(ctxptr, code.idx)
@@ -949,16 +950,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyIntPtr:
 			p := load(ctxptr, code.idx)
@@ -966,17 +967,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtr:
 			p := load(ctxptr, code.idx)
@@ -985,12 +986,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -1001,7 +1002,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1009,7 +1010,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1019,7 +1020,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyIntPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1027,7 +1028,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1037,7 +1038,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1046,13 +1047,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt8:
 			ptr := load(ctxptr, code.idx)
@@ -1063,14 +1064,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8:
@@ -1081,7 +1082,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1094,7 +1095,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt8:
@@ -1107,7 +1108,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -1116,13 +1117,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt8(p)))
+			b = appendInt(b, int64(ptrToInt8(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt8Only, opStructFieldHeadOmitEmptyInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := int64(e.ptrToInt8(p))
+			v := int64(ptrToInt8(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -1134,12 +1135,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt8(p)))
+			b = appendInt(b, int64(ptrToInt8(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1151,17 +1152,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1171,16 +1172,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendInt(b, int64(e.ptrToInt8(p)))
+					b = appendInt(b, int64(ptrToInt8(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1192,12 +1193,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -1211,7 +1212,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1220,7 +1221,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1232,14 +1233,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -1251,7 +1252,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1261,7 +1262,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -1277,18 +1278,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8:
 			ptr := load(ctxptr, code.idx)
@@ -1296,14 +1297,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8:
@@ -1311,7 +1312,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1324,7 +1325,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8:
@@ -1334,7 +1335,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -1345,7 +1346,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1354,7 +1355,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1371,13 +1372,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1386,16 +1387,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1403,17 +1404,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1422,12 +1423,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -1438,7 +1439,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1446,7 +1447,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1456,7 +1457,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1464,7 +1465,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1474,7 +1475,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1483,13 +1484,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt16:
 			ptr := load(ctxptr, code.idx)
@@ -1500,14 +1501,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16:
@@ -1518,7 +1519,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1531,7 +1532,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt16:
@@ -1544,7 +1545,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -1553,13 +1554,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt16(p)))
+			b = appendInt(b, int64(ptrToInt16(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt16Only, opStructFieldHeadOmitEmptyInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := int64(e.ptrToInt16(p))
+			v := int64(ptrToInt16(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -1571,12 +1572,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt16(p)))
+			b = appendInt(b, int64(ptrToInt16(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1588,17 +1589,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1608,16 +1609,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendInt(b, int64(e.ptrToInt16(p)))
+					b = appendInt(b, int64(ptrToInt16(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1629,12 +1630,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -1648,7 +1649,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1657,7 +1658,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1669,14 +1670,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -1688,7 +1689,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1698,7 +1699,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -1714,18 +1715,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16:
 			ptr := load(ctxptr, code.idx)
@@ -1733,14 +1734,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16:
@@ -1748,7 +1749,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1761,7 +1762,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16:
@@ -1771,7 +1772,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -1782,7 +1783,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1791,7 +1792,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1808,13 +1809,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1823,16 +1824,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1840,17 +1841,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1859,12 +1860,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -1875,7 +1876,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1883,7 +1884,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1893,7 +1894,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1901,7 +1902,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1911,7 +1912,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -1920,13 +1921,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt32:
 			ptr := load(ctxptr, code.idx)
@@ -1937,14 +1938,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32:
@@ -1955,7 +1956,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -1968,7 +1969,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt32:
@@ -1981,7 +1982,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -1990,13 +1991,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt32(p)))
+			b = appendInt(b, int64(ptrToInt32(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt32Only, opStructFieldHeadOmitEmptyInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := int64(e.ptrToInt32(p))
+			v := int64(ptrToInt32(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -2008,12 +2009,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt32(p)))
+			b = appendInt(b, int64(ptrToInt32(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2025,17 +2026,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2045,16 +2046,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendInt(b, int64(e.ptrToInt32(p)))
+					b = appendInt(b, int64(ptrToInt32(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2066,12 +2067,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -2085,7 +2086,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2094,7 +2095,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -2106,14 +2107,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -2125,7 +2126,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2135,7 +2136,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -2151,18 +2152,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32:
 			ptr := load(ctxptr, code.idx)
@@ -2170,14 +2171,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32:
@@ -2185,7 +2186,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -2198,7 +2199,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32:
@@ -2208,7 +2209,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -2219,7 +2220,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -2228,7 +2229,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -2245,13 +2246,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2260,16 +2261,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2277,17 +2278,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2296,12 +2297,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -2312,7 +2313,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2320,7 +2321,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -2330,7 +2331,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2338,7 +2339,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -2348,7 +2349,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2357,13 +2358,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt64:
 			ptr := load(ctxptr, code.idx)
@@ -2374,14 +2375,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64:
@@ -2392,7 +2393,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -2405,7 +2406,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt64:
@@ -2418,7 +2419,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -2427,13 +2428,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, e.ptrToInt64(p))
+			b = appendInt(b, ptrToInt64(p))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt64Only, opStructFieldHeadOmitEmptyInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := e.ptrToInt64(p)
+			v := ptrToInt64(p)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -2445,12 +2446,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, e.ptrToInt64(p))
+			b = appendInt(b, ptrToInt64(p))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2462,17 +2463,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2482,16 +2483,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendInt(b, e.ptrToInt64(p))
+					b = appendInt(b, ptrToInt64(p))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2503,12 +2504,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -2522,7 +2523,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2531,7 +2532,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -2543,14 +2544,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -2562,7 +2563,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2572,7 +2573,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -2588,18 +2589,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64:
 			ptr := load(ctxptr, code.idx)
@@ -2607,14 +2608,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64:
@@ -2622,7 +2623,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -2635,7 +2636,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64:
@@ -2645,7 +2646,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -2656,7 +2657,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -2665,7 +2666,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -2682,13 +2683,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2697,16 +2698,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2714,17 +2715,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2733,12 +2734,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -2749,7 +2750,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2757,7 +2758,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -2767,7 +2768,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2775,7 +2776,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -2785,7 +2786,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2794,13 +2795,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint:
 			ptr := load(ctxptr, code.idx)
@@ -2811,14 +2812,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint:
@@ -2829,7 +2830,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -2842,7 +2843,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint:
@@ -2855,7 +2856,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -2864,13 +2865,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint(p)))
+			b = appendUint(b, uint64(ptrToUint(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintOnly, opStructFieldHeadOmitEmptyUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := uint64(e.ptrToUint(p))
+			v := uint64(ptrToUint(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -2882,12 +2883,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint(p)))
+			b = appendUint(b, uint64(ptrToUint(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUintPtr:
 			p := load(ctxptr, code.idx)
@@ -2899,17 +2900,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUintPtr:
 			p := load(ctxptr, code.idx)
@@ -2919,16 +2920,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendUint(b, uint64(e.ptrToUint(p)))
+					b = appendUint(b, uint64(ptrToUint(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUintPtr:
 			p := load(ctxptr, code.idx)
@@ -2940,12 +2941,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -2959,7 +2960,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -2968,7 +2969,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -2980,14 +2981,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUintPtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -2999,7 +3000,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3009,7 +3010,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3025,18 +3026,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint:
 			ptr := load(ctxptr, code.idx)
@@ -3044,14 +3045,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint:
@@ -3059,7 +3060,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3072,7 +3073,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint:
@@ -3082,7 +3083,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3093,7 +3094,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3102,7 +3103,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3119,13 +3120,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3134,16 +3135,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3151,17 +3152,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3170,12 +3171,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3186,7 +3187,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3194,7 +3195,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3204,7 +3205,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUintPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3212,7 +3213,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3222,7 +3223,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3231,13 +3232,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint8:
 			ptr := load(ctxptr, code.idx)
@@ -3248,14 +3249,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8:
@@ -3266,7 +3267,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3279,7 +3280,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint8:
@@ -3292,7 +3293,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3301,13 +3302,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint8(p)))
+			b = appendUint(b, uint64(ptrToUint8(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint8Only, opStructFieldHeadOmitEmptyUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := uint64(e.ptrToUint8(p))
+			v := uint64(ptrToUint8(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -3319,12 +3320,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint8(p)))
+			b = appendUint(b, uint64(ptrToUint8(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3336,17 +3337,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3356,16 +3357,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendUint(b, uint64(e.ptrToUint8(p)))
+					b = appendUint(b, uint64(ptrToUint8(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3377,12 +3378,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -3396,7 +3397,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3405,7 +3406,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3417,14 +3418,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -3436,7 +3437,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3446,7 +3447,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3462,18 +3463,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8:
 			ptr := load(ctxptr, code.idx)
@@ -3481,14 +3482,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8:
@@ -3496,7 +3497,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3509,7 +3510,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8:
@@ -3519,7 +3520,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3530,7 +3531,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3539,7 +3540,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3556,13 +3557,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3571,16 +3572,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3588,17 +3589,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3607,12 +3608,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3623,7 +3624,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3631,7 +3632,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3641,7 +3642,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3649,7 +3650,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3659,7 +3660,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3668,13 +3669,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint16:
 			ptr := load(ctxptr, code.idx)
@@ -3685,14 +3686,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16:
@@ -3703,7 +3704,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3716,7 +3717,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint16:
@@ -3729,7 +3730,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3738,13 +3739,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint16(p)))
+			b = appendUint(b, uint64(ptrToUint16(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint16Only, opStructFieldHeadOmitEmptyUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := uint64(e.ptrToUint16(p))
+			v := uint64(ptrToUint16(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -3756,12 +3757,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint16(p)))
+			b = appendUint(b, uint64(ptrToUint16(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -3773,17 +3774,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -3793,16 +3794,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendUint(b, uint64(e.ptrToUint16(p)))
+					b = appendUint(b, uint64(ptrToUint16(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -3814,12 +3815,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -3833,7 +3834,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3842,7 +3843,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3854,14 +3855,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -3873,7 +3874,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -3883,7 +3884,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3899,18 +3900,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16:
 			ptr := load(ctxptr, code.idx)
@@ -3918,14 +3919,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16:
@@ -3933,7 +3934,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3946,7 +3947,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16:
@@ -3956,7 +3957,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3967,7 +3968,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3976,7 +3977,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -3993,13 +3994,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4008,16 +4009,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4025,17 +4026,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4044,12 +4045,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -4060,7 +4061,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4068,7 +4069,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -4078,7 +4079,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4086,7 +4087,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -4096,7 +4097,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4105,13 +4106,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint32:
 			ptr := load(ctxptr, code.idx)
@@ -4122,14 +4123,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32:
@@ -4140,7 +4141,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -4153,7 +4154,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint32:
@@ -4166,7 +4167,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -4175,13 +4176,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint32(p)))
+			b = appendUint(b, uint64(ptrToUint32(p)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint32Only, opStructFieldHeadOmitEmptyUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := uint64(e.ptrToUint32(p))
+			v := uint64(ptrToUint32(p))
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -4193,12 +4194,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint32(p)))
+			b = appendUint(b, uint64(ptrToUint32(p)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4210,17 +4211,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4230,16 +4231,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendUint(b, uint64(e.ptrToUint32(p)))
+					b = appendUint(b, uint64(ptrToUint32(p)))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4251,12 +4252,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -4270,7 +4271,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4279,7 +4280,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -4291,14 +4292,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -4310,7 +4311,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4320,7 +4321,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -4336,18 +4337,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32:
 			ptr := load(ctxptr, code.idx)
@@ -4355,14 +4356,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32:
@@ -4370,7 +4371,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -4383,7 +4384,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32:
@@ -4393,7 +4394,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -4404,7 +4405,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -4413,7 +4414,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -4430,13 +4431,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4445,16 +4446,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4462,17 +4463,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4481,12 +4482,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -4497,7 +4498,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4505,7 +4506,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -4515,7 +4516,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4523,7 +4524,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -4533,7 +4534,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4542,13 +4543,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint64:
 			ptr := load(ctxptr, code.idx)
@@ -4559,14 +4560,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64:
@@ -4577,7 +4578,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -4590,7 +4591,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint64:
@@ -4603,7 +4604,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -4612,13 +4613,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, e.ptrToUint64(p))
+			b = appendUint(b, ptrToUint64(p))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint64Only, opStructFieldHeadOmitEmptyUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := e.ptrToUint64(p)
+			v := ptrToUint64(p)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -4630,12 +4631,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, e.ptrToUint64(p))
+			b = appendUint(b, ptrToUint64(p))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -4647,17 +4648,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -4667,16 +4668,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = appendUint(b, e.ptrToUint64(p))
+					b = appendUint(b, ptrToUint64(p))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -4688,12 +4689,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -4707,7 +4708,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4716,7 +4717,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -4728,14 +4729,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -4747,7 +4748,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4757,7 +4758,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -4773,18 +4774,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64:
 			ptr := load(ctxptr, code.idx)
@@ -4792,14 +4793,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64:
@@ -4807,7 +4808,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -4820,7 +4821,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64:
@@ -4830,7 +4831,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -4841,7 +4842,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -4850,7 +4851,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -4867,13 +4868,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -4882,16 +4883,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -4899,17 +4900,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -4918,12 +4919,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -4934,7 +4935,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4942,7 +4943,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -4952,7 +4953,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4960,7 +4961,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -4970,7 +4971,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -4979,13 +4980,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat32:
 			ptr := load(ctxptr, code.idx)
@@ -4996,14 +4997,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32:
@@ -5014,7 +5015,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -5027,7 +5028,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagFloat32:
@@ -5040,7 +5041,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -5049,13 +5050,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = encodeFloat32(b, e.ptrToFloat32(p))
+			b = encodeFloat32(b, ptrToFloat32(p))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat32Only, opStructFieldHeadOmitEmptyFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := e.ptrToFloat32(p)
+			v := ptrToFloat32(p)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = encodeFloat32(b, v)
@@ -5067,12 +5068,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = encodeFloat32(b, e.ptrToFloat32(p))
+			b = encodeFloat32(b, ptrToFloat32(p))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5084,17 +5085,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+					b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5104,16 +5105,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5125,12 +5126,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+					b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -5144,7 +5145,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5153,7 +5154,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -5165,14 +5166,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -5184,7 +5185,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5194,7 +5195,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -5210,18 +5211,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+					b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32:
 			ptr := load(ctxptr, code.idx)
@@ -5229,14 +5230,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32:
@@ -5244,7 +5245,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -5257,7 +5258,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32:
@@ -5267,7 +5268,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -5278,7 +5279,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -5287,7 +5288,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -5304,13 +5305,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5319,16 +5320,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5336,17 +5337,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5355,12 +5356,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -5371,7 +5372,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5379,7 +5380,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -5389,7 +5390,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5397,7 +5398,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -5407,7 +5408,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5416,13 +5417,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat64:
 			ptr := load(ctxptr, code.idx)
@@ -5431,7 +5432,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeComma(b)
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5444,7 +5445,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmptyFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64:
@@ -5455,7 +5456,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
@@ -5471,7 +5472,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagFloat64:
@@ -5482,7 +5483,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5497,7 +5498,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -5507,7 +5508,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmptyFloat64Only, opStructFieldHeadOmitEmptyFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if v != 0 {
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
@@ -5522,7 +5523,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -5531,7 +5532,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5543,11 +5544,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					v := e.ptrToFloat64(p + code.offset)
+					v := ptrToFloat64(p + code.offset)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -5557,7 +5558,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5567,10 +5568,10 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					v := e.ptrToFloat64(p + code.offset)
+					v := ptrToFloat64(p + code.offset)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -5580,7 +5581,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5592,12 +5593,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					v := e.ptrToFloat64(p + code.offset)
+					v := ptrToFloat64(p + code.offset)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -5615,7 +5616,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5624,7 +5625,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5640,14 +5641,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64PtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5663,7 +5664,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5673,7 +5674,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5693,12 +5694,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -5708,14 +5709,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5727,7 +5728,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64:
@@ -5735,12 +5736,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.escapedKey...)
-					v := e.ptrToFloat64(ptr + code.offset)
+					v := ptrToFloat64(ptr + code.offset)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -5752,7 +5753,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64:
@@ -5762,7 +5763,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5777,7 +5778,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5790,12 +5791,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.escapedKey...)
-					v := e.ptrToFloat64(ptr + code.offset)
+					v := ptrToFloat64(ptr + code.offset)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -5811,7 +5812,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5821,7 +5822,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5830,11 +5831,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5843,7 +5844,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5851,12 +5852,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5865,7 +5866,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5874,12 +5875,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5894,7 +5895,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5902,7 +5903,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5916,7 +5917,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5924,7 +5925,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5938,7 +5939,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
@@ -5947,7 +5948,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p + code.offset)
+				v := ptrToFloat64(p + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5964,7 +5965,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadString:
 			ptr := load(ctxptr, code.idx)
@@ -5975,14 +5976,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyString:
@@ -5993,7 +5994,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
@@ -6006,7 +6007,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagString:
@@ -6018,7 +6019,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				s := e.ptrToString(ptr + code.offset)
+				s := ptrToString(ptr + code.offset)
 				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, s)))
 				b = encodeComma(b)
 				code = code.next
@@ -6027,13 +6028,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+			b = encodeEscapedString(b, ptrToString(p+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyStringOnly, opStructFieldHeadOmitEmptyStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := e.ptrToString(p)
+			v := ptrToString(p)
 			if v != "" {
 				b = append(b, code.escapedKey...)
 				b = encodeEscapedString(b, v)
@@ -6044,11 +6045,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6060,17 +6061,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+					b = encodeEscapedString(b, ptrToString(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6080,16 +6081,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
 					b = append(b, code.escapedKey...)
-					b = encodeEscapedString(b, e.ptrToString(p))
+					b = encodeEscapedString(b, ptrToString(p))
 					b = encodeComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6101,11 +6102,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+					b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 				}
 			}
 			b = encodeComma(b)
@@ -6118,7 +6119,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -6127,7 +6128,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -6139,14 +6140,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyStringPtrOnly:
 			b = append(b, '{')
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -6158,7 +6159,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -6167,7 +6168,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -6182,18 +6183,18 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+					b = encodeEscapedString(b, ptrToString(p+code.offset))
 				}
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadString:
 			ptr := load(ctxptr, code.idx)
@@ -6201,14 +6202,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyString:
@@ -6216,7 +6217,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
@@ -6229,7 +6230,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagString:
@@ -6238,7 +6239,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(ptr))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(ptr))))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -6248,7 +6249,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -6257,7 +6258,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
@@ -6273,12 +6274,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(ptr))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(ptr))))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6287,16 +6288,16 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6304,17 +6305,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6323,11 +6324,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				break
 			}
 			b = append(b, code.escapedKey...)
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -6337,7 +6338,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -6345,7 +6346,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -6355,7 +6356,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyStringPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -6363,7 +6364,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.nextField
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -6373,7 +6374,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
@@ -6381,7 +6382,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -6393,7 +6394,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadBool:
 			ptr := load(ctxptr, code.idx)
@@ -6408,7 +6409,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+				b = encodeBool(b, ptrToBool(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -6425,11 +6426,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadBool:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadBool:
 			ptr := load(ctxptr, code.idx)
@@ -6437,7 +6438,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+				b = encodeBool(b, ptrToBool(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -6449,7 +6450,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadBytes:
 			ptr := load(ctxptr, code.idx)
@@ -6464,12 +6465,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadBytes:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadBytes:
 			ptr := load(ctxptr, code.idx)
@@ -6477,7 +6478,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -6489,7 +6490,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadArray:
 			ptr := load(ctxptr, code.idx) + code.offset
@@ -6510,7 +6511,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				store(ctxptr, code.idx, ptr)
 			}
 		case opStructFieldPtrAnonymousHeadArray:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadArray:
 			ptr := load(ctxptr, code.idx) + code.offset
@@ -6529,7 +6530,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadSlice:
 			ptr := load(ctxptr, code.idx)
@@ -6551,7 +6552,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				store(ctxptr, code.idx, p)
 			}
 		case opStructFieldPtrAnonymousHeadSlice:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadSlice:
 			ptr := load(ctxptr, code.idx)
@@ -6571,7 +6572,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadMarshalJSON:
 			ptr := load(ctxptr, code.idx)
@@ -6583,7 +6584,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				ptr += code.offset
-				v := e.ptrToInterface(code, ptr)
+				v := ptrToInterface(code, ptr)
 				rv := reflect.ValueOf(v)
 				if rv.Type().Kind() == reflect.Interface && rv.IsNil() {
 					b = encodeNull(b)
@@ -6609,7 +6610,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadMarshalJSON:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadMarshalJSON:
 			ptr := load(ctxptr, code.idx)
@@ -6618,7 +6619,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				ptr += code.offset
-				v := e.ptrToInterface(code, ptr)
+				v := ptrToInterface(code, ptr)
 				rv := reflect.ValueOf(v)
 				if rv.Type().Kind() == reflect.Interface && rv.IsNil() {
 					b = encodeNull(b)
@@ -6651,7 +6652,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadMarshalText:
 			ptr := load(ctxptr, code.idx)
@@ -6663,7 +6664,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				ptr += code.offset
-				v := e.ptrToInterface(code, ptr)
+				v := ptrToInterface(code, ptr)
 				rv := reflect.ValueOf(v)
 				if rv.Type().Kind() == reflect.Interface && rv.IsNil() {
 					b = encodeNull(b)
@@ -6680,7 +6681,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadMarshalText:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadMarshalText:
 			ptr := load(ctxptr, code.idx)
@@ -6689,7 +6690,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				ptr += code.offset
-				v := e.ptrToInterface(code, ptr)
+				v := ptrToInterface(code, ptr)
 				rv := reflect.ValueOf(v)
 				if rv.Type().Kind() == reflect.Interface && rv.IsNil() {
 					b = encodeNull(b)
@@ -6708,7 +6709,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyBool:
@@ -6719,7 +6720,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToBool(ptr + code.offset)
+				v := ptrToBool(ptr + code.offset)
 				if !v {
 					code = code.nextField
 				} else {
@@ -6732,7 +6733,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyBool:
@@ -6740,7 +6741,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToBool(ptr + code.offset)
+				v := ptrToBool(ptr + code.offset)
 				if !v {
 					code = code.nextField
 				} else {
@@ -6753,7 +6754,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyBytes:
@@ -6764,7 +6765,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := e.ptrToBytes(ptr + code.offset)
+				v := ptrToBytes(ptr + code.offset)
 				if len(v) == 0 {
 					code = code.nextField
 				} else {
@@ -6777,7 +6778,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyBytes:
@@ -6785,7 +6786,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToBytes(ptr + code.offset)
+				v := ptrToBytes(ptr + code.offset)
 				if len(v) == 0 {
 					code = code.nextField
 				} else {
@@ -6798,7 +6799,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmptyMarshalJSON:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyMarshalJSON:
@@ -6810,7 +6811,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				isPtr := code.typ.Kind() == reflect.Ptr
 				if p == nil || (!isPtr && *(*unsafe.Pointer)(p) == nil) {
 					code = code.nextField
@@ -6846,7 +6847,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadOmitEmptyMarshalJSON:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyMarshalJSON:
@@ -6855,7 +6856,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				isPtr := code.typ.Kind() == reflect.Ptr
 				if p == nil || (!isPtr && *(*unsafe.Pointer)(p) == nil) {
 					code = code.nextField
@@ -6891,7 +6892,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadOmitEmptyMarshalText:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyMarshalText:
@@ -6903,7 +6904,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				isPtr := code.typ.Kind() == reflect.Ptr
 				if p == nil || (!isPtr && *(*unsafe.Pointer)(p) == nil) {
 					code = code.nextField
@@ -6925,7 +6926,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadOmitEmptyMarshalText:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyMarshalText:
@@ -6934,7 +6935,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				isPtr := code.typ.Kind() == reflect.Ptr
 				if p == nil || (!isPtr && *(*unsafe.Pointer)(p) == nil) {
 					code = code.nextField
@@ -6956,7 +6957,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTag:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTag:
@@ -6975,7 +6976,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTag:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTag:
@@ -6990,7 +6991,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagBool:
@@ -7003,7 +7004,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+				b = encodeBool(b, ptrToBool(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -7022,14 +7023,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			b = append(b, '{')
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagBool:
@@ -7039,7 +7040,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, code.escapedKey...)
 				b = append(b, '"')
-				b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+				b = encodeBool(b, ptrToBool(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -7047,7 +7048,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagBytes:
@@ -7059,14 +7060,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				b = append(b, code.escapedKey...)
-				b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagBytes:
@@ -7075,14 +7076,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				b = append(b, code.escapedKey...)
-				b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 				b = encodeComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagMarshalJSON:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagMarshalJSON:
@@ -7094,7 +7095,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				isPtr := code.typ.Kind() == reflect.Ptr
 				v := *(*interface{})(unsafe.Pointer(&interfaceHeader{typ: code.typ, ptr: p}))
 				bb, err := v.(Marshaler).MarshalJSON()
@@ -7117,7 +7118,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					code = code.nextField
 				} else {
 					var buf bytes.Buffer
-					if err := compact(&buf, bb, e.enabledHTMLEscape); err != nil {
+					if err := compact(&buf, bb, true); err != nil {
 						return nil, err
 					}
 					b = append(b, code.escapedKey...)
@@ -7129,7 +7130,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagMarshalJSON:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagMarshalJSON:
@@ -7138,7 +7139,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				isPtr := code.typ.Kind() == reflect.Ptr
 				v := *(*interface{})(unsafe.Pointer(&interfaceHeader{typ: code.typ, ptr: p}))
 				bb, err := v.(Marshaler).MarshalJSON()
@@ -7161,7 +7162,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 					code = code.nextField
 				} else {
 					var buf bytes.Buffer
-					if err := compact(&buf, bb, e.enabledHTMLEscape); err != nil {
+					if err := compact(&buf, bb, true); err != nil {
 						return nil, err
 					}
 					b = append(b, code.escapedKey...)
@@ -7173,7 +7174,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrHeadStringTagMarshalText:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagMarshalText:
@@ -7185,7 +7186,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			} else {
 				b = append(b, '{')
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				v := *(*interface{})(unsafe.Pointer(&interfaceHeader{typ: code.typ, ptr: p}))
 				bytes, err := v.(encoding.TextMarshaler).MarshalText()
 				if err != nil {
@@ -7202,7 +7203,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldPtrAnonymousHeadStringTagMarshalText:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagMarshalText:
@@ -7211,7 +7212,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 				code = code.end.next
 			} else {
 				ptr += code.offset
-				p := e.ptrToUnsafePtr(ptr)
+				p := ptrToUnsafePtr(ptr)
 				v := *(*interface{})(unsafe.Pointer(&interfaceHeader{typ: code.typ, ptr: p}))
 				bytes, err := v.(encoding.TextMarshaler).MarshalText()
 				if err != nil {
@@ -7248,12 +7249,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldInt:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt(ptr + code.offset)
+			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -7264,47 +7265,47 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldIntPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldIntNPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt8:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt8(ptr + code.offset)
+			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -7315,30 +7316,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt8Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt16:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt16(ptr + code.offset)
+			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -7349,30 +7350,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt16Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt32:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt32(ptr + code.offset)
+			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -7383,30 +7384,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt64:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt64(ptr + code.offset)
+			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -7417,30 +7418,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldInt64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint(ptr + code.offset)
+			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -7451,30 +7452,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUintPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint8:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint8(ptr + code.offset)
+			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -7485,30 +7486,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint8Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint16:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint16(ptr + code.offset)
+			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -7519,30 +7520,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint16Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint32:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint32(ptr + code.offset)
+			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -7553,30 +7554,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint64:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint64(ptr + code.offset)
+			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -7587,30 +7588,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint64(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint64(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldFloat32:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat32(ptr + code.offset)
+			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = encodeFloat32(b, v)
@@ -7621,25 +7622,25 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldFloat32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldFloat64:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -7648,7 +7649,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructFieldOmitEmptyFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
@@ -7660,7 +7661,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructFieldStringTagFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -7673,14 +7674,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldFloat64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 				b = encodeComma(b)
 				code = code.next
 				break
 			}
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -7690,12 +7691,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldString:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+			b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyString:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToString(ptr + code.offset)
+			v := ptrToString(ptr + code.offset)
 			if v != "" {
 				b = append(b, code.escapedKey...)
 				b = encodeEscapedString(b, v)
@@ -7705,50 +7706,50 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldStringTagString:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			s := e.ptrToString(ptr + code.offset)
+			s := ptrToString(ptr + code.offset)
 			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, s)))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldStringPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyStringPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = encodeNoEscapedString(b, e.ptrToString(p))
+				b = encodeNoEscapedString(b, ptrToString(p))
 				b = encodeComma(b)
 			}
 			code = code.next
 		case opStructFieldStringTagStringPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldBool:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyBool:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBool(ptr + code.offset)
+			v := ptrToBool(ptr + code.offset)
 			if v {
 				b = append(b, code.escapedKey...)
 				b = encodeBool(b, v)
@@ -7759,30 +7760,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldBoolPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeBool(b, e.ptrToBool(p))
+				b = encodeBool(b, ptrToBool(p))
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldBytes:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
 				b = append(b, code.escapedKey...)
 				b = encodeByteSlice(b, v)
@@ -7791,7 +7792,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructFieldStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			b = append(b, code.escapedKey...)
 			b = encodeByteSlice(b, v)
 			b = encodeComma(b)
@@ -7800,7 +7801,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7816,9 +7817,9 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
 			if code.typ.Kind() == reflect.Ptr && code.typ.Elem().Implements(marshalJSONType) {
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			if v != nil && p != 0 {
 				bb, err := v.(Marshaler).MarshalJSON()
 				if err != nil {
@@ -7836,13 +7837,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
 			}
 			var buf bytes.Buffer
-			if err := compact(&buf, bb, e.enabledHTMLEscape); err != nil {
+			if err := compact(&buf, bb, true); err != nil {
 				return nil, err
 			}
 			b = append(b, code.escapedKey...)
@@ -7853,7 +7854,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7864,7 +7865,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldOmitEmptyMarshalText:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			if v != nil {
 				bytes, err := v.(encoding.TextMarshaler).MarshalText()
 				if err != nil {
@@ -7878,7 +7879,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7896,7 +7897,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldOmitEmptyArray:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			array := e.ptrToSlice(p)
+			array := ptrToSlice(p)
 			if p == 0 || uintptr(array.data) == 0 {
 				code = code.nextField
 			} else {
@@ -7913,7 +7914,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructFieldOmitEmptySlice:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			slice := e.ptrToSlice(p)
+			slice := ptrToSlice(p)
 			if p == 0 || uintptr(slice.data) == 0 {
 				code = code.nextField
 			} else {
@@ -7983,12 +7984,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndInt:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt(ptr + code.offset)
+			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -8007,27 +8008,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndIntPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyIntPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8042,12 +8043,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagIntPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8055,29 +8056,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndIntNPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt8:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt8(ptr + code.offset)
+			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -8096,27 +8097,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt8Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt8Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8131,12 +8132,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagInt8Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8144,29 +8145,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndInt8NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt16:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt16(ptr + code.offset)
+			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -8185,27 +8186,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt16Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt16Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8220,12 +8221,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagInt16Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8233,29 +8234,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndInt16NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt32:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt32(ptr + code.offset)
+			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, int64(v))
@@ -8274,27 +8275,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8309,12 +8310,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagInt32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8322,29 +8323,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndInt32NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt64:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt64(ptr + code.offset)
+			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendInt(b, v)
@@ -8363,27 +8364,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndInt64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8398,12 +8399,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagInt64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8411,29 +8412,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndInt64NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint(ptr + code.offset)
+			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -8452,27 +8453,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUintPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUintPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8487,12 +8488,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagUintPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8500,29 +8501,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndUintNPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint8:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint8(ptr + code.offset)
+			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -8541,27 +8542,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint8Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint8Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8576,12 +8577,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagUint8Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8589,29 +8590,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndUint8NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint16:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint16(ptr + code.offset)
+			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -8630,27 +8631,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint16Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint16Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8665,12 +8666,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagUint16Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8678,29 +8679,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndUint16NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint32:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint32(ptr + code.offset)
+			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, uint64(v))
@@ -8719,27 +8720,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8754,12 +8755,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagUint32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8767,29 +8768,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndUint32NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint64:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint64(ptr + code.offset)
+			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = appendUint(b, v)
@@ -8808,27 +8809,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8843,12 +8844,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagUint64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8856,29 +8857,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndUint64NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndFloat32:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat32(ptr + code.offset)
+			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
 				b = append(b, code.escapedKey...)
 				b = encodeFloat32(b, v)
@@ -8897,27 +8898,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndFloat32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyFloat32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8932,12 +8933,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagFloat32Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8945,24 +8946,24 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndFloat32NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndFloat64:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -8971,7 +8972,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructEndOmitEmptyFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
@@ -8991,7 +8992,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructEndStringTagFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -9004,14 +9005,14 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndFloat64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 				b = appendStructEnd(b)
 				code = code.next
 				break
 			}
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -9020,10 +9021,10 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructEndOmitEmptyFloat64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -9042,12 +9043,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagFloat64Ptr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -9059,17 +9060,17 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndFloat64NPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -9080,12 +9081,12 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndString:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+			b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyString:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToString(ptr + code.offset)
+			v := ptrToString(ptr + code.offset)
 			if v != "" {
 				b = append(b, code.escapedKey...)
 				b = encodeEscapedString(b, v)
@@ -9103,27 +9104,27 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagString:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			s := e.ptrToString(ptr + code.offset)
+			s := ptrToString(ptr + code.offset)
 			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, s)))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndStringPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyStringPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.escapedKey...)
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -9138,11 +9139,11 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagStringPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToString(p)
+				v := ptrToString(p)
 				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, v)))
 			}
 			b = appendStructEnd(b)
@@ -9150,29 +9151,29 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringNPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			for i := 0; i < code.ptrNum-1; i++ {
 				if p == 0 {
 					break
 				}
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 			}
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndBool:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyBool:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBool(ptr + code.offset)
+			v := ptrToBool(ptr + code.offset)
 			if v {
 				b = append(b, code.escapedKey...)
 				b = encodeBool(b, v)
@@ -9191,30 +9192,30 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			b = append(b, '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndBoolPtr:
 			b = append(b, code.escapedKey...)
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeBool(b, e.ptrToBool(p))
+				b = encodeBool(b, ptrToBool(p))
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndBytes:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
 				b = append(b, code.escapedKey...)
 				b = encodeByteSlice(b, v)
@@ -9231,7 +9232,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			code = code.next
 		case opStructEndStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			b = append(b, code.escapedKey...)
 			b = encodeByteSlice(b, v)
 			b = appendStructEnd(b)
@@ -9240,7 +9241,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -9255,8 +9256,8 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndOmitEmptyMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
-			if v != nil && (code.typ.Kind() != reflect.Ptr || e.ptrToPtr(p) != 0) {
+			v := ptrToInterface(code, p)
+			if v != nil && (code.typ.Kind() != reflect.Ptr || ptrToPtr(p) != 0) {
 				bb, err := v.(Marshaler).MarshalJSON()
 				if err != nil {
 					return nil, errMarshaler(code, err)
@@ -9281,13 +9282,13 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
 			}
 			var buf bytes.Buffer
-			if err := compact(&buf, bb, e.enabledHTMLEscape); err != nil {
+			if err := compact(&buf, bb, true); err != nil {
 				return nil, err
 			}
 			b = append(b, code.escapedKey...)
@@ -9298,7 +9299,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.escapedKey...)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -9309,7 +9310,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndOmitEmptyMarshalText:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			if v != nil {
 				bytes, err := v.(encoding.TextMarshaler).MarshalText()
 				if err != nil {
@@ -9331,7 +9332,7 @@ func (e *Encoder) runEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcod
 		case opStructEndStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)

--- a/encode_vm_escaped.go
+++ b/encode_vm_escaped.go
@@ -21,7 +21,7 @@ func encodeRunEscaped(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, o
 	for {
 		switch code.op {
 		default:
-			return nil, fmt.Errorf("failed to handle opcode. doesn't implement %s", code.op)
+			return nil, fmt.Errorf("encoder (escaped): opcode %s has not been implemented", code.op)
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next

--- a/encode_vm_escaped_indent.go
+++ b/encode_vm_escaped_indent.go
@@ -277,7 +277,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
@@ -288,11 +288,11 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', '\n')
 					code = code.end.next
 				}
@@ -300,7 +300,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opRootSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
@@ -311,11 +311,11 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -325,7 +325,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				data := load(ctxptr, code.headIdx)
 				size := code.size
@@ -334,7 +334,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
@@ -343,33 +343,33 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				code = code.next
 				data := load(ctxptr, code.headIdx)
 				store(ctxptr, code.idx, data+idx*code.size)
 			} else {
 				b = append(b, '\n')
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, ']')
 				code = code.end.next
 			}
 		case opArrayHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				if code.length > 0 {
 					b = append(b, '[', '\n')
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					store(ctxptr, code.elemIdx, 0)
 					code = code.next
 					store(ctxptr, code.idx, p)
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -378,7 +378,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			idx := load(ctxptr, code.elemIdx)
 			idx++
 			if idx < code.length {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				p := load(ctxptr, code.headIdx)
 				size := code.size
@@ -387,14 +387,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
 		case opMapHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
@@ -415,14 +415,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = encodeIndent(ctx, b, code.next.indent)
+						b = appendIndent(ctx, b, code.next.indent)
 					}
 
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 					code = code.next
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -430,7 +430,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opMapHeadLoad:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				code = code.end.next
 			} else {
@@ -438,7 +438,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				ptr = ptrToPtr(ptr)
 				uptr := ptrToUnsafePtr(ptr)
 				if uintptr(uptr) == 0 {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = encodeNull(b)
 					b = encodeIndentComma(b)
 					code = code.end.next
@@ -461,12 +461,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = encodeIndent(ctx, b, code.next.indent)
+						b = appendIndent(ctx, b, code.next.indent)
 					}
 
 					code = code.next
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -477,7 +477,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			idx++
 			if (opt & EncodeOptionUnorderedMap) != 0 {
 				if idx < length {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					store(ctxptr, code.elemIdx, idx)
 					ptr := load(ctxptr, code.mapIter)
 					iter := ptrToUnsafePtr(ptr)
@@ -487,7 +487,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				} else {
 					last := len(b) - 1
 					b[last] = '\n'
-					b = encodeIndent(ctx, b, code.indent-1)
+					b = appendIndent(ctx, b, code.indent-1)
 					b = append(b, '}', ',', '\n')
 					code = code.end.next
 				}
@@ -573,20 +573,20 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else if code.next == code.end {
 				// not exists fields
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '}', ',', '\n')
 				code = code.end.next
 				store(ctxptr, code.idx, ptr)
 			} else {
 				b = append(b, '{', '\n')
 				if !code.anonymousKey {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 				}
@@ -603,18 +603,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
 				if p == 0 || *(*uintptr)(*(*unsafe.Pointer)(unsafe.Pointer(&p))) == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					code = code.next
@@ -625,7 +625,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 			}
@@ -636,7 +636,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey && ptr != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p := ptr + code.offset
@@ -656,7 +656,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -681,7 +681,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -703,7 +703,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -714,7 +714,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadIntOnly, opStructFieldHeadIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt(p)))
@@ -725,7 +725,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -735,7 +735,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagIntOnly, opStructFieldHeadStringTagIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt(p)))
@@ -754,7 +754,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -779,7 +779,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt(p)))
@@ -799,7 +799,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -826,7 +826,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -850,7 +850,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p+code.offset)))
@@ -870,7 +870,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -888,7 +888,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -913,7 +913,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -932,7 +932,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -948,7 +948,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -962,7 +962,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -978,7 +978,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -991,7 +991,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1009,7 +1009,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1033,7 +1033,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p)))
@@ -1049,7 +1049,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1072,7 +1072,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1095,7 +1095,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p+code.offset)))
@@ -1112,7 +1112,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1135,7 +1135,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(ptr)))
@@ -1160,7 +1160,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1182,7 +1182,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -1193,7 +1193,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt8(p)))
@@ -1204,7 +1204,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt8(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1214,7 +1214,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt8(p)))
@@ -1233,7 +1233,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1258,7 +1258,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt8(p)))
@@ -1278,7 +1278,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1305,7 +1305,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1329,7 +1329,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
@@ -1349,7 +1349,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1367,7 +1367,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -1392,7 +1392,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -1411,7 +1411,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1427,7 +1427,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1441,7 +1441,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -1457,7 +1457,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1470,7 +1470,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1488,7 +1488,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1512,7 +1512,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p)))
@@ -1528,7 +1528,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1551,7 +1551,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1574,7 +1574,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
@@ -1591,7 +1591,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1614,7 +1614,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(ptr)))
@@ -1639,7 +1639,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1661,7 +1661,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -1672,7 +1672,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt16(p)))
@@ -1683,7 +1683,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt16(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1693,7 +1693,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt16(p)))
@@ -1712,7 +1712,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1737,7 +1737,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt16(p)))
@@ -1757,7 +1757,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1784,7 +1784,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1808,7 +1808,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
@@ -1828,7 +1828,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1846,7 +1846,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -1871,7 +1871,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -1890,7 +1890,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1906,7 +1906,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1920,7 +1920,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -1936,7 +1936,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1949,7 +1949,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1967,7 +1967,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1991,7 +1991,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p)))
@@ -2007,7 +2007,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2030,7 +2030,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2053,7 +2053,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
@@ -2070,7 +2070,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2093,7 +2093,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(ptr)))
@@ -2118,7 +2118,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2140,7 +2140,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -2151,7 +2151,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt32(p)))
@@ -2162,7 +2162,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt32(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2172,7 +2172,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt32(p)))
@@ -2191,7 +2191,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2216,7 +2216,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt32(p)))
@@ -2236,7 +2236,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2263,7 +2263,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2287,7 +2287,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
@@ -2307,7 +2307,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2325,7 +2325,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -2350,7 +2350,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -2369,7 +2369,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2385,7 +2385,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2399,7 +2399,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -2415,7 +2415,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2428,7 +2428,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2446,7 +2446,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2470,7 +2470,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p)))
@@ -2486,7 +2486,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2509,7 +2509,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2532,7 +2532,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
@@ -2549,7 +2549,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2572,7 +2572,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(ptr))
@@ -2597,7 +2597,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2619,7 +2619,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -2630,7 +2630,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendInt(b, ptrToInt64(p))
@@ -2641,7 +2641,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := ptrToInt64(p)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2651,7 +2651,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, ptrToInt64(p))
@@ -2670,7 +2670,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2695,7 +2695,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, ptrToInt64(p))
@@ -2715,7 +2715,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2742,7 +2742,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2766,7 +2766,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p+code.offset))
@@ -2786,7 +2786,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2804,7 +2804,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -2829,7 +2829,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -2848,7 +2848,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2864,7 +2864,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2878,7 +2878,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -2894,7 +2894,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2907,7 +2907,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2925,7 +2925,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2949,7 +2949,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p))
@@ -2965,7 +2965,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2988,7 +2988,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3011,7 +3011,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p+code.offset))
@@ -3028,7 +3028,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3051,7 +3051,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3076,7 +3076,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3098,7 +3098,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3109,7 +3109,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUintOnly, opStructFieldHeadUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint(p)))
@@ -3120,7 +3120,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3130,7 +3130,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUintOnly, opStructFieldHeadStringTagUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint(p)))
@@ -3149,7 +3149,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3174,7 +3174,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint(p)))
@@ -3194,7 +3194,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3221,7 +3221,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3245,7 +3245,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
@@ -3265,7 +3265,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3283,7 +3283,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -3308,7 +3308,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3327,7 +3327,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3343,7 +3343,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3357,7 +3357,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3373,7 +3373,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3386,7 +3386,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3404,7 +3404,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3428,7 +3428,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p)))
@@ -3444,7 +3444,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3467,7 +3467,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3490,7 +3490,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
@@ -3507,7 +3507,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3530,7 +3530,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(ptr)))
@@ -3555,7 +3555,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3577,7 +3577,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -3588,7 +3588,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3599,7 +3599,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint8(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3609,7 +3609,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3628,7 +3628,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3653,7 +3653,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3673,7 +3673,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3700,7 +3700,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3724,7 +3724,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
@@ -3744,7 +3744,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3762,7 +3762,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -3787,7 +3787,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -3806,7 +3806,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3822,7 +3822,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3836,7 +3836,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -3852,7 +3852,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3865,7 +3865,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3883,7 +3883,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3907,7 +3907,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3923,7 +3923,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3946,7 +3946,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3969,7 +3969,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
@@ -3986,7 +3986,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4009,7 +4009,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(ptr)))
@@ -4034,7 +4034,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4056,7 +4056,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -4067,7 +4067,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4078,7 +4078,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint16(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4088,7 +4088,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4107,7 +4107,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4132,7 +4132,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4152,7 +4152,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4179,7 +4179,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4203,7 +4203,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
@@ -4223,7 +4223,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4241,7 +4241,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -4266,7 +4266,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -4285,7 +4285,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4301,7 +4301,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4315,7 +4315,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -4331,7 +4331,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4344,7 +4344,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4362,7 +4362,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4386,7 +4386,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4402,7 +4402,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4425,7 +4425,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4448,7 +4448,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
@@ -4465,7 +4465,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4488,7 +4488,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(ptr)))
@@ -4513,7 +4513,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4535,7 +4535,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -4546,7 +4546,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4557,7 +4557,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint32(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4567,7 +4567,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4586,7 +4586,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4611,7 +4611,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4631,7 +4631,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4658,7 +4658,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4682,7 +4682,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
@@ -4702,7 +4702,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4720,7 +4720,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -4745,7 +4745,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -4764,7 +4764,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4780,7 +4780,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4794,7 +4794,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -4810,7 +4810,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4823,7 +4823,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4841,7 +4841,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4865,7 +4865,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4881,7 +4881,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4904,7 +4904,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4927,7 +4927,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
@@ -4944,7 +4944,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4967,7 +4967,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(ptr))
@@ -4992,7 +4992,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5014,7 +5014,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -5025,7 +5025,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = appendUint(b, ptrToUint64(p))
@@ -5036,7 +5036,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := ptrToUint64(p)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -5046,7 +5046,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, ptrToUint64(p))
@@ -5065,7 +5065,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5090,7 +5090,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, ptrToUint64(p))
@@ -5110,7 +5110,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5137,7 +5137,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5161,7 +5161,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p+code.offset))
@@ -5181,7 +5181,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5199,7 +5199,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -5224,7 +5224,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -5243,7 +5243,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5259,7 +5259,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5273,7 +5273,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -5289,7 +5289,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5302,7 +5302,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5320,7 +5320,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5344,7 +5344,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p))
@@ -5360,7 +5360,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5383,7 +5383,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5406,7 +5406,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p+code.offset))
@@ -5423,7 +5423,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5446,7 +5446,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(ptr))
@@ -5471,7 +5471,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5493,7 +5493,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
@@ -5504,7 +5504,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadFloat32Only, opStructFieldHeadFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = encodeFloat32(b, ptrToFloat32(p))
@@ -5515,7 +5515,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := ptrToFloat32(p)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -5525,7 +5525,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagFloat32Only, opStructFieldHeadStringTagFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat32(b, ptrToFloat32(p))
@@ -5544,7 +5544,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5569,7 +5569,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, ptrToFloat32(p))
@@ -5589,7 +5589,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5616,7 +5616,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5640,7 +5640,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
@@ -5660,7 +5660,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5678,7 +5678,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -5703,7 +5703,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(ptr))
@@ -5722,7 +5722,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5738,7 +5738,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5752,7 +5752,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(ptr))
@@ -5768,7 +5768,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5781,7 +5781,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5799,7 +5799,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5823,7 +5823,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p))
@@ -5839,7 +5839,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5862,7 +5862,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5885,7 +5885,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
@@ -5902,7 +5902,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5929,7 +5929,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 					return nil, errUnsupportedFloat(v)
 				}
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -5957,7 +5957,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -5979,7 +5979,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				v := ptrToFloat64(ptr + code.offset)
@@ -5994,7 +5994,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadFloat64Only, opStructFieldHeadFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			v := ptrToFloat64(p)
@@ -6012,7 +6012,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				return nil, errUnsupportedFloat(v)
 			}
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -6022,7 +6022,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagFloat64Only, opStructFieldHeadStringTagFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			v := ptrToFloat64(p)
@@ -6045,7 +6045,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6074,7 +6074,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					v := ptrToFloat64(p)
@@ -6098,7 +6098,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6129,7 +6129,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6157,7 +6157,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -6181,7 +6181,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6203,7 +6203,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -6232,7 +6232,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToFloat64(ptr)
@@ -6258,7 +6258,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -6274,7 +6274,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -6292,7 +6292,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToFloat64(ptr)
@@ -6312,7 +6312,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					v := ptrToFloat64(ptr)
@@ -6329,7 +6329,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -6351,7 +6351,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6379,7 +6379,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -6399,7 +6399,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6426,7 +6426,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6453,7 +6453,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -6474,7 +6474,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6501,7 +6501,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(ptr))
@@ -6526,7 +6526,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, v)
@@ -6548,7 +6548,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToString(ptr + code.offset)
@@ -6559,7 +6559,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringOnly, opStructFieldHeadStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = encodeEscapedString(b, ptrToString(p))
@@ -6570,7 +6570,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, '{', '\n')
 			v := ptrToString(p)
 			if v != "" {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, v)
@@ -6580,7 +6580,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagStringOnly, opStructFieldHeadStringTagStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
@@ -6598,7 +6598,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6623,7 +6623,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, ptrToString(p))
@@ -6643,7 +6643,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6668,7 +6668,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6692,7 +6692,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(p+code.offset))
@@ -6712,7 +6712,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6728,7 +6728,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -6753,7 +6753,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
@@ -6772,7 +6772,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, v)
@@ -6788,7 +6788,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(ptr+code.offset))))
@@ -6800,7 +6800,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
@@ -6816,7 +6816,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, v)
@@ -6829,7 +6829,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(ptr+code.offset))))
@@ -6845,7 +6845,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6869,7 +6869,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(p))
@@ -6885,7 +6885,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6906,7 +6906,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6929,7 +6929,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(p+code.offset))
@@ -6946,7 +6946,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6962,14 +6962,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeBool(b, ptrToBool(ptr))
@@ -6982,14 +6982,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, ptrToBytes(ptr))
@@ -7005,18 +7005,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				v := ptrToBool(ptr + code.offset)
 				if !v {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeBool(b, v)
@@ -7033,18 +7033,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				v := ptrToBytes(ptr + code.offset)
 				if len(v) == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeByteSlice(b, v)
@@ -7067,7 +7067,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			} else {
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
@@ -7082,13 +7082,13 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
 				b = encodeBool(b, ptrToBool(ptr+code.offset))
@@ -7105,13 +7105,13 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
@@ -7119,7 +7119,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.next
 			}
 		case opStructField:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7132,7 +7132,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 || **(**uintptr)(unsafe.Pointer(&p)) == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
@@ -7141,13 +7141,13 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldStringTag:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			code = code.next
 			store(ctxptr, code.idx, p)
 		case opStructFieldInt:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7158,7 +7158,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7167,7 +7167,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -7175,7 +7175,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7186,7 +7186,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7195,7 +7195,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -7203,7 +7203,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7214,7 +7214,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7223,7 +7223,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -7231,7 +7231,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7242,7 +7242,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7251,7 +7251,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -7259,7 +7259,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7270,7 +7270,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -7279,7 +7279,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -7287,7 +7287,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7298,7 +7298,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7307,7 +7307,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -7315,7 +7315,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7326,7 +7326,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7335,7 +7335,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -7343,7 +7343,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7354,7 +7354,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7363,7 +7363,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -7371,7 +7371,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7382,7 +7382,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7391,7 +7391,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -7399,7 +7399,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7410,7 +7410,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -7419,7 +7419,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -7427,7 +7427,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7438,7 +7438,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -7447,7 +7447,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
@@ -7455,7 +7455,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7473,7 +7473,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -7486,7 +7486,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
@@ -7494,7 +7494,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldString:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7505,7 +7505,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, v)
@@ -7514,7 +7514,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			s := ptrToString(ptr + code.offset)
@@ -7522,7 +7522,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7538,7 +7538,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(p))
@@ -7546,7 +7546,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			}
 			code = code.next
 		case opStructFieldStringTagStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7559,7 +7559,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBool:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7570,7 +7570,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
@@ -7579,7 +7579,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeBool(b, ptrToBool(ptr+code.offset))
@@ -7587,7 +7587,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBytes:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7598,7 +7598,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
@@ -7607,14 +7607,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldMarshalJSON:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7642,7 +7642,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
@@ -7670,7 +7670,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
@@ -7683,7 +7683,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldArray:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7703,13 +7703,13 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 || uintptr(array.data) == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldSlice:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7729,13 +7729,13 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 || uintptr(slice.data) == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldMap:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7764,14 +7764,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					code = code.next
 				}
 			}
 		case opStructFieldMapLoad:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7799,7 +7799,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					code = code.next
@@ -7808,7 +7808,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldStruct:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -7831,7 +7831,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				headCode := code.next
@@ -7859,12 +7859,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = b[:len(b)-2]
 			}
 			b = append(b, '\n')
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, '}')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructEndInt:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7875,7 +7875,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7890,7 +7890,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7898,7 +7898,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -7906,7 +7906,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndIntPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7922,7 +7922,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p)))
@@ -7937,14 +7937,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagIntPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7959,7 +7959,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7970,7 +7970,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7985,7 +7985,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7993,7 +7993,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -8001,7 +8001,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8017,7 +8017,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p)))
@@ -8032,14 +8032,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8054,7 +8054,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8065,7 +8065,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -8080,7 +8080,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8088,7 +8088,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -8096,7 +8096,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8112,7 +8112,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p)))
@@ -8127,14 +8127,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8149,7 +8149,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8160,7 +8160,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -8175,7 +8175,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8183,7 +8183,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -8191,7 +8191,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8207,7 +8207,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p)))
@@ -8222,14 +8222,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8244,7 +8244,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8255,7 +8255,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -8270,7 +8270,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8278,7 +8278,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -8286,7 +8286,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8302,7 +8302,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p))
@@ -8317,14 +8317,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8339,7 +8339,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8350,7 +8350,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8365,7 +8365,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8373,7 +8373,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -8381,7 +8381,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUintPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8397,7 +8397,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p)))
@@ -8412,14 +8412,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUintPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8434,7 +8434,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8445,7 +8445,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8460,7 +8460,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8468,7 +8468,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -8476,7 +8476,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8492,7 +8492,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p)))
@@ -8507,14 +8507,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8529,7 +8529,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8540,7 +8540,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8555,7 +8555,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8563,7 +8563,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -8571,7 +8571,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8587,7 +8587,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p)))
@@ -8602,14 +8602,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8624,7 +8624,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8635,7 +8635,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8650,7 +8650,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8658,7 +8658,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -8666,7 +8666,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8682,7 +8682,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p)))
@@ -8697,14 +8697,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8719,7 +8719,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8730,7 +8730,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -8745,7 +8745,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8753,7 +8753,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -8761,7 +8761,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8777,7 +8777,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p))
@@ -8792,14 +8792,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8814,7 +8814,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8825,7 +8825,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -8840,7 +8840,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8848,7 +8848,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
@@ -8856,7 +8856,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8872,7 +8872,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p))
@@ -8887,14 +8887,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8909,7 +8909,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8924,7 +8924,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -8942,7 +8942,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8954,7 +8954,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
@@ -8962,7 +8962,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8982,7 +8982,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -9001,14 +9001,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9027,7 +9027,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndString:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9038,7 +9038,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, v)
@@ -9053,7 +9053,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9061,7 +9061,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			s := ptrToString(ptr + code.offset)
@@ -9069,7 +9069,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9085,7 +9085,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, ptrToString(p))
@@ -9100,14 +9100,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9120,7 +9120,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBool:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9131,7 +9131,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
@@ -9146,7 +9146,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9154,7 +9154,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeBool(b, ptrToBool(ptr+code.offset))
@@ -9162,7 +9162,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBytes:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9173,7 +9173,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
@@ -9188,7 +9188,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9196,14 +9196,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndMarshalJSON:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9231,7 +9231,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
@@ -9258,7 +9258,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset

--- a/encode_vm_escaped_indent.go
+++ b/encode_vm_escaped_indent.go
@@ -12,7 +12,7 @@ import (
 	"unsafe"
 )
 
-func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet) ([]byte, error) {
+func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt EncodeOption) ([]byte, error) {
 	ptrOffset := uintptr(0)
 	ctxptr := ctx.ptr()
 	code := codeSet.code
@@ -24,113 +24,113 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next
-			store(ctxptr, code.idx, e.ptrToPtr(ptr))
+			store(ctxptr, code.idx, ptrToPtr(ptr))
 		case opInt:
-			b = appendInt(b, int64(e.ptrToInt(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt8:
-			b = appendInt(b, int64(e.ptrToInt8(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt16:
-			b = appendInt(b, int64(e.ptrToInt16(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt32:
-			b = appendInt(b, int64(e.ptrToInt32(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt64:
-			b = appendInt(b, e.ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint:
-			b = appendUint(b, uint64(e.ptrToUint(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint8:
-			b = appendUint(b, uint64(e.ptrToUint8(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint16:
-			b = appendUint(b, uint64(e.ptrToUint16(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint32:
-			b = appendUint(b, uint64(e.ptrToUint32(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint64:
-			b = appendUint(b, e.ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opIntString:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt8String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt8(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt16String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt16(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt32String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt32(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt64String:
 			b = append(b, '"')
-			b = appendInt(b, e.ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUintString:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint8String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint8(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint16String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint16(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint32String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint32(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint64String:
 			b = append(b, '"')
-			b = appendUint(b, e.ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opFloat32:
-			b = encodeFloat32(b, e.ptrToFloat32(load(ctxptr, code.idx)))
+			b = encodeFloat32(b, ptrToFloat32(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opFloat64:
-			v := e.ptrToFloat64(load(ctxptr, code.idx))
+			v := ptrToFloat64(load(ctxptr, code.idx))
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -138,20 +138,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opString:
-			b = encodeEscapedString(b, e.ptrToString(load(ctxptr, code.idx)))
+			b = encodeEscapedString(b, ptrToString(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opBool:
-			b = encodeBool(b, e.ptrToBool(load(ctxptr, code.idx)))
+			b = encodeBool(b, ptrToBool(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opBytes:
 			ptr := load(ctxptr, code.idx)
-			slice := e.ptrToSlice(ptr)
+			slice := ptrToSlice(ptr)
 			if ptr == 0 || uintptr(slice.data) == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeByteSlice(b, e.ptrToBytes(ptr))
+				b = encodeByteSlice(b, ptrToBytes(ptr))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -169,7 +169,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 			ctx.seenPtr = append(ctx.seenPtr, ptr)
-			iface := (*interfaceHeader)(e.ptrToUnsafePtr(ptr))
+			iface := (*interfaceHeader)(ptrToUnsafePtr(ptr))
 			if iface == nil || iface.ptr == nil {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -177,7 +177,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			}
 			ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(iface))
-			ifaceCodeSet, err := e.compileToGetCodeSet(uintptr(unsafe.Pointer(iface.typ)))
+			ifaceCodeSet, err := encodeCompileToGetCodeSet(uintptr(unsafe.Pointer(iface.typ)))
 			if err != nil {
 				return nil, err
 			}
@@ -199,13 +199,13 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 
 			ctx.ptrs = newPtrs
 
-			oldBaseIndent := e.baseIndent
-			e.baseIndent = code.indent
-			bb, err := e.runEscapedIndent(ctx, b, ifaceCodeSet)
+			oldBaseIndent := ctx.baseIndent
+			ctx.baseIndent = code.indent
+			bb, err := encodeRunEscapedIndent(ctx, b, ifaceCodeSet, opt)
 			if err != nil {
 				return nil, err
 			}
-			e.baseIndent = oldBaseIndent
+			ctx.baseIndent = oldBaseIndent
 
 			ctx.ptrs = oldPtrs
 			ctxptr = ctx.ptr()
@@ -221,7 +221,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.next
 				break
 			}
-			v := e.ptrToInterface(code, ptr)
+			v := ptrToInterface(code, ptr)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -241,8 +241,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
@@ -252,7 +252,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opMarshalText:
 			ptr := load(ctxptr, code.idx)
 			isPtr := code.typ.Kind() == reflect.Ptr
-			p := e.ptrToUnsafePtr(ptr)
+			p := ptrToUnsafePtr(ptr)
 			if p == nil {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -277,22 +277,22 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				slice := e.ptrToSlice(p)
+				slice := ptrToSlice(p)
 				store(ctxptr, code.elemIdx, 0)
 				store(ctxptr, code.length, uintptr(slice.len))
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', '\n')
 					code = code.end.next
 				}
@@ -300,22 +300,22 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opRootSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				slice := e.ptrToSlice(p)
+				slice := ptrToSlice(p)
 				store(ctxptr, code.elemIdx, 0)
 				store(ctxptr, code.length, uintptr(slice.len))
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -325,7 +325,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				data := load(ctxptr, code.headIdx)
 				size := code.size
@@ -334,7 +334,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
@@ -343,33 +343,33 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				code = code.next
 				data := load(ctxptr, code.headIdx)
 				store(ctxptr, code.idx, data+idx*code.size)
 			} else {
 				b = append(b, '\n')
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, ']')
 				code = code.end.next
 			}
 		case opArrayHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				if code.length > 0 {
 					b = append(b, '[', '\n')
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					store(ctxptr, code.elemIdx, 0)
 					code = code.next
 					store(ctxptr, code.idx, p)
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -378,7 +378,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			idx := load(ctxptr, code.elemIdx)
 			idx++
 			if idx < code.length {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				p := load(ctxptr, code.headIdx)
 				size := code.size
@@ -387,19 +387,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
 		case opMapHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				uptr := e.ptrToUnsafePtr(ptr)
+				uptr := ptrToUnsafePtr(ptr)
 				mlen := maplen(uptr)
 				if mlen > 0 {
 					b = append(b, '{', '\n')
@@ -409,20 +409,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 					store(ctxptr, code.length, uintptr(mlen))
 					store(ctxptr, code.mapIter, uintptr(iter))
 
-					if !e.unorderedMap {
+					if (opt & EncodeOptionUnorderedMap) == 0 {
 						mapCtx := newMapContext(mlen)
 						mapCtx.pos = append(mapCtx.pos, len(b))
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = e.encodeIndent(b, code.next.indent)
+						b = encodeIndent(ctx, b, code.next.indent)
 					}
 
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 					code = code.next
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -430,15 +430,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opMapHeadLoad:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				code = code.end.next
 			} else {
 				// load pointer
-				ptr = e.ptrToPtr(ptr)
-				uptr := e.ptrToUnsafePtr(ptr)
+				ptr = ptrToPtr(ptr)
+				uptr := ptrToUnsafePtr(ptr)
 				if uintptr(uptr) == 0 {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = encodeNull(b)
 					b = encodeIndentComma(b)
 					code = code.end.next
@@ -455,18 +455,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 
-					if !e.unorderedMap {
+					if (opt & EncodeOptionUnorderedMap) == 0 {
 						mapCtx := newMapContext(mlen)
 						mapCtx.pos = append(mapCtx.pos, len(b))
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = e.encodeIndent(b, code.next.indent)
+						b = encodeIndent(ctx, b, code.next.indent)
 					}
 
 					code = code.next
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -475,29 +475,29 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			idx := load(ctxptr, code.elemIdx)
 			length := load(ctxptr, code.length)
 			idx++
-			if e.unorderedMap {
+			if (opt & EncodeOptionUnorderedMap) != 0 {
 				if idx < length {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					store(ctxptr, code.elemIdx, idx)
 					ptr := load(ctxptr, code.mapIter)
-					iter := e.ptrToUnsafePtr(ptr)
+					iter := ptrToUnsafePtr(ptr)
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 					code = code.next
 				} else {
 					last := len(b) - 1
 					b[last] = '\n'
-					b = e.encodeIndent(b, code.indent-1)
+					b = encodeIndent(ctx, b, code.indent-1)
 					b = append(b, '}', ',', '\n')
 					code = code.end.next
 				}
 			} else {
 				ptr := load(ctxptr, code.end.mapPos)
-				mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+				mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 				mapCtx.pos = append(mapCtx.pos, len(b))
 				if idx < length {
 					ptr := load(ctxptr, code.mapIter)
-					iter := e.ptrToUnsafePtr(ptr)
+					iter := ptrToUnsafePtr(ptr)
 					store(ctxptr, code.elemIdx, idx)
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
@@ -507,15 +507,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opMapValue:
-			if e.unorderedMap {
+			if (opt & EncodeOptionUnorderedMap) != 0 {
 				b = append(b, ':', ' ')
 			} else {
 				ptr := load(ctxptr, code.end.mapPos)
-				mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+				mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 				mapCtx.pos = append(mapCtx.pos, len(b))
 			}
 			ptr := load(ctxptr, code.mapIter)
-			iter := e.ptrToUnsafePtr(ptr)
+			iter := ptrToUnsafePtr(ptr)
 			value := mapitervalue(iter)
 			store(ctxptr, code.next.idx, uintptr(value))
 			mapiternext(iter)
@@ -524,7 +524,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			// this operation only used by sorted map
 			length := int(load(ctxptr, code.length))
 			ptr := load(ctxptr, code.mapPos)
-			mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+			mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 			pos := mapCtx.pos
 			for i := 0; i < length; i++ {
 				startKey := pos[i*2]
@@ -543,8 +543,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			sort.Sort(mapCtx.slice)
 			buf := mapCtx.buf
 			for _, item := range mapCtx.slice.items {
-				buf = append(buf, e.prefix...)
-				buf = append(buf, bytes.Repeat(e.indentStr, e.baseIndent+code.indent+1)...)
+				buf = append(buf, ctx.prefix...)
+				buf = append(buf, bytes.Repeat(ctx.indentStr, ctx.baseIndent+code.indent+1)...)
 				buf = append(buf, item.key...)
 				buf[len(buf)-2] = ':'
 				buf[len(buf)-1] = ' '
@@ -552,8 +552,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			}
 			buf = buf[:len(buf)-2]
 			buf = append(buf, '\n')
-			buf = append(buf, e.prefix...)
-			buf = append(buf, bytes.Repeat(e.indentStr, e.baseIndent+code.indent)...)
+			buf = append(buf, ctx.prefix...)
+			buf = append(buf, bytes.Repeat(ctx.indentStr, ctx.baseIndent+code.indent)...)
 			buf = append(buf, '}', ',', '\n')
 
 			b = b[:pos[0]]
@@ -568,25 +568,25 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else if code.next == code.end {
 				// not exists fields
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '}', ',', '\n')
 				code = code.end.next
 				store(ctxptr, code.idx, ptr)
 			} else {
 				b = append(b, '{', '\n')
 				if !code.anonymousKey {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 				}
@@ -597,24 +597,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
 				if p == 0 || *(*uintptr)(*(*unsafe.Pointer)(unsafe.Pointer(&p))) == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					code = code.next
@@ -625,7 +625,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 			}
@@ -636,7 +636,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey && ptr != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				p := ptr + code.offset
@@ -646,7 +646,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.nextField
 			}
 		case opStructFieldPtrHeadInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt:
 			ptr := load(ctxptr, code.idx)
@@ -656,17 +656,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt:
@@ -677,11 +677,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -692,7 +692,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt:
@@ -703,10 +703,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -714,18 +714,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadIntOnly, opStructFieldHeadIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt(p)))
+			b = appendInt(b, int64(ptrToInt(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntOnly, opStructFieldHeadOmitEmptyIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt(p))
+			v := int64(ptrToInt(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -735,15 +735,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagIntOnly, opStructFieldHeadStringTagIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt(p)))
+			b = appendInt(b, int64(ptrToInt(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadIntPtr:
 			p := load(ctxptr, code.idx)
@@ -754,20 +754,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyIntPtr:
 			p := load(ctxptr, code.idx)
@@ -777,18 +777,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt(p)))
+					b = appendInt(b, int64(ptrToInt(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagIntPtr:
 			p := load(ctxptr, code.idx)
@@ -799,15 +799,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -821,18 +821,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -844,16 +844,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -865,19 +865,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -888,51 +888,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -941,18 +941,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -962,10 +962,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -974,11 +974,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -991,17 +991,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtr:
 			p := load(ctxptr, code.idx)
@@ -1009,19 +1009,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyIntPtr:
 			p := load(ctxptr, code.idx)
@@ -1029,19 +1029,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtr:
 			p := load(ctxptr, code.idx)
@@ -1049,15 +1049,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1068,17 +1068,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1088,17 +1088,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1108,24 +1108,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt8:
 			ptr := load(ctxptr, code.idx)
@@ -1135,17 +1135,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(ptr)))
+				b = appendInt(b, int64(ptrToInt8(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8:
@@ -1156,11 +1156,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1171,7 +1171,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt8:
@@ -1182,10 +1182,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1193,18 +1193,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt8(p)))
+			b = appendInt(b, int64(ptrToInt8(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt8Only, opStructFieldHeadOmitEmptyInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt8(p))
+			v := int64(ptrToInt8(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1214,15 +1214,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt8(p)))
+			b = appendInt(b, int64(ptrToInt8(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1233,20 +1233,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1256,18 +1256,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt8(p)))
+					b = appendInt(b, int64(ptrToInt8(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1278,15 +1278,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -1300,18 +1300,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1323,16 +1323,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -1344,19 +1344,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1367,51 +1367,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1420,18 +1420,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1441,10 +1441,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1453,11 +1453,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1470,17 +1470,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1488,19 +1488,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1508,19 +1508,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1528,15 +1528,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1547,17 +1547,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1567,17 +1567,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1587,24 +1587,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt16:
 			ptr := load(ctxptr, code.idx)
@@ -1614,17 +1614,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(ptr)))
+				b = appendInt(b, int64(ptrToInt16(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16:
@@ -1635,11 +1635,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1650,7 +1650,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt16:
@@ -1661,10 +1661,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1672,18 +1672,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt16(p)))
+			b = appendInt(b, int64(ptrToInt16(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt16Only, opStructFieldHeadOmitEmptyInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt16(p))
+			v := int64(ptrToInt16(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1693,15 +1693,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt16(p)))
+			b = appendInt(b, int64(ptrToInt16(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1712,20 +1712,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1735,18 +1735,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt16(p)))
+					b = appendInt(b, int64(ptrToInt16(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1757,15 +1757,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -1779,18 +1779,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1802,16 +1802,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -1823,19 +1823,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1846,51 +1846,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1899,18 +1899,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1920,10 +1920,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1932,11 +1932,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1949,17 +1949,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1967,19 +1967,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1987,19 +1987,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -2007,15 +2007,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2026,17 +2026,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2046,17 +2046,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2066,24 +2066,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt32:
 			ptr := load(ctxptr, code.idx)
@@ -2093,17 +2093,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(ptr)))
+				b = appendInt(b, int64(ptrToInt32(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32:
@@ -2114,11 +2114,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2129,7 +2129,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt32:
@@ -2140,10 +2140,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2151,18 +2151,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt32(p)))
+			b = appendInt(b, int64(ptrToInt32(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt32Only, opStructFieldHeadOmitEmptyInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt32(p))
+			v := int64(ptrToInt32(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2172,15 +2172,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt32(p)))
+			b = appendInt(b, int64(ptrToInt32(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2191,20 +2191,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2214,18 +2214,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt32(p)))
+					b = appendInt(b, int64(ptrToInt32(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2236,15 +2236,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -2258,18 +2258,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2281,16 +2281,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -2302,19 +2302,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2325,51 +2325,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2378,18 +2378,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2399,10 +2399,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2411,11 +2411,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2428,17 +2428,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2446,19 +2446,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2466,19 +2466,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2486,15 +2486,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2505,17 +2505,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2525,17 +2525,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2545,24 +2545,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt64:
 			ptr := load(ctxptr, code.idx)
@@ -2572,17 +2572,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(ptr))
+				b = appendInt(b, ptrToInt64(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64:
@@ -2593,11 +2593,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2608,7 +2608,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt64:
@@ -2619,10 +2619,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2630,18 +2630,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendInt(b, e.ptrToInt64(p))
+			b = appendInt(b, ptrToInt64(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt64Only, opStructFieldHeadOmitEmptyInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToInt64(p)
+			v := ptrToInt64(p)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2651,15 +2651,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, e.ptrToInt64(p))
+			b = appendInt(b, ptrToInt64(p))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2670,20 +2670,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2693,18 +2693,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, e.ptrToInt64(p))
+					b = appendInt(b, ptrToInt64(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2715,15 +2715,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -2737,18 +2737,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2760,16 +2760,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -2781,19 +2781,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2804,51 +2804,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2857,18 +2857,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2878,10 +2878,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2890,11 +2890,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2907,17 +2907,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2925,19 +2925,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2945,19 +2945,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2965,15 +2965,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2984,17 +2984,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3004,17 +3004,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3024,24 +3024,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint:
 			ptr := load(ctxptr, code.idx)
@@ -3051,17 +3051,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint:
@@ -3072,11 +3072,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3087,7 +3087,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint:
@@ -3098,10 +3098,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3109,18 +3109,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadUintOnly, opStructFieldHeadUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint(p)))
+			b = appendUint(b, uint64(ptrToUint(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintOnly, opStructFieldHeadOmitEmptyUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint(p))
+			v := uint64(ptrToUint(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3130,15 +3130,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUintOnly, opStructFieldHeadStringTagUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint(p)))
+			b = appendUint(b, uint64(ptrToUint(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3149,20 +3149,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3172,18 +3172,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint(p)))
+					b = appendUint(b, uint64(ptrToUint(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3194,15 +3194,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -3216,18 +3216,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3239,16 +3239,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3260,19 +3260,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3283,51 +3283,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3336,18 +3336,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3357,10 +3357,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3369,11 +3369,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3386,17 +3386,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3404,19 +3404,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3424,19 +3424,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3444,15 +3444,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3463,17 +3463,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3483,17 +3483,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3503,24 +3503,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint8:
 			ptr := load(ctxptr, code.idx)
@@ -3530,17 +3530,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr)))
+				b = appendUint(b, uint64(ptrToUint8(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8:
@@ -3551,11 +3551,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3566,7 +3566,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint8:
@@ -3577,10 +3577,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3588,18 +3588,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint8(p)))
+			b = appendUint(b, uint64(ptrToUint8(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint8Only, opStructFieldHeadOmitEmptyUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint8(p))
+			v := uint64(ptrToUint8(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3609,15 +3609,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint8(p)))
+			b = appendUint(b, uint64(ptrToUint8(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3628,20 +3628,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3651,18 +3651,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint8(p)))
+					b = appendUint(b, uint64(ptrToUint8(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3673,15 +3673,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -3695,18 +3695,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3718,16 +3718,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3739,19 +3739,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3762,51 +3762,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3815,18 +3815,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3836,10 +3836,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3848,11 +3848,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3865,17 +3865,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3883,19 +3883,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3903,19 +3903,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3923,15 +3923,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3942,17 +3942,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3962,17 +3962,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3982,24 +3982,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint16:
 			ptr := load(ctxptr, code.idx)
@@ -4009,17 +4009,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr)))
+				b = appendUint(b, uint64(ptrToUint16(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16:
@@ -4030,11 +4030,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4045,7 +4045,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint16:
@@ -4056,10 +4056,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4067,18 +4067,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint16(p)))
+			b = appendUint(b, uint64(ptrToUint16(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint16Only, opStructFieldHeadOmitEmptyUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint16(p))
+			v := uint64(ptrToUint16(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4088,15 +4088,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint16(p)))
+			b = appendUint(b, uint64(ptrToUint16(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4107,20 +4107,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4130,18 +4130,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint16(p)))
+					b = appendUint(b, uint64(ptrToUint16(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4152,15 +4152,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -4174,18 +4174,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4197,16 +4197,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -4218,19 +4218,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4241,51 +4241,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4294,18 +4294,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4315,10 +4315,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4327,11 +4327,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4344,17 +4344,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4362,19 +4362,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4382,19 +4382,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4402,15 +4402,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4421,17 +4421,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4441,17 +4441,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4461,24 +4461,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint32:
 			ptr := load(ctxptr, code.idx)
@@ -4488,17 +4488,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr)))
+				b = appendUint(b, uint64(ptrToUint32(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32:
@@ -4509,11 +4509,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4524,7 +4524,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint32:
@@ -4535,10 +4535,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4546,18 +4546,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint32(p)))
+			b = appendUint(b, uint64(ptrToUint32(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint32Only, opStructFieldHeadOmitEmptyUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint32(p))
+			v := uint64(ptrToUint32(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4567,15 +4567,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint32(p)))
+			b = appendUint(b, uint64(ptrToUint32(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4586,20 +4586,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4609,18 +4609,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint32(p)))
+					b = appendUint(b, uint64(ptrToUint32(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4631,15 +4631,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -4653,18 +4653,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4676,16 +4676,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -4697,19 +4697,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4720,51 +4720,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4773,18 +4773,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4794,10 +4794,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4806,11 +4806,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4823,17 +4823,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4841,19 +4841,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4861,19 +4861,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4881,15 +4881,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4900,17 +4900,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4920,17 +4920,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4940,24 +4940,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint64:
 			ptr := load(ctxptr, code.idx)
@@ -4967,17 +4967,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(ptr))
+				b = appendUint(b, ptrToUint64(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64:
@@ -4988,11 +4988,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5003,7 +5003,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint64:
@@ -5014,10 +5014,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5025,18 +5025,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendUint(b, e.ptrToUint64(p))
+			b = appendUint(b, ptrToUint64(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint64Only, opStructFieldHeadOmitEmptyUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToUint64(p)
+			v := ptrToUint64(p)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -5046,15 +5046,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, e.ptrToUint64(p))
+			b = appendUint(b, ptrToUint64(p))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5065,20 +5065,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5088,18 +5088,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, e.ptrToUint64(p))
+					b = appendUint(b, ptrToUint64(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5110,15 +5110,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -5132,18 +5132,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5155,16 +5155,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -5176,19 +5176,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5199,51 +5199,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5252,18 +5252,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5273,10 +5273,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5285,11 +5285,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5302,17 +5302,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5320,19 +5320,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5340,19 +5340,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5360,15 +5360,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5379,17 +5379,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5399,17 +5399,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5419,24 +5419,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat32:
 			ptr := load(ctxptr, code.idx)
@@ -5446,17 +5446,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr))
+				b = encodeFloat32(b, ptrToFloat32(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32:
@@ -5467,11 +5467,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5482,7 +5482,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagFloat32:
@@ -5493,10 +5493,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5504,18 +5504,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadFloat32Only, opStructFieldHeadFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = encodeFloat32(b, e.ptrToFloat32(p))
+			b = encodeFloat32(b, ptrToFloat32(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat32Only, opStructFieldHeadOmitEmptyFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToFloat32(p)
+			v := ptrToFloat32(p)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -5525,15 +5525,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagFloat32Only, opStructFieldHeadStringTagFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = encodeFloat32(b, e.ptrToFloat32(p))
+			b = encodeFloat32(b, ptrToFloat32(p))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5544,20 +5544,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5567,18 +5567,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5589,15 +5589,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+					b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -5611,18 +5611,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5634,16 +5634,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -5655,19 +5655,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5678,51 +5678,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr))
+				b = encodeFloat32(b, ptrToFloat32(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5731,18 +5731,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5752,10 +5752,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr))
+				b = encodeFloat32(b, ptrToFloat32(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5764,11 +5764,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5781,17 +5781,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5799,19 +5799,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5819,19 +5819,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5839,15 +5839,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5858,17 +5858,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5878,17 +5878,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5898,24 +5898,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat64:
 			ptr := load(ctxptr, code.idx)
@@ -5924,12 +5924,12 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -5939,7 +5939,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadOmitEmptyFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64:
@@ -5950,14 +5950,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -5968,7 +5968,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagFloat64:
@@ -5979,10 +5979,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5994,10 +5994,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadFloat64Only, opStructFieldHeadFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -6007,12 +6007,12 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadOmitEmptyFloat64Only, opStructFieldHeadOmitEmptyFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -6022,10 +6022,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagFloat64Only, opStructFieldHeadStringTagFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -6034,7 +6034,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6045,14 +6045,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6062,7 +6062,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6072,12 +6072,12 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6087,7 +6087,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6098,15 +6098,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6124,18 +6124,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6151,16 +6151,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6176,19 +6176,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6203,19 +6203,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6225,17 +6225,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6244,21 +6244,21 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -6267,18 +6267,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6292,10 +6292,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6308,14 +6308,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					v := e.ptrToFloat64(ptr)
+					v := ptrToFloat64(ptr)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6329,11 +6329,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6343,7 +6343,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6351,14 +6351,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6367,7 +6367,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6375,14 +6375,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6391,7 +6391,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6399,15 +6399,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6422,17 +6422,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6446,17 +6446,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6470,18 +6470,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6491,7 +6491,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadString:
 			ptr := load(ctxptr, code.idx)
@@ -6501,17 +6501,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(ptr))
+				b = encodeEscapedString(b, ptrToString(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyString:
@@ -6522,11 +6522,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, v)
@@ -6537,7 +6537,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagString:
@@ -6548,10 +6548,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, v)))
 				b = encodeIndentComma(b)
 				code = code.next
@@ -6559,18 +6559,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringOnly, opStructFieldHeadStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = encodeEscapedString(b, e.ptrToString(p))
+			b = encodeEscapedString(b, ptrToString(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyStringOnly, opStructFieldHeadOmitEmptyStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToString(p)
+			v := ptrToString(p)
 			if v != "" {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, v)
@@ -6580,14 +6580,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagStringOnly, opStructFieldHeadStringTagStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6598,20 +6598,20 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeEscapedString(b, e.ptrToString(p))
+					b = encodeEscapedString(b, ptrToString(p))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6621,18 +6621,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = encodeEscapedString(b, e.ptrToString(p))
+					b = encodeEscapedString(b, ptrToString(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6643,14 +6643,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+					b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 				}
 			}
 			b = encodeIndentComma(b)
@@ -6663,18 +6663,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6686,16 +6686,16 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -6707,18 +6707,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p+code.offset))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p+code.offset))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6728,51 +6728,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+					b = encodeEscapedString(b, ptrToString(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadString:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyString:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, v)
@@ -6781,17 +6781,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagString:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(ptr+code.offset))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(ptr+code.offset))))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -6800,10 +6800,10 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -6812,11 +6812,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeEscapedString(b, v)
@@ -6829,15 +6829,15 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(ptr+code.offset))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(ptr+code.offset))))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6845,19 +6845,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6865,19 +6865,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6885,14 +6885,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p+code.offset))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p+code.offset))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6902,17 +6902,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6922,17 +6922,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeEscapedString(b, ptrToString(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -6942,81 +6942,81 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p+code.offset))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p+code.offset))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadBool:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeBool(b, e.ptrToBool(ptr))
+				b = encodeBool(b, ptrToBool(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadBytes:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeByteSlice(b, e.ptrToBytes(ptr))
+				b = encodeByteSlice(b, ptrToBytes(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				v := e.ptrToBool(ptr + code.offset)
+				v := ptrToBool(ptr + code.offset)
 				if !v {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeBool(b, v)
@@ -7027,24 +7027,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				v := e.ptrToBytes(ptr + code.offset)
+				v := ptrToBytes(ptr + code.offset)
 				if len(v) == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					b = encodeByteSlice(b, v)
@@ -7055,7 +7055,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTag:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTag:
@@ -7067,7 +7067,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			} else {
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
@@ -7076,22 +7076,22 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+				b = encodeBool(b, ptrToBool(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -7099,27 +7099,27 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldPtrHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructField:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7132,7 +7132,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if p == 0 || **(**uintptr)(unsafe.Pointer(&p)) == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
@@ -7141,24 +7141,24 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldStringTag:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			code = code.next
 			store(ctxptr, code.idx, p)
 		case opStructFieldInt:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt(ptr + code.offset)
+			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7167,26 +7167,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt8(ptr + code.offset)
+			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7195,26 +7195,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt16(ptr + code.offset)
+			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7223,26 +7223,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt32(ptr + code.offset)
+			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7251,26 +7251,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt64(ptr + code.offset)
+			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -7279,26 +7279,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint(ptr + code.offset)
+			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7307,26 +7307,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint8(ptr + code.offset)
+			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7335,26 +7335,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint16(ptr + code.offset)
+			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7363,26 +7363,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint32(ptr + code.offset)
+			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7391,26 +7391,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint64(ptr + code.offset)
+			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -7419,26 +7419,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat32(ptr + code.offset)
+			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -7447,19 +7447,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -7468,12 +7468,12 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldOmitEmptyFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -7482,11 +7482,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
@@ -7494,18 +7494,18 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldString:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
+			b = encodeEscapedString(b, ptrToString(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyString:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToString(ptr + code.offset)
+			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, v)
@@ -7514,63 +7514,63 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			s := e.ptrToString(ptr + code.offset)
+			s := ptrToString(ptr + code.offset)
 			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, s)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyStringPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(p))
+				b = encodeNoEscapedString(b, ptrToString(p))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructFieldStringTagStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBool:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyBool:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBool(ptr + code.offset)
+			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
@@ -7579,26 +7579,26 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBytes:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
@@ -7607,19 +7607,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldMarshalJSON:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7632,8 +7632,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
@@ -7642,11 +7642,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7659,8 +7659,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
@@ -7670,11 +7670,11 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructFieldStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7683,12 +7683,12 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldArray:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			array := e.ptrToSlice(p)
+			array := ptrToSlice(p)
 			if p == 0 || uintptr(array.data) == 0 {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -7699,22 +7699,22 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldOmitEmptyArray:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			array := e.ptrToSlice(p)
+			array := ptrToSlice(p)
 			if p == 0 || uintptr(array.data) == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldSlice:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			slice := e.ptrToSlice(p)
+			slice := ptrToSlice(p)
 			if p == 0 || uintptr(slice.data) == 0 {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -7725,17 +7725,17 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldOmitEmptySlice:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			slice := e.ptrToSlice(p)
+			slice := ptrToSlice(p)
 			if p == 0 || uintptr(slice.data) == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldMap:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7744,8 +7744,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 				code = code.nextField
 			} else {
-				p = e.ptrToPtr(p)
-				mlen := maplen(e.ptrToUnsafePtr(p))
+				p = ptrToPtr(p)
+				mlen := maplen(ptrToUnsafePtr(p))
 				if mlen == 0 {
 					b = append(b, '{', '}', ',', '\n')
 					mapCode := code.next
@@ -7764,14 +7764,14 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					code = code.next
 				}
 			}
 		case opStructFieldMapLoad:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7780,8 +7780,8 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = encodeNull(b)
 				code = code.nextField
 			} else {
-				p = e.ptrToPtr(p)
-				mlen := maplen(e.ptrToUnsafePtr(p))
+				p = ptrToPtr(p)
+				mlen := maplen(ptrToUnsafePtr(p))
 				if mlen == 0 {
 					b = append(b, '{', '}', ',', '\n')
 					code = code.nextField
@@ -7799,7 +7799,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
 					code = code.next
@@ -7808,7 +7808,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 		case opStructFieldStruct:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -7831,7 +7831,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				headCode := code.next
@@ -7859,27 +7859,27 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 				b = b[:len(b)-2]
 			}
 			b = append(b, '\n')
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, '}')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructEndInt:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt(ptr + code.offset)
+			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -7890,7 +7890,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7898,35 +7898,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndIntPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyIntPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -7937,44 +7937,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagIntPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt8(ptr + code.offset)
+			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -7985,7 +7985,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7993,35 +7993,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt8Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt8(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8032,44 +8032,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt16(ptr + code.offset)
+			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8080,7 +8080,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8088,35 +8088,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt16Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt16(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8127,44 +8127,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt32(ptr + code.offset)
+			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8175,7 +8175,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8183,35 +8183,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt32(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8222,44 +8222,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt64(ptr + code.offset)
+			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8270,7 +8270,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8278,35 +8278,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, ptrToInt64(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8317,44 +8317,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint(ptr + code.offset)
+			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8365,7 +8365,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8373,35 +8373,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUintPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUintPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8412,44 +8412,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUintPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint8(ptr + code.offset)
+			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8460,7 +8460,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8468,35 +8468,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint8Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint8(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8507,44 +8507,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint16(ptr + code.offset)
+			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8555,7 +8555,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8563,35 +8563,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint16Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint16(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8602,44 +8602,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint32(ptr + code.offset)
+			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8650,7 +8650,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8658,35 +8658,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint32(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8697,44 +8697,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint64(ptr + code.offset)
+			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8745,7 +8745,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8753,35 +8753,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, ptrToUint64(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8792,44 +8792,44 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat32(ptr + code.offset)
+			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8840,7 +8840,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8848,35 +8848,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = encodeFloat32(b, ptrToFloat32(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8887,51 +8887,51 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
 			b = encodeFloat64(b, v)
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8942,7 +8942,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8950,47 +8950,47 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9001,48 +9001,48 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndString:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeEscapedString(b, e.ptrToString(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeEscapedString(b, ptrToString(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyString:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToString(ptr + code.offset)
+			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeEscapedString(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9053,7 +9053,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9061,35 +9061,35 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			s := e.ptrToString(ptr + code.offset)
+			s := ptrToString(ptr + code.offset)
 			b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, s)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, e.ptrToString(p))
+				b = encodeEscapedString(b, ptrToString(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyStringPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = encodeEscapedString(b, e.ptrToString(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = encodeEscapedString(b, ptrToString(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9100,42 +9100,42 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeEscapedString(b, string(encodeEscapedString([]byte{}, ptrToString(p))))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBool:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyBool:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBool(ptr + code.offset)
+			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9146,7 +9146,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9154,30 +9154,30 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBytes:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9188,7 +9188,7 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9196,19 +9196,19 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			code = code.next
 		case opStructEndStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndMarshalJSON:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -9221,21 +9221,21 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
 			b = append(b, indentBuf.Bytes()...)
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -9248,27 +9248,27 @@ func (e *Encoder) runEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet 
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
 			b = encodeEscapedString(b, indentBuf.String())
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
 			}
 			b = encodeEscapedString(b, *(*string)(unsafe.Pointer(&bytes)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opEnd:
 			goto END

--- a/encode_vm_escaped_indent.go
+++ b/encode_vm_escaped_indent.go
@@ -20,7 +20,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 	for {
 		switch code.op {
 		default:
-			return nil, fmt.Errorf("failed to handle opcode. doesn't implement %s", code.op)
+			return nil, fmt.Errorf("encoder (escaped+indent): opcode %s has not been implemented", code.op)
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next

--- a/encode_vm_indent.go
+++ b/encode_vm_indent.go
@@ -12,7 +12,7 @@ import (
 	"unsafe"
 )
 
-func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet) ([]byte, error) {
+func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt EncodeOption) ([]byte, error) {
 	ptrOffset := uintptr(0)
 	ctxptr := ctx.ptr()
 	code := codeSet.code
@@ -24,113 +24,113 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next
-			store(ctxptr, code.idx, e.ptrToPtr(ptr))
+			store(ctxptr, code.idx, ptrToPtr(ptr))
 		case opInt:
-			b = appendInt(b, int64(e.ptrToInt(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt8:
-			b = appendInt(b, int64(e.ptrToInt8(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt16:
-			b = appendInt(b, int64(e.ptrToInt16(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt32:
-			b = appendInt(b, int64(e.ptrToInt32(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt64:
-			b = appendInt(b, e.ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint:
-			b = appendUint(b, uint64(e.ptrToUint(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint8:
-			b = appendUint(b, uint64(e.ptrToUint8(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint16:
-			b = appendUint(b, uint64(e.ptrToUint16(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint32:
-			b = appendUint(b, uint64(e.ptrToUint32(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint64:
-			b = appendUint(b, e.ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opIntString:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt8String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt8(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt16String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt16(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt32String:
 			b = append(b, '"')
-			b = appendInt(b, int64(e.ptrToInt32(load(ctxptr, code.idx))))
+			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opInt64String:
 			b = append(b, '"')
-			b = appendInt(b, e.ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUintString:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint8String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint8(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint16String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint16(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint32String:
 			b = append(b, '"')
-			b = appendUint(b, uint64(e.ptrToUint32(load(ctxptr, code.idx))))
+			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint64String:
 			b = append(b, '"')
-			b = appendUint(b, e.ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opFloat32:
-			b = encodeFloat32(b, e.ptrToFloat32(load(ctxptr, code.idx)))
+			b = encodeFloat32(b, ptrToFloat32(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opFloat64:
-			v := e.ptrToFloat64(load(ctxptr, code.idx))
+			v := ptrToFloat64(load(ctxptr, code.idx))
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -138,20 +138,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opString:
-			b = encodeNoEscapedString(b, e.ptrToString(load(ctxptr, code.idx)))
+			b = encodeNoEscapedString(b, ptrToString(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opBool:
-			b = encodeBool(b, e.ptrToBool(load(ctxptr, code.idx)))
+			b = encodeBool(b, ptrToBool(load(ctxptr, code.idx)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opBytes:
 			ptr := load(ctxptr, code.idx)
-			slice := e.ptrToSlice(ptr)
+			slice := ptrToSlice(ptr)
 			if ptr == 0 || uintptr(slice.data) == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeByteSlice(b, e.ptrToBytes(ptr))
+				b = encodeByteSlice(b, ptrToBytes(ptr))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -169,7 +169,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 			ctx.seenPtr = append(ctx.seenPtr, ptr)
-			iface := (*interfaceHeader)(e.ptrToUnsafePtr(ptr))
+			iface := (*interfaceHeader)(ptrToUnsafePtr(ptr))
 			if iface == nil || iface.ptr == nil {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -177,7 +177,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			}
 			ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(iface))
-			ifaceCodeSet, err := e.compileToGetCodeSet(uintptr(unsafe.Pointer(iface.typ)))
+			ifaceCodeSet, err := encodeCompileToGetCodeSet(uintptr(unsafe.Pointer(iface.typ)))
 			if err != nil {
 				return nil, err
 			}
@@ -199,13 +199,13 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 
 			ctx.ptrs = newPtrs
 
-			oldBaseIndent := e.baseIndent
-			e.baseIndent = code.indent
-			bb, err := e.runIndent(ctx, b, ifaceCodeSet)
+			oldBaseIndent := ctx.baseIndent
+			ctx.baseIndent = code.indent
+			bb, err := encodeRunIndent(ctx, b, ifaceCodeSet, opt)
 			if err != nil {
 				return nil, err
 			}
-			e.baseIndent = oldBaseIndent
+			ctx.baseIndent = oldBaseIndent
 
 			ctx.ptrs = oldPtrs
 			ctxptr = ctx.ptr()
@@ -221,7 +221,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.next
 				break
 			}
-			v := e.ptrToInterface(code, ptr)
+			v := ptrToInterface(code, ptr)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -241,8 +241,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
@@ -252,7 +252,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opMarshalText:
 			ptr := load(ctxptr, code.idx)
 			isPtr := code.typ.Kind() == reflect.Ptr
-			p := e.ptrToUnsafePtr(ptr)
+			p := ptrToUnsafePtr(ptr)
 			if p == nil {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -277,22 +277,22 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				slice := e.ptrToSlice(p)
+				slice := ptrToSlice(p)
 				store(ctxptr, code.elemIdx, 0)
 				store(ctxptr, code.length, uintptr(slice.len))
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', '\n')
 					code = code.end.next
 				}
@@ -300,22 +300,22 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opRootSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				slice := e.ptrToSlice(p)
+				slice := ptrToSlice(p)
 				store(ctxptr, code.elemIdx, 0)
 				store(ctxptr, code.length, uintptr(slice.len))
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -325,7 +325,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				data := load(ctxptr, code.headIdx)
 				size := code.size
@@ -334,7 +334,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
@@ -343,33 +343,33 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				code = code.next
 				data := load(ctxptr, code.headIdx)
 				store(ctxptr, code.idx, data+idx*code.size)
 			} else {
 				b = append(b, '\n')
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, ']')
 				code = code.end.next
 			}
 		case opArrayHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				if code.length > 0 {
 					b = append(b, '[', '\n')
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					store(ctxptr, code.elemIdx, 0)
 					code = code.next
 					store(ctxptr, code.idx, p)
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -378,7 +378,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			idx := load(ctxptr, code.elemIdx)
 			idx++
 			if idx < code.length {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				p := load(ctxptr, code.headIdx)
 				size := code.size
@@ -387,19 +387,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
 		case opMapHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				uptr := e.ptrToUnsafePtr(ptr)
+				uptr := ptrToUnsafePtr(ptr)
 				mlen := maplen(uptr)
 				if mlen > 0 {
 					b = append(b, '{', '\n')
@@ -409,20 +409,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 					store(ctxptr, code.length, uintptr(mlen))
 					store(ctxptr, code.mapIter, uintptr(iter))
 
-					if !e.unorderedMap {
+					if (opt & EncodeOptionUnorderedMap) == 0 {
 						mapCtx := newMapContext(mlen)
 						mapCtx.pos = append(mapCtx.pos, len(b))
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = e.encodeIndent(b, code.next.indent)
+						b = encodeIndent(ctx, b, code.next.indent)
 					}
 
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 					code = code.next
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -430,15 +430,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opMapHeadLoad:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				code = code.end.next
 			} else {
 				// load pointer
-				ptr = e.ptrToPtr(ptr)
-				uptr := e.ptrToUnsafePtr(ptr)
+				ptr = ptrToPtr(ptr)
+				uptr := ptrToUnsafePtr(ptr)
 				if uintptr(uptr) == 0 {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = encodeNull(b)
 					b = encodeIndentComma(b)
 					code = code.end.next
@@ -455,18 +455,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 
-					if !e.unorderedMap {
+					if (opt & EncodeOptionUnorderedMap) == 0 {
 						mapCtx := newMapContext(mlen)
 						mapCtx.pos = append(mapCtx.pos, len(b))
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = e.encodeIndent(b, code.next.indent)
+						b = encodeIndent(ctx, b, code.next.indent)
 					}
 
 					code = code.next
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -475,29 +475,29 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			idx := load(ctxptr, code.elemIdx)
 			length := load(ctxptr, code.length)
 			idx++
-			if e.unorderedMap {
+			if (opt & EncodeOptionUnorderedMap) != 0 {
 				if idx < length {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					store(ctxptr, code.elemIdx, idx)
 					ptr := load(ctxptr, code.mapIter)
-					iter := e.ptrToUnsafePtr(ptr)
+					iter := ptrToUnsafePtr(ptr)
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 					code = code.next
 				} else {
 					last := len(b) - 1
 					b[last] = '\n'
-					b = e.encodeIndent(b, code.indent-1)
+					b = encodeIndent(ctx, b, code.indent-1)
 					b = append(b, '}', ',', '\n')
 					code = code.end.next
 				}
 			} else {
 				ptr := load(ctxptr, code.end.mapPos)
-				mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+				mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 				mapCtx.pos = append(mapCtx.pos, len(b))
 				if idx < length {
 					ptr := load(ctxptr, code.mapIter)
-					iter := e.ptrToUnsafePtr(ptr)
+					iter := ptrToUnsafePtr(ptr)
 					store(ctxptr, code.elemIdx, idx)
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
@@ -507,15 +507,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opMapValue:
-			if e.unorderedMap {
+			if (opt & EncodeOptionUnorderedMap) != 0 {
 				b = append(b, ':', ' ')
 			} else {
 				ptr := load(ctxptr, code.end.mapPos)
-				mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+				mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 				mapCtx.pos = append(mapCtx.pos, len(b))
 			}
 			ptr := load(ctxptr, code.mapIter)
-			iter := e.ptrToUnsafePtr(ptr)
+			iter := ptrToUnsafePtr(ptr)
 			value := mapitervalue(iter)
 			store(ctxptr, code.next.idx, uintptr(value))
 			mapiternext(iter)
@@ -524,7 +524,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			// this operation only used by sorted map
 			length := int(load(ctxptr, code.length))
 			ptr := load(ctxptr, code.mapPos)
-			mapCtx := (*encodeMapContext)(e.ptrToUnsafePtr(ptr))
+			mapCtx := (*encodeMapContext)(ptrToUnsafePtr(ptr))
 			pos := mapCtx.pos
 			for i := 0; i < length; i++ {
 				startKey := pos[i*2]
@@ -543,8 +543,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			sort.Sort(mapCtx.slice)
 			buf := mapCtx.buf
 			for _, item := range mapCtx.slice.items {
-				buf = append(buf, e.prefix...)
-				buf = append(buf, bytes.Repeat(e.indentStr, e.baseIndent+code.indent+1)...)
+				buf = append(buf, ctx.prefix...)
+				buf = append(buf, bytes.Repeat(ctx.indentStr, ctx.baseIndent+code.indent+1)...)
 				buf = append(buf, item.key...)
 				buf[len(buf)-2] = ':'
 				buf[len(buf)-1] = ' '
@@ -552,8 +552,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			}
 			buf = buf[:len(buf)-2]
 			buf = append(buf, '\n')
-			buf = append(buf, e.prefix...)
-			buf = append(buf, bytes.Repeat(e.indentStr, e.baseIndent+code.indent)...)
+			buf = append(buf, ctx.prefix...)
+			buf = append(buf, bytes.Repeat(ctx.indentStr, ctx.baseIndent+code.indent)...)
 			buf = append(buf, '}', ',', '\n')
 
 			b = b[:pos[0]]
@@ -568,25 +568,25 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else if code.next == code.end {
 				// not exists fields
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '}', ',', '\n')
 				code = code.end.next
 				store(ctxptr, code.idx, ptr)
 			} else {
 				b = append(b, '{', '\n')
 				if !code.anonymousKey {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 				}
@@ -597,24 +597,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
 				if p == 0 || *(*uintptr)(*(*unsafe.Pointer)(unsafe.Pointer(&p))) == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					code = code.next
@@ -625,7 +625,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 			}
@@ -636,7 +636,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey && ptr != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p := ptr + code.offset
@@ -646,7 +646,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.nextField
 			}
 		case opStructFieldPtrHeadInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt:
 			ptr := load(ctxptr, code.idx)
@@ -656,17 +656,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt:
@@ -677,11 +677,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -692,7 +692,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt:
@@ -703,10 +703,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -714,18 +714,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadIntOnly, opStructFieldHeadIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt(p)))
+			b = appendInt(b, int64(ptrToInt(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntOnly, opStructFieldHeadOmitEmptyIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt(p))
+			v := int64(ptrToInt(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -735,15 +735,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagIntOnly, opStructFieldHeadStringTagIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt(p)))
+			b = appendInt(b, int64(ptrToInt(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadIntPtr:
 			p := load(ctxptr, code.idx)
@@ -754,20 +754,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyIntPtr:
 			p := load(ctxptr, code.idx)
@@ -777,18 +777,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt(p)))
+					b = appendInt(b, int64(ptrToInt(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagIntPtr:
 			p := load(ctxptr, code.idx)
@@ -799,15 +799,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -821,18 +821,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -844,16 +844,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -865,19 +865,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -888,51 +888,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -941,18 +941,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -962,10 +962,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -974,11 +974,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt(ptr + code.offset)
+				v := ptrToInt(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -991,17 +991,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtr:
 			p := load(ctxptr, code.idx)
@@ -1009,19 +1009,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyIntPtr:
 			p := load(ctxptr, code.idx)
@@ -1029,19 +1029,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagIntPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtr:
 			p := load(ctxptr, code.idx)
@@ -1049,15 +1049,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1068,17 +1068,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1088,17 +1088,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1108,24 +1108,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt8:
 			ptr := load(ctxptr, code.idx)
@@ -1135,17 +1135,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(ptr)))
+				b = appendInt(b, int64(ptrToInt8(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8:
@@ -1156,11 +1156,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1171,7 +1171,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt8:
@@ -1182,10 +1182,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1193,18 +1193,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt8(p)))
+			b = appendInt(b, int64(ptrToInt8(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt8Only, opStructFieldHeadOmitEmptyInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt8(p))
+			v := int64(ptrToInt8(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1214,15 +1214,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt8(p)))
+			b = appendInt(b, int64(ptrToInt8(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1233,20 +1233,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1256,18 +1256,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt8(p)))
+					b = appendInt(b, int64(ptrToInt8(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1278,15 +1278,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -1300,18 +1300,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1323,16 +1323,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -1344,19 +1344,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1367,51 +1367,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1420,18 +1420,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1441,10 +1441,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1453,11 +1453,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt8(ptr + code.offset)
+				v := ptrToInt8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1470,17 +1470,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1488,19 +1488,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1508,19 +1508,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8Ptr:
 			p := load(ctxptr, code.idx)
@@ -1528,15 +1528,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1547,17 +1547,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1567,17 +1567,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1587,24 +1587,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt16:
 			ptr := load(ctxptr, code.idx)
@@ -1614,17 +1614,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(ptr)))
+				b = appendInt(b, int64(ptrToInt16(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16:
@@ -1635,11 +1635,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1650,7 +1650,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt16:
@@ -1661,10 +1661,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1672,18 +1672,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt16(p)))
+			b = appendInt(b, int64(ptrToInt16(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt16Only, opStructFieldHeadOmitEmptyInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt16(p))
+			v := int64(ptrToInt16(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1693,15 +1693,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt16(p)))
+			b = appendInt(b, int64(ptrToInt16(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1712,20 +1712,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1735,18 +1735,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt16(p)))
+					b = appendInt(b, int64(ptrToInt16(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1757,15 +1757,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -1779,18 +1779,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1802,16 +1802,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -1823,19 +1823,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1846,51 +1846,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1899,18 +1899,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1920,10 +1920,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1932,11 +1932,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt16(ptr + code.offset)
+				v := ptrToInt16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1949,17 +1949,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1967,19 +1967,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -1987,19 +1987,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16Ptr:
 			p := load(ctxptr, code.idx)
@@ -2007,15 +2007,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2026,17 +2026,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2046,17 +2046,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2066,24 +2066,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt32:
 			ptr := load(ctxptr, code.idx)
@@ -2093,17 +2093,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(ptr)))
+				b = appendInt(b, int64(ptrToInt32(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32:
@@ -2114,11 +2114,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2129,7 +2129,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt32:
@@ -2140,10 +2140,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2151,18 +2151,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(e.ptrToInt32(p)))
+			b = appendInt(b, int64(ptrToInt32(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt32Only, opStructFieldHeadOmitEmptyInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(e.ptrToInt32(p))
+			v := int64(ptrToInt32(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2172,15 +2172,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt32(p)))
+			b = appendInt(b, int64(ptrToInt32(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2191,20 +2191,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2214,18 +2214,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(e.ptrToInt32(p)))
+					b = appendInt(b, int64(ptrToInt32(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2236,15 +2236,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -2258,18 +2258,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2281,16 +2281,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -2302,19 +2302,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2325,51 +2325,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2378,18 +2378,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2399,10 +2399,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2411,11 +2411,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt32(ptr + code.offset)
+				v := ptrToInt32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2428,17 +2428,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2446,19 +2446,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2466,19 +2466,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32Ptr:
 			p := load(ctxptr, code.idx)
@@ -2486,15 +2486,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2505,17 +2505,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2525,17 +2525,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2545,24 +2545,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p+code.offset)))
+				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt64:
 			ptr := load(ctxptr, code.idx)
@@ -2572,17 +2572,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(ptr))
+				b = appendInt(b, ptrToInt64(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64:
@@ -2593,11 +2593,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2608,7 +2608,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagInt64:
@@ -2619,10 +2619,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2630,18 +2630,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendInt(b, e.ptrToInt64(p))
+			b = appendInt(b, ptrToInt64(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt64Only, opStructFieldHeadOmitEmptyInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToInt64(p)
+			v := ptrToInt64(p)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2651,15 +2651,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, e.ptrToInt64(p))
+			b = appendInt(b, ptrToInt64(p))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2670,20 +2670,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2693,18 +2693,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, e.ptrToInt64(p))
+					b = appendInt(b, ptrToInt64(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2715,15 +2715,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -2737,18 +2737,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -2760,16 +2760,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -2781,19 +2781,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2804,51 +2804,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, e.ptrToInt64(p+code.offset))
+					b = appendInt(b, ptrToInt64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2857,18 +2857,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -2878,10 +2878,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -2890,11 +2890,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToInt64(ptr + code.offset)
+				v := ptrToInt64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2907,17 +2907,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+				b = appendInt(b, ptrToInt64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2925,19 +2925,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2945,19 +2945,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64Ptr:
 			p := load(ctxptr, code.idx)
@@ -2965,15 +2965,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -2984,17 +2984,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3004,17 +3004,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3024,24 +3024,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToInt64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint:
 			ptr := load(ctxptr, code.idx)
@@ -3051,17 +3051,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint:
@@ -3072,11 +3072,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3087,7 +3087,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint:
@@ -3098,10 +3098,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3109,18 +3109,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUintOnly, opStructFieldHeadUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint(p)))
+			b = appendUint(b, uint64(ptrToUint(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintOnly, opStructFieldHeadOmitEmptyUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint(p))
+			v := uint64(ptrToUint(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3130,15 +3130,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUintOnly, opStructFieldHeadStringTagUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint(p)))
+			b = appendUint(b, uint64(ptrToUint(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3149,20 +3149,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3172,18 +3172,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint(p)))
+					b = appendUint(b, uint64(ptrToUint(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3194,15 +3194,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -3216,18 +3216,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3239,16 +3239,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3260,19 +3260,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3283,51 +3283,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3336,18 +3336,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3357,10 +3357,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3369,11 +3369,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint(ptr + code.offset)
+				v := ptrToUint(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3386,17 +3386,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3404,19 +3404,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3424,19 +3424,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUintPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtr:
 			p := load(ctxptr, code.idx)
@@ -3444,15 +3444,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3463,17 +3463,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3483,17 +3483,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3503,24 +3503,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint8:
 			ptr := load(ctxptr, code.idx)
@@ -3530,17 +3530,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr)))
+				b = appendUint(b, uint64(ptrToUint8(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8:
@@ -3551,11 +3551,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3566,7 +3566,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint8:
@@ -3577,10 +3577,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3588,18 +3588,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint8(p)))
+			b = appendUint(b, uint64(ptrToUint8(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint8Only, opStructFieldHeadOmitEmptyUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint8(p))
+			v := uint64(ptrToUint8(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3609,15 +3609,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint8(p)))
+			b = appendUint(b, uint64(ptrToUint8(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3628,20 +3628,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3651,18 +3651,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint8(p)))
+					b = appendUint(b, uint64(ptrToUint8(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3673,15 +3673,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -3695,18 +3695,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3718,16 +3718,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3739,19 +3739,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3762,51 +3762,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3815,18 +3815,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint8:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3836,10 +3836,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3848,11 +3848,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint8(ptr + code.offset)
+				v := ptrToUint8(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3865,17 +3865,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3883,19 +3883,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3903,19 +3903,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8Ptr:
 			p := load(ctxptr, code.idx)
@@ -3923,15 +3923,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3942,17 +3942,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3962,17 +3962,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3982,24 +3982,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint16:
 			ptr := load(ctxptr, code.idx)
@@ -4009,17 +4009,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr)))
+				b = appendUint(b, uint64(ptrToUint16(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16:
@@ -4030,11 +4030,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4045,7 +4045,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint16:
@@ -4056,10 +4056,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4067,18 +4067,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint16(p)))
+			b = appendUint(b, uint64(ptrToUint16(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint16Only, opStructFieldHeadOmitEmptyUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint16(p))
+			v := uint64(ptrToUint16(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4088,15 +4088,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint16(p)))
+			b = appendUint(b, uint64(ptrToUint16(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4107,20 +4107,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4130,18 +4130,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint16(p)))
+					b = appendUint(b, uint64(ptrToUint16(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4152,15 +4152,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -4174,18 +4174,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4197,16 +4197,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -4218,19 +4218,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4241,51 +4241,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4294,18 +4294,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint16:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4315,10 +4315,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4327,11 +4327,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint16(ptr + code.offset)
+				v := ptrToUint16(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4344,17 +4344,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4362,19 +4362,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4382,19 +4382,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16Ptr:
 			p := load(ctxptr, code.idx)
@@ -4402,15 +4402,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4421,17 +4421,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4441,17 +4441,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4461,24 +4461,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint32:
 			ptr := load(ctxptr, code.idx)
@@ -4488,17 +4488,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr)))
+				b = appendUint(b, uint64(ptrToUint32(ptr)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32:
@@ -4509,11 +4509,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4524,7 +4524,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint32:
@@ -4535,10 +4535,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4546,18 +4546,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(e.ptrToUint32(p)))
+			b = appendUint(b, uint64(ptrToUint32(p)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint32Only, opStructFieldHeadOmitEmptyUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(e.ptrToUint32(p))
+			v := uint64(ptrToUint32(p))
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4567,15 +4567,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint32(p)))
+			b = appendUint(b, uint64(ptrToUint32(p)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4586,20 +4586,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4609,18 +4609,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(e.ptrToUint32(p)))
+					b = appendUint(b, uint64(ptrToUint32(p)))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4631,15 +4631,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 					b = append(b, '"')
 				}
 			}
@@ -4653,18 +4653,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4676,16 +4676,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -4697,19 +4697,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4720,51 +4720,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4773,18 +4773,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -4794,10 +4794,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4806,11 +4806,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint32(ptr + code.offset)
+				v := ptrToUint32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4823,17 +4823,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4841,19 +4841,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4861,19 +4861,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32Ptr:
 			p := load(ctxptr, code.idx)
@@ -4881,15 +4881,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -4900,17 +4900,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -4920,17 +4920,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -4940,24 +4940,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p+code.offset)))
+				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint64:
 			ptr := load(ctxptr, code.idx)
@@ -4967,17 +4967,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(ptr))
+				b = appendUint(b, ptrToUint64(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64:
@@ -4988,11 +4988,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5003,7 +5003,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagUint64:
@@ -5014,10 +5014,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5025,18 +5025,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendUint(b, e.ptrToUint64(p))
+			b = appendUint(b, ptrToUint64(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint64Only, opStructFieldHeadOmitEmptyUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToUint64(p)
+			v := ptrToUint64(p)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -5046,15 +5046,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, e.ptrToUint64(p))
+			b = appendUint(b, ptrToUint64(p))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5065,20 +5065,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5088,18 +5088,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, e.ptrToUint64(p))
+					b = appendUint(b, ptrToUint64(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5110,15 +5110,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -5132,18 +5132,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5155,16 +5155,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -5176,19 +5176,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5199,51 +5199,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, e.ptrToUint64(p+code.offset))
+					b = appendUint(b, ptrToUint64(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5252,18 +5252,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5273,10 +5273,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5285,11 +5285,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToUint64(ptr + code.offset)
+				v := ptrToUint64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5302,17 +5302,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+				b = appendUint(b, ptrToUint64(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5320,19 +5320,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5340,19 +5340,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64Ptr:
 			p := load(ctxptr, code.idx)
@@ -5360,15 +5360,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5379,17 +5379,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5399,17 +5399,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5419,24 +5419,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat32:
 			ptr := load(ctxptr, code.idx)
@@ -5446,17 +5446,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr))
+				b = encodeFloat32(b, ptrToFloat32(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32:
@@ -5467,11 +5467,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5482,7 +5482,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagFloat32:
@@ -5493,10 +5493,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5504,18 +5504,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadFloat32Only, opStructFieldHeadFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = encodeFloat32(b, e.ptrToFloat32(p))
+			b = encodeFloat32(b, ptrToFloat32(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat32Only, opStructFieldHeadOmitEmptyFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToFloat32(p)
+			v := ptrToFloat32(p)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -5525,15 +5525,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagFloat32Only, opStructFieldHeadStringTagFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = encodeFloat32(b, e.ptrToFloat32(p))
+			b = encodeFloat32(b, ptrToFloat32(p))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5544,20 +5544,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5567,18 +5567,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5589,15 +5589,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+					b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 					b = append(b, '"')
 				}
 			}
@@ -5611,18 +5611,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5634,16 +5634,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -5655,19 +5655,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5678,51 +5678,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeFloat32(b, e.ptrToFloat32(p))
+					b = encodeFloat32(b, ptrToFloat32(p))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr))
+				b = encodeFloat32(b, ptrToFloat32(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5731,18 +5731,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat32:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -5752,10 +5752,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr))
+				b = encodeFloat32(b, ptrToFloat32(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5764,11 +5764,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat32(ptr + code.offset)
+				v := ptrToFloat32(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5781,17 +5781,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5799,19 +5799,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5819,19 +5819,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat32Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32Ptr:
 			p := load(ctxptr, code.idx)
@@ -5839,15 +5839,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -5858,17 +5858,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -5878,17 +5878,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -5898,24 +5898,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p+code.offset))
+				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat64:
 			ptr := load(ctxptr, code.idx)
@@ -5924,12 +5924,12 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -5939,7 +5939,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadOmitEmptyFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64:
@@ -5950,14 +5950,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -5968,7 +5968,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagFloat64:
@@ -5979,10 +5979,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -5994,10 +5994,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadFloat64Only, opStructFieldHeadFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -6007,12 +6007,12 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadOmitEmptyFloat64Only, opStructFieldHeadOmitEmptyFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -6022,10 +6022,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagFloat64Only, opStructFieldHeadStringTagFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			v := e.ptrToFloat64(p)
+			v := ptrToFloat64(p)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -6034,7 +6034,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6045,14 +6045,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6062,7 +6062,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6072,12 +6072,12 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6087,7 +6087,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6098,15 +6098,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6124,18 +6124,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6151,16 +6151,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6176,19 +6176,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6203,19 +6203,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					v := e.ptrToFloat64(p)
+					v := ptrToFloat64(p)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6225,17 +6225,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6244,21 +6244,21 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -6267,18 +6267,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat64:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6292,10 +6292,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6308,14 +6308,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToFloat64(ptr + code.offset)
+				v := ptrToFloat64(ptr + code.offset)
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					v := e.ptrToFloat64(ptr)
+					v := ptrToFloat64(ptr)
 					if math.IsInf(v, 0) || math.IsNaN(v) {
 						return nil, errUnsupportedFloat(v)
 					}
@@ -6329,11 +6329,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				v := e.ptrToFloat64(ptr)
+				v := ptrToFloat64(ptr)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6343,7 +6343,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6351,14 +6351,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6367,7 +6367,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6375,14 +6375,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6391,7 +6391,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagFloat64Ptr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64Ptr:
 			p := load(ctxptr, code.idx)
@@ -6399,15 +6399,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6422,17 +6422,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6446,17 +6446,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6470,18 +6470,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
@@ -6491,7 +6491,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadString:
 			ptr := load(ctxptr, code.idx)
@@ -6501,17 +6501,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(ptr))
+				b = encodeNoEscapedString(b, ptrToString(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyString:
@@ -6522,11 +6522,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, v)
@@ -6537,7 +6537,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagString:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagString:
@@ -6548,10 +6548,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, v)))
 				b = encodeIndentComma(b)
 				code = code.next
@@ -6559,18 +6559,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringOnly, opStructFieldHeadStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = encodeNoEscapedString(b, e.ptrToString(p))
+			b = encodeNoEscapedString(b, ptrToString(p))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyStringOnly, opStructFieldHeadOmitEmptyStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := e.ptrToString(p)
+			v := ptrToString(p)
 			if v != "" {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, v)
@@ -6580,14 +6580,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagStringOnly, opStructFieldHeadStringTagStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p))))
+			b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p))))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6598,20 +6598,20 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeNoEscapedString(b, e.ptrToString(p))
+					b = encodeNoEscapedString(b, ptrToString(p))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadOmitEmptyStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6621,18 +6621,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p != 0 {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = encodeNoEscapedString(b, e.ptrToString(p))
+					b = encodeNoEscapedString(b, ptrToString(p))
 					b = encodeIndentComma(b)
 				}
 				code = code.next
 			}
 		case opStructFieldPtrHeadStringTagStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadStringTagStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6643,14 +6643,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = e.ptrToPtr(p)
+				p = ptrToPtr(p)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p))))
+					b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p))))
 				}
 			}
 			b = encodeIndentComma(b)
@@ -6663,18 +6663,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6686,16 +6686,16 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadOmitEmptyStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -6707,18 +6707,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = e.encodeIndent(b, code.indent+1)
+			b = encodeIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p+code.offset))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p+code.offset))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6728,51 +6728,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
 					if p == 0 {
 						break
 					}
-					p = e.ptrToPtr(p)
+					p = ptrToPtr(p)
 				}
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = encodeNoEscapedString(b, e.ptrToString(p+code.offset))
+					b = encodeNoEscapedString(b, ptrToString(p+code.offset))
 				}
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadString:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadOmitEmptyString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyString:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, v)
@@ -6781,17 +6781,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				}
 			}
 		case opStructFieldPtrAnonymousHeadStringTagString:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagString:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(ptr+code.offset))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(ptr+code.offset))))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -6800,10 +6800,10 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(ptr+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -6812,11 +6812,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := e.ptrToString(ptr + code.offset)
+				v := ptrToString(ptr + code.offset)
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, v)
@@ -6829,15 +6829,15 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(ptr+code.offset))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(ptr+code.offset))))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6845,19 +6845,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrAnonymousHeadOmitEmptyStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6865,19 +6865,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(p))
+				b = encodeNoEscapedString(b, ptrToString(p))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrAnonymousHeadStringTagStringPtr:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtr:
 			p := load(ctxptr, code.idx)
@@ -6885,14 +6885,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = e.ptrToPtr(p)
+			p = ptrToPtr(p)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p+code.offset))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p+code.offset))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6902,17 +6902,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -6922,17 +6922,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadOmitEmptyStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(p+code.offset))
+				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -6942,81 +6942,81 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			store(ctxptr, code.idx, e.ptrToPtr(p))
+			store(ctxptr, code.idx, ptrToPtr(p))
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p+code.offset))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p+code.offset))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadBool:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeBool(b, e.ptrToBool(ptr))
+				b = encodeBool(b, ptrToBool(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadBytes:
-			store(ctxptr, code.idx, e.ptrToPtr(load(ctxptr, code.idx)))
+			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
 			fallthrough
 		case opStructFieldHeadBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeByteSlice(b, e.ptrToBytes(ptr))
+				b = encodeByteSlice(b, ptrToBytes(ptr))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructFieldPtrHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				v := e.ptrToBool(ptr + code.offset)
+				v := ptrToBool(ptr + code.offset)
 				if !v {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeBool(b, v)
@@ -7027,24 +7027,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				v := e.ptrToBytes(ptr + code.offset)
+				v := ptrToBytes(ptr + code.offset)
 				if len(v) == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent+1)
+					b = encodeIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeByteSlice(b, v)
@@ -7055,7 +7055,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTag:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTag:
@@ -7067,7 +7067,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			} else {
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
@@ -7076,22 +7076,22 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+				b = encodeBool(b, ptrToBool(ptr+code.offset))
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -7099,27 +7099,27 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldPtrHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr != 0 {
-				store(ctxptr, code.idx, e.ptrToPtr(ptr))
+				store(ctxptr, code.idx, ptrToPtr(ptr))
 			}
 			fallthrough
 		case opStructFieldHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = e.encodeIndent(b, code.indent+1)
+				b = encodeIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 				b = encodeIndentComma(b)
 				code = code.next
 			}
 		case opStructField:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7132,7 +7132,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 || **(**uintptr)(unsafe.Pointer(&p)) == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
@@ -7141,24 +7141,24 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldStringTag:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			code = code.next
 			store(ctxptr, code.idx, p)
 		case opStructFieldInt:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt(ptr + code.offset)
+			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7167,26 +7167,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt8(ptr + code.offset)
+			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7195,26 +7195,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt16(ptr + code.offset)
+			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7223,26 +7223,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt32(ptr + code.offset)
+			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7251,26 +7251,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt64(ptr + code.offset)
+			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -7279,26 +7279,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint(ptr + code.offset)
+			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7307,26 +7307,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint8(ptr + code.offset)
+			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7335,26 +7335,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint16(ptr + code.offset)
+			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7363,26 +7363,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint32(ptr + code.offset)
+			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7391,26 +7391,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint64(ptr + code.offset)
+			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -7419,26 +7419,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat32(ptr + code.offset)
+			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -7447,19 +7447,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
@@ -7468,12 +7468,12 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldOmitEmptyFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -7482,11 +7482,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
@@ -7494,18 +7494,18 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldString:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeNoEscapedString(b, e.ptrToString(ptr+code.offset))
+			b = encodeNoEscapedString(b, ptrToString(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyString:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToString(ptr + code.offset)
+			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, v)
@@ -7514,63 +7514,63 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			s := e.ptrToString(ptr + code.offset)
+			s := ptrToString(ptr + code.offset)
 			b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, s)))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, e.ptrToString(p))
+				b = encodeNoEscapedString(b, ptrToString(p))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyStringPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(p))
+				b = encodeNoEscapedString(b, ptrToString(p))
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructFieldStringTagStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p))))
 			}
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBool:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyBool:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBool(ptr + code.offset)
+			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
@@ -7579,26 +7579,26 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBytes:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
@@ -7607,19 +7607,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldMarshalJSON:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7632,8 +7632,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
@@ -7642,11 +7642,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7659,8 +7659,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
@@ -7669,11 +7669,11 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructFieldStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -7682,12 +7682,12 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldArray:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			array := e.ptrToSlice(p)
+			array := ptrToSlice(p)
 			if p == 0 || uintptr(array.data) == 0 {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -7698,22 +7698,22 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldOmitEmptyArray:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			array := e.ptrToSlice(p)
+			array := ptrToSlice(p)
 			if p == 0 || uintptr(array.data) == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldSlice:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			slice := e.ptrToSlice(p)
+			slice := ptrToSlice(p)
 			if p == 0 || uintptr(slice.data) == 0 {
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
@@ -7724,17 +7724,17 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldOmitEmptySlice:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			slice := e.ptrToSlice(p)
+			slice := ptrToSlice(p)
 			if p == 0 || uintptr(slice.data) == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldMap:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7743,8 +7743,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 				code = code.nextField
 			} else {
-				p = e.ptrToPtr(p)
-				mlen := maplen(e.ptrToUnsafePtr(p))
+				p = ptrToPtr(p)
+				mlen := maplen(ptrToUnsafePtr(p))
 				if mlen == 0 {
 					b = append(b, '{', '}', ',', '\n')
 					mapCode := code.next
@@ -7763,14 +7763,14 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					code = code.next
 				}
 			}
 		case opStructFieldMapLoad:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7779,8 +7779,8 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 				code = code.nextField
 			} else {
-				p = e.ptrToPtr(p)
-				mlen := maplen(e.ptrToUnsafePtr(p))
+				p = ptrToPtr(p)
+				mlen := maplen(ptrToUnsafePtr(p))
 				if mlen == 0 {
 					b = append(b, '{', '}', ',', '\n')
 					code = code.nextField
@@ -7798,7 +7798,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					code = code.next
@@ -7807,7 +7807,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 		case opStructFieldStruct:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -7830,7 +7830,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				headCode := code.next
@@ -7858,27 +7858,27 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = b[:len(b)-2]
 			}
 			b = append(b, '\n')
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, '}')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructEndInt:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt(ptr + code.offset)
+			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -7889,7 +7889,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7897,35 +7897,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndIntPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyIntPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -7936,44 +7936,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagIntPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt(p)))
+				b = appendInt(b, int64(ptrToInt(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt8(ptr + code.offset)
+			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -7984,7 +7984,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7992,35 +7992,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt8(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt8Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt8(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8031,44 +8031,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt8(p)))
+				b = appendInt(b, int64(ptrToInt8(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt16(ptr + code.offset)
+			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8079,7 +8079,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8087,35 +8087,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt16(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt16Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt16(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8126,44 +8126,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt16(p)))
+				b = appendInt(b, int64(ptrToInt16(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt32(ptr + code.offset)
+			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8174,7 +8174,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8182,35 +8182,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(e.ptrToInt32(ptr+code.offset)))
+			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, int64(ptrToInt32(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8221,44 +8221,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(e.ptrToInt32(p)))
+				b = appendInt(b, int64(ptrToInt32(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToInt64(ptr + code.offset)
+			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8269,7 +8269,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8277,35 +8277,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, e.ptrToInt64(ptr+code.offset))
+			b = appendInt(b, ptrToInt64(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, e.ptrToInt64(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendInt(b, ptrToInt64(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8316,44 +8316,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, e.ptrToInt64(p))
+				b = appendInt(b, ptrToInt64(p))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint(ptr + code.offset)
+			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8364,7 +8364,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8372,35 +8372,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUintPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUintPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8411,44 +8411,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUintPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint(p)))
+				b = appendUint(b, uint64(ptrToUint(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint8:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint8(ptr + code.offset)
+			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8459,7 +8459,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8467,35 +8467,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint8(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint8Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint8(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8506,44 +8506,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint8Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint8(p)))
+				b = appendUint(b, uint64(ptrToUint8(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint16:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint16(ptr + code.offset)
+			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8554,7 +8554,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8562,35 +8562,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint16(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint16Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint16(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8601,44 +8601,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint16Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint16(p)))
+				b = appendUint(b, uint64(ptrToUint16(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint32(ptr + code.offset)
+			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8649,7 +8649,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8657,35 +8657,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(e.ptrToUint32(ptr+code.offset)))
+			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, uint64(ptrToUint32(p)))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8696,44 +8696,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(e.ptrToUint32(p)))
+				b = appendUint(b, uint64(ptrToUint32(p)))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToUint64(ptr + code.offset)
+			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8744,7 +8744,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8752,35 +8752,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, e.ptrToUint64(ptr+code.offset))
+			b = appendUint(b, ptrToUint64(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, e.ptrToUint64(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendUint(b, ptrToUint64(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8791,44 +8791,44 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, e.ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat32(ptr + code.offset)
+			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8839,7 +8839,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8847,35 +8847,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = encodeFloat32(b, e.ptrToFloat32(ptr+code.offset))
+			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat32Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = encodeFloat32(b, ptrToFloat32(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8886,51 +8886,51 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat32Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = encodeFloat32(b, e.ptrToFloat32(p))
+				b = encodeFloat32(b, ptrToFloat32(p))
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
 			b = encodeFloat64(b, v)
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -8941,7 +8941,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8949,47 +8949,47 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagFloat64:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToFloat64(ptr + code.offset)
+			v := ptrToFloat64(ptr + code.offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyFloat64Ptr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9000,48 +9000,48 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat64Ptr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				v := e.ptrToFloat64(p)
+				v := ptrToFloat64(p)
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
 				b = encodeFloat64(b, v)
 				b = append(b, '"')
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndString:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeNoEscapedString(b, e.ptrToString(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeNoEscapedString(b, ptrToString(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyString:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToString(ptr + code.offset)
+			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9052,7 +9052,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9060,35 +9060,35 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			s := e.ptrToString(ptr + code.offset)
+			s := ptrToString(ptr + code.offset)
 			b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, s)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, e.ptrToString(p))
+				b = encodeNoEscapedString(b, ptrToString(p))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyStringPtr:
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = encodeNoEscapedString(b, e.ptrToString(p))
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = encodeNoEscapedString(b, ptrToString(p))
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9099,42 +9099,42 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagStringPtr:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			p := e.ptrToPtr(ptr + code.offset)
+			p := ptrToPtr(ptr + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, e.ptrToString(p))))
+				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p))))
 			}
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBool:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyBool:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBool(ptr + code.offset)
+			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9145,7 +9145,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9153,30 +9153,30 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = encodeBool(b, e.ptrToBool(ptr+code.offset))
+			b = encodeBool(b, ptrToBool(ptr+code.offset))
 			b = append(b, '"')
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBytes:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyBytes:
 			ptr := load(ctxptr, code.headIdx)
-			v := e.ptrToBytes(ptr + code.offset)
+			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = e.encodeIndent(b, code.indent)
+				b = encodeIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
-				b = e.appendStructEndIndent(b, code.indent-1)
+				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
 				if b[last-1] == '{' {
@@ -9187,7 +9187,7 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = e.encodeIndent(b, code.indent)
+					b = encodeIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9195,19 +9195,19 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 		case opStructEndStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = encodeByteSlice(b, e.ptrToBytes(ptr+code.offset))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndMarshalJSON:
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -9220,21 +9220,21 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
 			b = append(b, indentBuf.Bytes()...)
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bb, err := v.(Marshaler).MarshalJSON()
 			if err != nil {
 				return nil, errMarshaler(code, err)
@@ -9247,27 +9247,27 @@ func (e *Encoder) runIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if err := encodeWithIndent(
 				&indentBuf,
 				compactBuf.Bytes(),
-				string(e.prefix)+strings.Repeat(string(e.indentStr), e.baseIndent+code.indent),
-				string(e.indentStr),
+				string(ctx.prefix)+strings.Repeat(string(ctx.indentStr), ctx.baseIndent+code.indent),
+				string(ctx.indentStr),
 			); err != nil {
 				return nil, err
 			}
 			b = encodeNoEscapedString(b, indentBuf.String())
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = e.encodeIndent(b, code.indent)
+			b = encodeIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
-			v := e.ptrToInterface(code, p)
+			v := ptrToInterface(code, p)
 			bytes, err := v.(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return nil, errMarshaler(code, err)
 			}
 			b = encodeNoEscapedString(b, *(*string)(unsafe.Pointer(&bytes)))
-			b = e.appendStructEndIndent(b, code.indent-1)
+			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opEnd:
 			goto END

--- a/encode_vm_indent.go
+++ b/encode_vm_indent.go
@@ -277,7 +277,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
@@ -288,11 +288,11 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', '\n')
 					code = code.end.next
 				}
@@ -300,7 +300,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opRootSliceHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
@@ -311,11 +311,11 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				store(ctxptr, code.idx, uintptr(slice.data))
 				if slice.len > 0 {
 					b = append(b, '[', '\n')
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					code = code.next
 					store(ctxptr, code.idx, uintptr(slice.data))
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -325,7 +325,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				data := load(ctxptr, code.headIdx)
 				size := code.size
@@ -334,7 +334,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
@@ -343,33 +343,33 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			length := load(ctxptr, code.length)
 			idx++
 			if idx < length {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				code = code.next
 				data := load(ctxptr, code.headIdx)
 				store(ctxptr, code.idx, data+idx*code.size)
 			} else {
 				b = append(b, '\n')
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, ']')
 				code = code.end.next
 			}
 		case opArrayHead:
 			p := load(ctxptr, code.idx)
 			if p == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				if code.length > 0 {
 					b = append(b, '[', '\n')
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					store(ctxptr, code.elemIdx, 0)
 					code = code.next
 					store(ctxptr, code.idx, p)
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '[', ']', ',', '\n')
 					code = code.end.next
 				}
@@ -378,7 +378,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			idx := load(ctxptr, code.elemIdx)
 			idx++
 			if idx < code.length {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				store(ctxptr, code.elemIdx, idx)
 				p := load(ctxptr, code.headIdx)
 				size := code.size
@@ -387,14 +387,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			} else {
 				b = b[:len(b)-2]
 				b = append(b, '\n')
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
 		case opMapHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
@@ -415,14 +415,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = encodeIndent(ctx, b, code.next.indent)
+						b = appendIndent(ctx, b, code.next.indent)
 					}
 
 					key := mapiterkey(iter)
 					store(ctxptr, code.next.idx, uintptr(key))
 					code = code.next
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -430,7 +430,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opMapHeadLoad:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				code = code.end.next
 			} else {
@@ -438,7 +438,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				ptr = ptrToPtr(ptr)
 				uptr := ptrToUnsafePtr(ptr)
 				if uintptr(uptr) == 0 {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = encodeNull(b)
 					b = encodeIndentComma(b)
 					code = code.end.next
@@ -461,12 +461,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						ctx.keepRefs = append(ctx.keepRefs, unsafe.Pointer(mapCtx))
 						store(ctxptr, code.end.mapPos, uintptr(unsafe.Pointer(mapCtx)))
 					} else {
-						b = encodeIndent(ctx, b, code.next.indent)
+						b = appendIndent(ctx, b, code.next.indent)
 					}
 
 					code = code.next
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '{', '}', ',', '\n')
 					code = code.end.next
 				}
@@ -477,7 +477,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			idx++
 			if (opt & EncodeOptionUnorderedMap) != 0 {
 				if idx < length {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					store(ctxptr, code.elemIdx, idx)
 					ptr := load(ctxptr, code.mapIter)
 					iter := ptrToUnsafePtr(ptr)
@@ -487,7 +487,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				} else {
 					last := len(b) - 1
 					b[last] = '\n'
-					b = encodeIndent(ctx, b, code.indent-1)
+					b = appendIndent(ctx, b, code.indent-1)
 					b = append(b, '}', ',', '\n')
 					code = code.end.next
 				}
@@ -573,20 +573,20 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHead:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else if code.next == code.end {
 				// not exists fields
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '}', ',', '\n')
 				code = code.end.next
 				store(ctxptr, code.idx, ptr)
 			} else {
 				b = append(b, '{', '\n')
 				if !code.anonymousKey {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 				}
@@ -603,18 +603,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadOmitEmpty:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
 				if p == 0 || *(*uintptr)(*(*unsafe.Pointer)(unsafe.Pointer(&p))) == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					code = code.next
@@ -625,7 +625,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 			}
@@ -636,7 +636,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if !code.anonymousKey && ptr != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p := ptr + code.offset
@@ -656,7 +656,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -681,7 +681,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -703,7 +703,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -714,7 +714,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadIntOnly, opStructFieldHeadIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt(p)))
@@ -725,7 +725,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -735,7 +735,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagIntOnly, opStructFieldHeadStringTagIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt(p)))
@@ -754,7 +754,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -779,7 +779,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt(p)))
@@ -799,7 +799,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -826,7 +826,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -850,7 +850,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p+code.offset)))
@@ -870,7 +870,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -888,7 +888,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -913,7 +913,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -932,7 +932,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -948,7 +948,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -962,7 +962,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -978,7 +978,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -991,7 +991,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1009,7 +1009,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1033,7 +1033,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p)))
@@ -1049,7 +1049,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1072,7 +1072,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1095,7 +1095,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p+code.offset)))
@@ -1112,7 +1112,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagIntPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1135,7 +1135,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(ptr)))
@@ -1160,7 +1160,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1182,7 +1182,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -1193,7 +1193,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt8(p)))
@@ -1204,7 +1204,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt8(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1214,7 +1214,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt8(p)))
@@ -1233,7 +1233,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1258,7 +1258,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt8(p)))
@@ -1278,7 +1278,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1305,7 +1305,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1329,7 +1329,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
@@ -1349,7 +1349,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1367,7 +1367,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -1392,7 +1392,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -1411,7 +1411,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1427,7 +1427,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1441,7 +1441,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -1457,7 +1457,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1470,7 +1470,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1488,7 +1488,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1512,7 +1512,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p)))
@@ -1528,7 +1528,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1551,7 +1551,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1574,7 +1574,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
@@ -1591,7 +1591,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1614,7 +1614,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(ptr)))
@@ -1639,7 +1639,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1661,7 +1661,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -1672,7 +1672,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt16(p)))
@@ -1683,7 +1683,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt16(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -1693,7 +1693,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt16(p)))
@@ -1712,7 +1712,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1737,7 +1737,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt16(p)))
@@ -1757,7 +1757,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -1784,7 +1784,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1808,7 +1808,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
@@ -1828,7 +1828,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -1846,7 +1846,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -1871,7 +1871,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -1890,7 +1890,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1906,7 +1906,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1920,7 +1920,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -1936,7 +1936,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -1949,7 +1949,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -1967,7 +1967,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -1991,7 +1991,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p)))
@@ -2007,7 +2007,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2030,7 +2030,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2053,7 +2053,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
@@ -2070,7 +2070,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2093,7 +2093,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(ptr)))
@@ -2118,7 +2118,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2140,7 +2140,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -2151,7 +2151,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendInt(b, int64(ptrToInt32(p)))
@@ -2162,7 +2162,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := int64(ptrToInt32(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2172,7 +2172,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt32(p)))
@@ -2191,7 +2191,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2216,7 +2216,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(ptrToInt32(p)))
@@ -2236,7 +2236,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2263,7 +2263,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2287,7 +2287,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
@@ -2307,7 +2307,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2325,7 +2325,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -2350,7 +2350,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -2369,7 +2369,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2385,7 +2385,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2399,7 +2399,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -2415,7 +2415,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, int64(v))
@@ -2428,7 +2428,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2446,7 +2446,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2470,7 +2470,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p)))
@@ -2486,7 +2486,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2509,7 +2509,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2532,7 +2532,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
@@ -2549,7 +2549,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2572,7 +2572,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(ptr))
@@ -2597,7 +2597,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2619,7 +2619,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -2630,7 +2630,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendInt(b, ptrToInt64(p))
@@ -2641,7 +2641,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := ptrToInt64(p)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -2651,7 +2651,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, ptrToInt64(p))
@@ -2670,7 +2670,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2695,7 +2695,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, ptrToInt64(p))
@@ -2715,7 +2715,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -2742,7 +2742,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2766,7 +2766,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p+code.offset))
@@ -2786,7 +2786,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -2804,7 +2804,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -2829,7 +2829,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -2848,7 +2848,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2864,7 +2864,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2878,7 +2878,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -2894,7 +2894,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendInt(b, v)
@@ -2907,7 +2907,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -2925,7 +2925,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2949,7 +2949,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p))
@@ -2965,7 +2965,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -2988,7 +2988,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3011,7 +3011,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p+code.offset))
@@ -3028,7 +3028,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3051,7 +3051,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3076,7 +3076,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3098,7 +3098,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3109,7 +3109,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadUintOnly, opStructFieldHeadUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint(p)))
@@ -3120,7 +3120,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3130,7 +3130,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagUintOnly, opStructFieldHeadStringTagUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint(p)))
@@ -3149,7 +3149,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3174,7 +3174,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint(p)))
@@ -3194,7 +3194,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3221,7 +3221,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3245,7 +3245,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
@@ -3265,7 +3265,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3283,7 +3283,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -3308,7 +3308,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3327,7 +3327,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3343,7 +3343,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3357,7 +3357,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -3373,7 +3373,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3386,7 +3386,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3404,7 +3404,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3428,7 +3428,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p)))
@@ -3444,7 +3444,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3467,7 +3467,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3490,7 +3490,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
@@ -3507,7 +3507,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUintPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3530,7 +3530,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(ptr)))
@@ -3555,7 +3555,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3577,7 +3577,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -3588,7 +3588,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3599,7 +3599,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint8(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -3609,7 +3609,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3628,7 +3628,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3653,7 +3653,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3673,7 +3673,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -3700,7 +3700,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3724,7 +3724,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
@@ -3744,7 +3744,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3762,7 +3762,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -3787,7 +3787,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -3806,7 +3806,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3822,7 +3822,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3836,7 +3836,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -3852,7 +3852,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -3865,7 +3865,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -3883,7 +3883,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3907,7 +3907,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p)))
@@ -3923,7 +3923,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -3946,7 +3946,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -3969,7 +3969,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
@@ -3986,7 +3986,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4009,7 +4009,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(ptr)))
@@ -4034,7 +4034,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4056,7 +4056,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -4067,7 +4067,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4078,7 +4078,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint16(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4088,7 +4088,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4107,7 +4107,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4132,7 +4132,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4152,7 +4152,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4179,7 +4179,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4203,7 +4203,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
@@ -4223,7 +4223,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4241,7 +4241,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -4266,7 +4266,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -4285,7 +4285,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4301,7 +4301,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4315,7 +4315,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -4331,7 +4331,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4344,7 +4344,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4362,7 +4362,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4386,7 +4386,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p)))
@@ -4402,7 +4402,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4425,7 +4425,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4448,7 +4448,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
@@ -4465,7 +4465,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4488,7 +4488,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(ptr)))
@@ -4513,7 +4513,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4535,7 +4535,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -4546,7 +4546,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4557,7 +4557,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := uint64(ptrToUint32(p))
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -4567,7 +4567,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4586,7 +4586,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4611,7 +4611,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4631,7 +4631,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -4658,7 +4658,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4682,7 +4682,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
@@ -4702,7 +4702,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4720,7 +4720,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -4745,7 +4745,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -4764,7 +4764,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4780,7 +4780,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4794,7 +4794,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -4810,7 +4810,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, uint64(v))
@@ -4823,7 +4823,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -4841,7 +4841,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4865,7 +4865,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p)))
@@ -4881,7 +4881,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -4904,7 +4904,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4927,7 +4927,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
@@ -4944,7 +4944,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -4967,7 +4967,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(ptr))
@@ -4992,7 +4992,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5014,7 +5014,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -5025,7 +5025,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = appendUint(b, ptrToUint64(p))
@@ -5036,7 +5036,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := ptrToUint64(p)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -5046,7 +5046,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, ptrToUint64(p))
@@ -5065,7 +5065,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5090,7 +5090,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, ptrToUint64(p))
@@ -5110,7 +5110,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5137,7 +5137,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5161,7 +5161,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p+code.offset))
@@ -5181,7 +5181,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5199,7 +5199,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -5224,7 +5224,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -5243,7 +5243,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5259,7 +5259,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5273,7 +5273,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -5289,7 +5289,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = appendUint(b, v)
@@ -5302,7 +5302,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5320,7 +5320,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5344,7 +5344,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p))
@@ -5360,7 +5360,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5383,7 +5383,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5406,7 +5406,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p+code.offset))
@@ -5423,7 +5423,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5446,7 +5446,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(ptr))
@@ -5471,7 +5471,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5493,7 +5493,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
@@ -5504,7 +5504,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadFloat32Only, opStructFieldHeadFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = encodeFloat32(b, ptrToFloat32(p))
@@ -5515,7 +5515,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := ptrToFloat32(p)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -5525,7 +5525,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagFloat32Only, opStructFieldHeadStringTagFloat32Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat32(b, ptrToFloat32(p))
@@ -5544,7 +5544,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5569,7 +5569,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, ptrToFloat32(p))
@@ -5589,7 +5589,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -5616,7 +5616,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5640,7 +5640,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
@@ -5660,7 +5660,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5678,7 +5678,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -5703,7 +5703,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(ptr))
@@ -5722,7 +5722,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5738,7 +5738,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5752,7 +5752,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(ptr))
@@ -5768,7 +5768,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat32(b, v)
@@ -5781,7 +5781,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -5799,7 +5799,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5823,7 +5823,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p))
@@ -5839,7 +5839,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -5862,7 +5862,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5885,7 +5885,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p+code.offset))
@@ -5902,7 +5902,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat32PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -5929,7 +5929,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 					return nil, errUnsupportedFloat(v)
 				}
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -5957,7 +5957,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -5979,7 +5979,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				v := ptrToFloat64(ptr + code.offset)
@@ -5994,7 +5994,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadFloat64Only, opStructFieldHeadFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			v := ptrToFloat64(p)
@@ -6012,7 +6012,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				return nil, errUnsupportedFloat(v)
 			}
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -6022,7 +6022,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagFloat64Only, opStructFieldHeadStringTagFloat64Only:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			v := ptrToFloat64(p)
@@ -6045,7 +6045,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6074,7 +6074,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					v := ptrToFloat64(p)
@@ -6098,7 +6098,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6129,7 +6129,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6157,7 +6157,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -6181,7 +6181,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6203,7 +6203,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -6232,7 +6232,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToFloat64(ptr)
@@ -6258,7 +6258,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeFloat64(b, v)
@@ -6274,7 +6274,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -6292,7 +6292,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToFloat64(ptr)
@@ -6312,7 +6312,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					v := ptrToFloat64(ptr)
@@ -6329,7 +6329,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
@@ -6351,7 +6351,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6379,7 +6379,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -6399,7 +6399,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6426,7 +6426,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6453,7 +6453,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -6474,7 +6474,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagFloat64PtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6501,7 +6501,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(ptr))
@@ -6526,7 +6526,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, v)
@@ -6548,7 +6548,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToString(ptr + code.offset)
@@ -6559,7 +6559,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringOnly, opStructFieldHeadStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = encodeNoEscapedString(b, ptrToString(p))
@@ -6570,7 +6570,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, '{', '\n')
 			v := ptrToString(p)
 			if v != "" {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, v)
@@ -6580,7 +6580,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldPtrHeadStringTagStringOnly, opStructFieldHeadStringTagStringOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(p))))
@@ -6598,7 +6598,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6623,7 +6623,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, '{', '\n')
 				p = ptrToPtr(p)
 				if p != 0 {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, ptrToString(p))
@@ -6643,7 +6643,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				break
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				p = ptrToPtr(p)
@@ -6668,7 +6668,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6692,7 +6692,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
@@ -6712,7 +6712,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			b = encodeIndent(ctx, b, code.indent+1)
+			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6728,7 +6728,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				for i := 0; i < code.ptrNum; i++ {
@@ -6753,7 +6753,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(ptr+code.offset))
@@ -6772,7 +6772,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, v)
@@ -6788,7 +6788,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(ptr+code.offset))))
@@ -6800,7 +6800,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(ptr+code.offset))
@@ -6816,7 +6816,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if v == "" {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeNoEscapedString(b, v)
@@ -6829,7 +6829,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, string(encodeNoEscapedString([]byte{}, ptrToString(ptr+code.offset))))
@@ -6845,7 +6845,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6869,7 +6869,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(p))
@@ -6885,7 +6885,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p = ptrToPtr(p)
@@ -6906,7 +6906,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6929,7 +6929,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(p+code.offset))
@@ -6946,7 +6946,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			fallthrough
 		case opStructFieldAnonymousHeadStringTagStringPtrOnly:
 			p := load(ctxptr, code.idx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -6962,14 +6962,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeBool(b, ptrToBool(ptr))
@@ -6982,14 +6982,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, ptrToBytes(ptr))
@@ -7005,18 +7005,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadOmitEmptyBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				v := ptrToBool(ptr + code.offset)
 				if !v {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeBool(b, v)
@@ -7033,18 +7033,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadOmitEmptyBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, '{', '\n')
 				v := ptrToBytes(ptr + code.offset)
 				if len(v) == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent+1)
+					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					b = encodeByteSlice(b, v)
@@ -7067,7 +7067,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			} else {
 				b = append(b, '{', '\n')
 				p := ptr + code.offset
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
@@ -7082,13 +7082,13 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagBool:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
 				b = encodeBool(b, ptrToBool(ptr+code.offset))
@@ -7105,13 +7105,13 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldHeadStringTagBytes:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = encodeNull(b)
 				b = encodeIndentComma(b)
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				b = encodeIndent(ctx, b, code.indent+1)
+				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
@@ -7119,7 +7119,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.next
 			}
 		case opStructField:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7132,7 +7132,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 || **(**uintptr)(unsafe.Pointer(&p)) == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
@@ -7141,13 +7141,13 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldStringTag:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			code = code.next
 			store(ctxptr, code.idx, p)
 		case opStructFieldInt:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7158,7 +7158,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7167,7 +7167,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -7175,7 +7175,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7186,7 +7186,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7195,7 +7195,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -7203,7 +7203,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7214,7 +7214,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7223,7 +7223,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -7231,7 +7231,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7242,7 +7242,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7251,7 +7251,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -7259,7 +7259,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldInt64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7270,7 +7270,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -7279,7 +7279,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -7287,7 +7287,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7298,7 +7298,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7307,7 +7307,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -7315,7 +7315,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7326,7 +7326,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7335,7 +7335,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -7343,7 +7343,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7354,7 +7354,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7363,7 +7363,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -7371,7 +7371,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7382,7 +7382,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -7391,7 +7391,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -7399,7 +7399,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldUint64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7410,7 +7410,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -7419,7 +7419,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -7427,7 +7427,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7438,7 +7438,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -7447,7 +7447,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
@@ -7455,7 +7455,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldFloat64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7473,7 +7473,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if math.IsInf(v, 0) || math.IsNaN(v) {
 					return nil, errUnsupportedFloat(v)
 				}
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat64(b, v)
@@ -7486,7 +7486,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
@@ -7494,7 +7494,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldString:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7505,7 +7505,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, v)
@@ -7514,7 +7514,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			s := ptrToString(ptr + code.offset)
@@ -7522,7 +7522,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7538,7 +7538,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(p))
@@ -7546,7 +7546,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			}
 			code = code.next
 		case opStructFieldStringTagStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7559,7 +7559,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBool:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7570,7 +7570,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
@@ -7579,7 +7579,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeBool(b, ptrToBool(ptr+code.offset))
@@ -7587,7 +7587,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldBytes:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7598,7 +7598,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
@@ -7607,14 +7607,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldMarshalJSON:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7642,7 +7642,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
@@ -7669,7 +7669,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructFieldStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
@@ -7682,7 +7682,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldArray:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7702,13 +7702,13 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 || uintptr(array.data) == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldSlice:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7728,13 +7728,13 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 || uintptr(slice.data) == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				code = code.next
 			}
 		case opStructFieldMap:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7763,14 +7763,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					code = code.next
 				}
 			}
 		case opStructFieldMapLoad:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7798,7 +7798,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if mlen == 0 {
 					code = code.nextField
 				} else {
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
 					code = code.next
@@ -7807,7 +7807,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 		case opStructFieldStruct:
 			ptr := load(ctxptr, code.headIdx)
 			p := ptr + code.offset
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			if p == 0 {
@@ -7830,7 +7830,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				code = code.nextField
 			} else {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				headCode := code.next
@@ -7858,12 +7858,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = b[:len(b)-2]
 			}
 			b = append(b, '\n')
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, '}')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructEndInt:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7874,7 +7874,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7889,7 +7889,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7897,7 +7897,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagInt:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
@@ -7905,7 +7905,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndIntPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7921,7 +7921,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt(p)))
@@ -7936,14 +7936,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagIntPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7958,7 +7958,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -7969,7 +7969,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -7984,7 +7984,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -7992,7 +7992,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagInt8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
@@ -8000,7 +8000,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8016,7 +8016,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt8(p)))
@@ -8031,14 +8031,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8053,7 +8053,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8064,7 +8064,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -8079,7 +8079,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8087,7 +8087,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagInt16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
@@ -8095,7 +8095,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8111,7 +8111,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt16(p)))
@@ -8126,14 +8126,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8148,7 +8148,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8159,7 +8159,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(v))
@@ -8174,7 +8174,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8182,7 +8182,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagInt32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
@@ -8190,7 +8190,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8206,7 +8206,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, int64(ptrToInt32(p)))
@@ -8221,14 +8221,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8243,7 +8243,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8254,7 +8254,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToInt64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, v)
@@ -8269,7 +8269,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8277,7 +8277,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagInt64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendInt(b, ptrToInt64(ptr+code.offset))
@@ -8285,7 +8285,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndInt64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8301,7 +8301,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendInt(b, ptrToInt64(p))
@@ -8316,14 +8316,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagInt64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8338,7 +8338,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8349,7 +8349,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8364,7 +8364,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8372,7 +8372,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagUint:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
@@ -8380,7 +8380,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUintPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8396,7 +8396,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint(p)))
@@ -8411,14 +8411,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUintPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8433,7 +8433,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8444,7 +8444,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint8(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8459,7 +8459,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8467,7 +8467,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagUint8:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
@@ -8475,7 +8475,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8491,7 +8491,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint8(p)))
@@ -8506,14 +8506,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint8Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8528,7 +8528,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8539,7 +8539,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint16(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8554,7 +8554,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8562,7 +8562,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagUint16:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
@@ -8570,7 +8570,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8586,7 +8586,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint16(p)))
@@ -8601,14 +8601,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint16Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8623,7 +8623,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8634,7 +8634,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(v))
@@ -8649,7 +8649,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8657,7 +8657,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagUint32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
@@ -8665,7 +8665,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8681,7 +8681,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, uint64(ptrToUint32(p)))
@@ -8696,14 +8696,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8718,7 +8718,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8729,7 +8729,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToUint64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, v)
@@ -8744,7 +8744,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8752,7 +8752,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagUint64:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = appendUint(b, ptrToUint64(ptr+code.offset))
@@ -8760,7 +8760,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndUint64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8776,7 +8776,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = appendUint(b, ptrToUint64(p))
@@ -8791,14 +8791,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagUint64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8813,7 +8813,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8824,7 +8824,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToFloat32(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, v)
@@ -8839,7 +8839,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8847,7 +8847,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagFloat32:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat32(b, ptrToFloat32(ptr+code.offset))
@@ -8855,7 +8855,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8871,7 +8871,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeFloat32(b, ptrToFloat32(p))
@@ -8886,14 +8886,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat32Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8908,7 +8908,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8923,7 +8923,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToFloat64(ptr + code.offset)
 			if v != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -8941,7 +8941,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -8953,7 +8953,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if math.IsInf(v, 0) || math.IsNaN(v) {
 				return nil, errUnsupportedFloat(v)
 			}
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeFloat64(b, v)
@@ -8961,7 +8961,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndFloat64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -8981,7 +8981,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				v := ptrToFloat64(p)
@@ -9000,14 +9000,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagFloat64Ptr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9026,7 +9026,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndString:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9037,7 +9037,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToString(ptr + code.offset)
 			if v != "" {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, v)
@@ -9052,7 +9052,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9060,7 +9060,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagString:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			s := ptrToString(ptr + code.offset)
@@ -9068,7 +9068,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9084,7 +9084,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeNoEscapedString(b, ptrToString(p))
@@ -9099,14 +9099,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
 			}
 			code = code.next
 		case opStructEndStringTagStringPtr:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9119,7 +9119,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBool:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9130,7 +9130,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBool(ptr + code.offset)
 			if v {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeBool(b, v)
@@ -9145,7 +9145,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9153,7 +9153,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagBool:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
 			b = encodeBool(b, ptrToBool(ptr+code.offset))
@@ -9161,7 +9161,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndBytes:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9172,7 +9172,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			ptr := load(ctxptr, code.headIdx)
 			v := ptrToBytes(ptr + code.offset)
 			if len(v) > 0 {
-				b = encodeIndent(ctx, b, code.indent)
+				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = encodeByteSlice(b, v)
@@ -9187,7 +9187,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 						b = b[:len(b)-2]
 					}
 					b = append(b, '\n')
-					b = encodeIndent(ctx, b, code.indent)
+					b = appendIndent(ctx, b, code.indent)
 					b = append(b, '}')
 				}
 				b = encodeIndentComma(b)
@@ -9195,14 +9195,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagBytes:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			b = encodeByteSlice(b, ptrToBytes(ptr+code.offset))
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndMarshalJSON:
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
@@ -9230,7 +9230,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagMarshalJSON:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset
@@ -9257,7 +9257,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 		case opStructEndStringTagMarshalText:
 			ptr := load(ctxptr, code.headIdx)
-			b = encodeIndent(ctx, b, code.indent)
+			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			p := ptr + code.offset

--- a/encode_vm_indent.go
+++ b/encode_vm_indent.go
@@ -20,7 +20,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 	for {
 		switch code.op {
 		default:
-			return nil, fmt.Errorf("failed to handle opcode. doesn't implement %s", code.op)
+			return nil, fmt.Errorf("encoder (indent): opcode %s has not been implemented", code.op)
 		case opPtr:
 			ptr := load(ctxptr, code.idx)
 			code = code.next

--- a/json.go
+++ b/json.go
@@ -159,7 +159,7 @@ func Marshal(v interface{}) ([]byte, error) {
 
 // MarshalNoEscape
 func MarshalNoEscape(v interface{}) ([]byte, error) {
-	return marshal(v, EncodeOptionHTMLEscape)
+	return marshalNoEscape(v, EncodeOptionHTMLEscape)
 }
 
 // MarshalWithOption returns the JSON encoding of v with EncodeOption.

--- a/option.go
+++ b/option.go
@@ -1,10 +1,9 @@
 package json
 
-type EncodeOption func(*Encoder) error
+type EncodeOptionFunc func(EncodeOption) EncodeOption
 
-func UnorderedMap() EncodeOption {
-	return func(e *Encoder) error {
-		e.unorderedMap = true
-		return nil
+func UnorderedMap() func(EncodeOption) EncodeOption {
+	return func(opt EncodeOption) EncodeOption {
+		return opt | EncodeOptionUnorderedMap
 	}
 }


### PR DESCRIPTION
- Rename many Encoder's private APIs
- Strip many methods from the Encoder
- Fix error message ( https://github.com/goccy/go-json/issues/106 )
- Add `.codecov.yml` to the project's root directory.