### PR TITLE
Dramatically improve decoder performance

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,112 @@
+package json
+
+import (
+	"fmt"
+	"reflect"
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	maxAcceptableTypeAddrRange = 1024 * 1024 * 2 // 2 Mib
+)
+
+var (
+	cachedOpcodeSets       []*opcodeSet
+	cachedOpcodeMap        unsafe.Pointer // map[uintptr]*opcodeSet
+	existsCachedOpcodeSets bool
+	cachedDecoder          []decoder
+	cachedDecoderMap       unsafe.Pointer // map[uintptr]decoder
+	existsCachedDecoder    bool
+	baseTypeAddr           uintptr
+)
+
+//go:linkname typelinks reflect.typelinks
+func typelinks() ([]unsafe.Pointer, [][]int32)
+
+//go:linkname rtypeOff reflect.rtypeOff
+func rtypeOff(unsafe.Pointer, int32) unsafe.Pointer
+
+func setupCodec() error {
+	sections, offsets := typelinks()
+	if len(sections) != 1 {
+		return fmt.Errorf("failed to get sections")
+	}
+	if len(offsets) != 1 {
+		return fmt.Errorf("failed to get offsets")
+	}
+	section := sections[0]
+	offset := offsets[0]
+	var (
+		min uintptr = uintptr(^uint(0))
+		max uintptr = 0
+	)
+	for i := 0; i < len(offset); i++ {
+		typ := (*rtype)(rtypeOff(section, offset[i]))
+		addr := uintptr(unsafe.Pointer(typ))
+		if min > addr {
+			min = addr
+		}
+		if max < addr {
+			max = addr
+		}
+		if typ.Kind() == reflect.Ptr {
+			addr = uintptr(unsafe.Pointer(typ.Elem()))
+			if min > addr {
+				min = addr
+			}
+			if max < addr {
+				max = addr
+			}
+		}
+	}
+	addrRange := max - min
+	if addrRange == 0 {
+		return fmt.Errorf("failed to get address range of types")
+	}
+	if addrRange > maxAcceptableTypeAddrRange {
+		return fmt.Errorf("too big address range %d", addrRange)
+	}
+	cachedOpcodeSets = make([]*opcodeSet, addrRange)
+	existsCachedOpcodeSets = true
+	cachedDecoder = make([]decoder, addrRange)
+	existsCachedDecoder = true
+	baseTypeAddr = min
+	return nil
+}
+
+func init() {
+	_ = setupCodec()
+}
+
+func loadOpcodeMap() map[uintptr]*opcodeSet {
+	p := atomic.LoadPointer(&cachedOpcodeMap)
+	return *(*map[uintptr]*opcodeSet)(unsafe.Pointer(&p))
+}
+
+func storeOpcodeSet(typ uintptr, set *opcodeSet, m map[uintptr]*opcodeSet) {
+	newOpcodeMap := make(map[uintptr]*opcodeSet, len(m)+1)
+	newOpcodeMap[typ] = set
+
+	for k, v := range m {
+		newOpcodeMap[k] = v
+	}
+
+	atomic.StorePointer(&cachedOpcodeMap, *(*unsafe.Pointer)(unsafe.Pointer(&newOpcodeMap)))
+}
+
+func loadDecoderMap() map[uintptr]decoder {
+	p := atomic.LoadPointer(&cachedDecoderMap)
+	return *(*map[uintptr]decoder)(unsafe.Pointer(&p))
+}
+
+func storeDecoder(typ uintptr, dec decoder, m map[uintptr]decoder) {
+	newDecoderMap := make(map[uintptr]decoder, len(m)+1)
+	newDecoderMap[typ] = dec
+
+	for k, v := range m {
+		newDecoderMap[k] = v
+	}
+
+	atomic.StorePointer(&cachedDecoderMap, *(*unsafe.Pointer)(unsafe.Pointer(&newDecoderMap)))
+}

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -6,6 +6,21 @@ import (
 	"unsafe"
 )
 
+func (d *Decoder) compileToGetDecoderSlowPath(typeptr uintptr, typ *rtype) (decoder, error) {
+	decoderMap := loadDecoderMap()
+	if dec, exists := decoderMap[typeptr]; exists {
+		return dec, nil
+	}
+
+	d.structTypeToDecoder = map[uintptr]decoder{}
+	dec, err := d.compileHead(typ)
+	if err != nil {
+		return nil, err
+	}
+	storeDecoder(typeptr, dec, decoderMap)
+	return dec, nil
+}
+
 func (d *Decoder) compileHead(typ *rtype) (decoder, error) {
 	switch {
 	case rtype_ptrTo(typ).Implements(unmarshalJSONType):

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -401,5 +401,6 @@ func (d *Decoder) compileStruct(typ *rtype, structName, fieldName string) (decod
 		}
 	}
 	delete(d.structTypeToDecoder, typeptr)
+	structDec.tryOptimize()
 	return structDec, nil
 }

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -272,6 +272,7 @@ func (d *Decoder) removeConflictFields(fieldMap map[string]*structFieldSet, conf
 			if v.isTaggedKey {
 				// conflict tag key
 				delete(fieldMap, k)
+				delete(fieldMap, strings.ToLower(k))
 				conflictedMap[k] = struct{}{}
 				conflictedMap[strings.ToLower(k)] = struct{}{}
 			}
@@ -290,6 +291,7 @@ func (d *Decoder) removeConflictFields(fieldMap map[string]*structFieldSet, conf
 			} else {
 				// conflict tag key
 				delete(fieldMap, k)
+				delete(fieldMap, strings.ToLower(k))
 				conflictedMap[k] = struct{}{}
 				conflictedMap[strings.ToLower(k)] = struct{}{}
 			}
@@ -355,6 +357,7 @@ func (d *Decoder) compileStruct(typ *rtype, structName, fieldName string) (decod
 							if v.isTaggedKey {
 								// conflict tag key
 								delete(fieldMap, k)
+								delete(fieldMap, strings.ToLower(k))
 								conflictedMap[k] = struct{}{}
 								conflictedMap[strings.ToLower(k)] = struct{}{}
 							}
@@ -373,6 +376,7 @@ func (d *Decoder) compileStruct(typ *rtype, structName, fieldName string) (decod
 							} else {
 								// conflict tag key
 								delete(fieldMap, k)
+								delete(fieldMap, strings.ToLower(k))
 								conflictedMap[k] = struct{}{}
 								conflictedMap[strings.ToLower(k)] = struct{}{}
 							}

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -260,6 +260,8 @@ func (d *Decoder) removeConflictFields(fieldMap map[string]*structFieldSet, conf
 				dec:         v.dec,
 				offset:      baseOffset + v.offset,
 				isTaggedKey: v.isTaggedKey,
+				key:         k,
+				keyLen:      int64(len(k)),
 			}
 			fieldMap[k] = fieldSet
 			lower := strings.ToLower(k)
@@ -282,6 +284,8 @@ func (d *Decoder) removeConflictFields(fieldMap map[string]*structFieldSet, conf
 					dec:         v.dec,
 					offset:      baseOffset + v.offset,
 					isTaggedKey: v.isTaggedKey,
+					key:         k,
+					keyLen:      int64(len(k)),
 				}
 				fieldMap[k] = fieldSet
 				lower := strings.ToLower(k)
@@ -345,6 +349,8 @@ func (d *Decoder) compileStruct(typ *rtype, structName, fieldName string) (decod
 								dec:         newAnonymousFieldDecoder(pdec.typ, v.offset, v.dec),
 								offset:      field.Offset,
 								isTaggedKey: v.isTaggedKey,
+								key:         k,
+								keyLen:      int64(len(k)),
 							}
 							fieldMap[k] = fieldSet
 							lower := strings.ToLower(k)
@@ -367,6 +373,8 @@ func (d *Decoder) compileStruct(typ *rtype, structName, fieldName string) (decod
 									dec:         newAnonymousFieldDecoder(pdec.typ, v.offset, v.dec),
 									offset:      field.Offset,
 									isTaggedKey: v.isTaggedKey,
+									key:         k,
+									keyLen:      int64(len(k)),
 								}
 								fieldMap[k] = fieldSet
 								lower := strings.ToLower(k)
@@ -388,19 +396,23 @@ func (d *Decoder) compileStruct(typ *rtype, structName, fieldName string) (decod
 			if tag.isString {
 				dec = newWrappedStringDecoder(dec, structName, field.Name)
 			}
-			fieldSet := &structFieldSet{dec: dec, offset: field.Offset, isTaggedKey: tag.isTaggedKey}
+			var key string
 			if tag.key != "" {
-				fieldMap[tag.key] = fieldSet
-				lower := strings.ToLower(tag.key)
-				if _, exists := fieldMap[lower]; !exists {
-					fieldMap[lower] = fieldSet
-				}
+				key = tag.key
 			} else {
-				fieldMap[field.Name] = fieldSet
-				lower := strings.ToLower(field.Name)
-				if _, exists := fieldMap[lower]; !exists {
-					fieldMap[lower] = fieldSet
-				}
+				key = field.Name
+			}
+			fieldSet := &structFieldSet{
+				dec:         dec,
+				offset:      field.Offset,
+				isTaggedKey: tag.isTaggedKey,
+				key:         key,
+				keyLen:      int64(len(key)),
+			}
+			fieldMap[key] = fieldSet
+			lower := strings.ToLower(key)
+			if _, exists := fieldMap[lower]; !exists {
+				fieldMap[lower] = fieldSet
 			}
 		}
 	}

--- a/decode_compile_norace.go
+++ b/decode_compile_norace.go
@@ -1,0 +1,22 @@
+// +build !race
+
+package json
+
+func (d *Decoder) compileToGetDecoder(typeptr uintptr, typ *rtype) (decoder, error) {
+	if !existsCachedDecoder {
+		return d.compileToGetDecoderSlowPath(typeptr, typ)
+	}
+
+	index := typeptr - baseTypeAddr
+	if dec := cachedDecoder[index]; dec != nil {
+		return dec, nil
+	}
+
+	d.structTypeToDecoder = map[uintptr]decoder{}
+	dec, err := d.compileHead(typ)
+	if err != nil {
+		return nil, err
+	}
+	cachedDecoder[index] = dec
+	return dec, nil
+}

--- a/decode_compile_race.go
+++ b/decode_compile_race.go
@@ -1,0 +1,31 @@
+// +build race
+
+package json
+
+import "sync"
+
+var decMu sync.RWMutex
+
+func (d *Decoder) compileToGetDecoder(typeptr uintptr, typ *rtype) (decoder, error) {
+	if !existsCachedDecoder {
+		return d.compileToGetDecoderSlowPath(typeptr, typ)
+	}
+
+	index := typeptr - baseTypeAddr
+	decMu.RLock()
+	if dec := cachedDecoder[index]; dec != nil {
+		decMu.RUnlock()
+		return dec, nil
+	}
+	decMu.RUnlock()
+
+	d.structTypeToDecoder = map[uintptr]decoder{}
+	dec, err := d.compileHead(typ)
+	if err != nil {
+		return nil, err
+	}
+	decMu.Lock()
+	cachedDecoder[index] = dec
+	decMu.Unlock()
+	return dec, nil
+}

--- a/decode_context.go
+++ b/decode_context.go
@@ -1,5 +1,7 @@
 package json
 
+import "unsafe"
+
 var (
 	isWhiteSpace = [256]bool{}
 )
@@ -9,6 +11,10 @@ func init() {
 	isWhiteSpace['\n'] = true
 	isWhiteSpace['\t'] = true
 	isWhiteSpace['\r'] = true
+}
+
+func char(ptr unsafe.Pointer, offset int64) byte {
+	return *(*byte)(unsafe.Pointer(uintptr(ptr) + uintptr(offset)))
 }
 
 func skipWhiteSpace(buf []byte, cursor int64) int64 {

--- a/decode_int.go
+++ b/decode_int.go
@@ -130,8 +130,9 @@ ERROR:
 }
 
 func (d *intDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, error) {
+	b := (*sliceHeader)(unsafe.Pointer(&buf)).data
 	for {
-		switch buf[cursor] {
+		switch char(b, cursor) {
 		case ' ', '\n', '\t', '\r':
 			cursor++
 			continue
@@ -139,14 +140,14 @@ func (d *intDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, error)
 			start := cursor
 			cursor++
 		LOOP:
-			if numTable[buf[cursor]] {
+			if numTable[char(b, cursor)] {
 				cursor++
 				goto LOOP
 			}
 			num := buf[start:cursor]
 			return num, cursor, nil
 		default:
-			return nil, 0, d.typeError([]byte{buf[cursor]}, cursor)
+			return nil, 0, d.typeError([]byte{char(b, cursor)}, cursor)
 		}
 	}
 }

--- a/decode_stream.go
+++ b/decode_stream.go
@@ -85,11 +85,11 @@ func (s *stream) read() bool {
 
 func (s *stream) skipWhiteSpace() {
 LOOP:
-	c := s.char()
-	if isWhiteSpace[c] {
+	switch s.char() {
+	case ' ', '\n', '\t', '\r':
 		s.cursor++
 		goto LOOP
-	} else if c == nul {
+	case nul:
 		if s.read() {
 			goto LOOP
 		}

--- a/decode_string.go
+++ b/decode_string.go
@@ -249,11 +249,12 @@ func (d *stringDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, err
 		case '"':
 			cursor++
 			start := cursor
+			b := (*sliceHeader)(unsafe.Pointer(&buf)).data
 			for {
-				switch buf[cursor] {
+				switch char(b, cursor) {
 				case '\\':
 					cursor++
-					switch buf[cursor] {
+					switch char(b, cursor) {
 					case '"':
 						buf[cursor] = '"'
 						buf = append(buf[:cursor-1], buf[cursor:]...)

--- a/decode_string.go
+++ b/decode_string.go
@@ -35,7 +35,7 @@ func (d *stringDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 	if err != nil {
 		return err
 	}
-	*(*string)(p) = string(bytes)
+	*(*string)(p) = *(*string)(unsafe.Pointer(&bytes))
 	s.reset()
 	return nil
 }

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -671,5 +671,4 @@ func (d *structDecoder) decode(buf []byte, cursor int64, p unsafe.Pointer) (int6
 		}
 		cursor++
 	}
-	return cursor, nil
 }

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -120,13 +120,14 @@ func decodeKeyByBitmapInt8(d *structDecoder, buf []byte, cursor int64) (int64, *
 		field  *structFieldSet
 		curBit int8 = math.MaxInt8
 	)
+	b := (*sliceHeader)(unsafe.Pointer(&buf)).data
 	for {
-		switch buf[cursor] {
+		switch char(b, cursor) {
 		case ' ', '\n', '\t', '\r':
 			cursor++
 		case '"':
 			cursor++
-			c := buf[cursor]
+			c := char(b, cursor)
 			switch c {
 			case '"':
 				cursor++
@@ -138,7 +139,7 @@ func decodeKeyByBitmapInt8(d *structDecoder, buf []byte, cursor int64) (int64, *
 			bitmap := d.keyBitmapInt8
 			keyBitmapLen := len(bitmap)
 			for {
-				c := buf[cursor]
+				c := char(b, cursor)
 				switch c {
 				case '"':
 					x := uint64(curBit & -curBit)
@@ -152,13 +153,13 @@ func decodeKeyByBitmapInt8(d *structDecoder, buf []byte, cursor int64) (int64, *
 					if keyIdx >= keyBitmapLen {
 						for {
 							cursor++
-							switch buf[cursor] {
+							switch char(b, cursor) {
 							case '"':
 								cursor++
 								return cursor, field, nil
 							case '\\':
 								cursor++
-								if buf[cursor] == nul {
+								if char(b, cursor) == nul {
 									return 0, nil, errUnexpectedEndOfJSON("string", cursor)
 								}
 							case nul:
@@ -170,13 +171,13 @@ func decodeKeyByBitmapInt8(d *structDecoder, buf []byte, cursor int64) (int64, *
 					if curBit == 0 {
 						for {
 							cursor++
-							switch buf[cursor] {
+							switch char(b, cursor) {
 							case '"':
 								cursor++
 								return cursor, field, nil
 							case '\\':
 								cursor++
-								if buf[cursor] == nul {
+								if char(b, cursor) == nul {
 									return 0, nil, errUnexpectedEndOfJSON("string", cursor)
 								}
 							case nul:
@@ -199,13 +200,14 @@ func decodeKeyByBitmapInt16(d *structDecoder, buf []byte, cursor int64) (int64, 
 		field  *structFieldSet
 		curBit int16 = math.MaxInt16
 	)
+	b := (*sliceHeader)(unsafe.Pointer(&buf)).data
 	for {
-		switch buf[cursor] {
+		switch char(b, cursor) {
 		case ' ', '\n', '\t', '\r':
 			cursor++
 		case '"':
 			cursor++
-			c := buf[cursor]
+			c := char(b, cursor)
 			switch c {
 			case '"':
 				cursor++
@@ -217,7 +219,7 @@ func decodeKeyByBitmapInt16(d *structDecoder, buf []byte, cursor int64) (int64, 
 			bitmap := d.keyBitmapInt16
 			keyBitmapLen := len(bitmap)
 			for {
-				c := buf[cursor]
+				c := char(b, cursor)
 				switch c {
 				case '"':
 					x := uint64(curBit & -curBit)
@@ -231,13 +233,13 @@ func decodeKeyByBitmapInt16(d *structDecoder, buf []byte, cursor int64) (int64, 
 					if keyIdx >= keyBitmapLen {
 						for {
 							cursor++
-							switch buf[cursor] {
+							switch char(b, cursor) {
 							case '"':
 								cursor++
 								return cursor, field, nil
 							case '\\':
 								cursor++
-								if buf[cursor] == nul {
+								if char(b, cursor) == nul {
 									return 0, nil, errUnexpectedEndOfJSON("string", cursor)
 								}
 							case nul:
@@ -249,13 +251,13 @@ func decodeKeyByBitmapInt16(d *structDecoder, buf []byte, cursor int64) (int64, 
 					if curBit == 0 {
 						for {
 							cursor++
-							switch buf[cursor] {
+							switch char(b, cursor) {
 							case '"':
 								cursor++
 								return cursor, field, nil
 							case '\\':
 								cursor++
-								if buf[cursor] == nul {
+								if char(b, cursor) == nul {
 									return 0, nil, errUnexpectedEndOfJSON("string", cursor)
 								}
 							case nul:

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -564,9 +564,6 @@ func (d *structDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 			return err
 		}
 		s.skipWhiteSpace()
-		if s.char() == nul {
-			s.read()
-		}
 		if s.char() != ':' {
 			return errExpected("colon after object key", s.totalOffset())
 		}

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -331,6 +331,11 @@ func decodeKeyByBitmapInt8Stream(d *structDecoder, s *stream) (*structFieldSet, 
 		switch s.char() {
 		case ' ', '\n', '\t', '\r':
 			s.cursor++
+		case nul:
+			if s.read() {
+				continue
+			}
+			return nil, "", errNotAtBeginningOfValue(s.totalOffset())
 		case '"':
 			s.cursor++
 		FIRST_CHAR:
@@ -434,6 +439,11 @@ func decodeKeyByBitmapInt16Stream(d *structDecoder, s *stream) (*structFieldSet,
 		switch s.char() {
 		case ' ', '\n', '\t', '\r':
 			s.cursor++
+		case nul:
+			if s.read() {
+				continue
+			}
+			return nil, "", errNotAtBeginningOfValue(s.totalOffset())
 		case '"':
 			s.cursor++
 		FIRST_CHAR:
@@ -585,9 +595,6 @@ func (d *structDecoder) decodeStream(s *stream, p unsafe.Pointer) error {
 			}
 		}
 		s.skipWhiteSpace()
-		if s.char() == nul {
-			s.read()
-		}
 		c := s.char()
 		if c == '}' {
 			s.cursor++

--- a/encode_compile.go
+++ b/encode_compile.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -22,73 +21,9 @@ type opcodeSet struct {
 }
 
 var (
-	marshalJSONType        = reflect.TypeOf((*Marshaler)(nil)).Elem()
-	marshalTextType        = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
-	cachedOpcode           unsafe.Pointer // map[uintptr]*opcodeSet
-	baseTypeAddr           uintptr
-	cachedOpcodeSets       []*opcodeSet
-	existsCachedOpcodeSets bool
+	marshalJSONType = reflect.TypeOf((*Marshaler)(nil)).Elem()
+	marshalTextType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 )
-
-const (
-	maxAcceptableTypeAddrRange = 1024 * 1024 * 2 // 2 Mib
-)
-
-//go:linkname typelinks reflect.typelinks
-func typelinks() ([]unsafe.Pointer, [][]int32)
-
-//go:linkname rtypeOff reflect.rtypeOff
-func rtypeOff(unsafe.Pointer, int32) unsafe.Pointer
-
-func setupOpcodeSets() error {
-	sections, offsets := typelinks()
-	if len(sections) != 1 {
-		return fmt.Errorf("failed to get sections")
-	}
-	if len(offsets) != 1 {
-		return fmt.Errorf("failed to get offsets")
-	}
-	section := sections[0]
-	offset := offsets[0]
-	var (
-		min uintptr = uintptr(^uint(0))
-		max uintptr = 0
-	)
-	for i := 0; i < len(offset); i++ {
-		typ := (*rtype)(rtypeOff(section, offset[i]))
-		addr := uintptr(unsafe.Pointer(typ))
-		if min > addr {
-			min = addr
-		}
-		if max < addr {
-			max = addr
-		}
-		if typ.Kind() == reflect.Ptr {
-			addr = uintptr(unsafe.Pointer(typ.Elem()))
-			if min > addr {
-				min = addr
-			}
-			if max < addr {
-				max = addr
-			}
-		}
-	}
-	addrRange := max - min
-	if addrRange == 0 {
-		return fmt.Errorf("failed to get address range of types")
-	}
-	if addrRange > maxAcceptableTypeAddrRange {
-		return fmt.Errorf("too big address range %d", addrRange)
-	}
-	cachedOpcodeSets = make([]*opcodeSet, addrRange)
-	existsCachedOpcodeSets = true
-	baseTypeAddr = min
-	return nil
-}
-
-func init() {
-	_ = setupOpcodeSets()
-}
 
 func encodeCompileToGetCodeSetSlowPath(typeptr uintptr) (*opcodeSet, error) {
 	opcodeMap := loadOpcodeMap()
@@ -115,22 +50,6 @@ func encodeCompileToGetCodeSetSlowPath(typeptr uintptr) (*opcodeSet, error) {
 	}
 	storeOpcodeSet(typeptr, codeSet, opcodeMap)
 	return codeSet, nil
-}
-
-func loadOpcodeMap() map[uintptr]*opcodeSet {
-	p := atomic.LoadPointer(&cachedOpcode)
-	return *(*map[uintptr]*opcodeSet)(unsafe.Pointer(&p))
-}
-
-func storeOpcodeSet(typ uintptr, set *opcodeSet, m map[uintptr]*opcodeSet) {
-	newOpcodeMap := make(map[uintptr]*opcodeSet, len(m)+1)
-	newOpcodeMap[typ] = set
-
-	for k, v := range m {
-		newOpcodeMap[k] = v
-	}
-
-	atomic.StorePointer(&cachedOpcode, *(*unsafe.Pointer)(unsafe.Pointer(&newOpcodeMap)))
 }
 
 func encodeCompileHead(ctx *encodeCompileContext) (*opcode, error) {


### PR DESCRIPTION
Good news. In Unmarshal's benchmark, go-json is faster than gojay .

Faster 20% - 30% than master branch 

```
benchmark                                                     old ns/op     new ns/op     delta
Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson-16        2547          2436          -4.36%
Benchmark_Decode_SmallStruct_Unmarshal_JsonIter-16            793           758           -4.41%
Benchmark_Decode_SmallStruct_Unmarshal_GoJay-16               461           444           -3.69%
Benchmark_Decode_SmallStruct_Unmarshal_GoJayUnsafe-16         409           405           -0.98%
Benchmark_Decode_SmallStruct_Unmarshal_SegmentioJson-16       1039          1024          -1.44%
Benchmark_Decode_SmallStruct_Unmarshal_GoJson-16              498           352           -29.32%
Benchmark_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-16      516           344           -33.33%
Benchmark_Decode_SmallStruct_Stream_EncodingJson-16           2751          2738          -0.47%
Benchmark_Decode_SmallStruct_Stream_JsonIter-16               972           992           +2.06%
Benchmark_Decode_SmallStruct_Stream_GoJay-16                  562           555           -1.25%
Benchmark_Decode_SmallStruct_Stream_SegmentioJson-16          5293          5553          +4.91%
Benchmark_Decode_SmallStruct_Stream_GoJson-16                 987           783           -20.67%
Benchmark_Decode_MediumStruct_Unmarshal_EncodingJson-16       15134         15578         +2.93%
Benchmark_Decode_MediumStruct_Unmarshal_JsonIter-16           5382          5352          -0.56%
Benchmark_Decode_MediumStruct_Unmarshal_GoJay-16              3151          3178          +0.86%
Benchmark_Decode_MediumStruct_Unmarshal_GoJayUnsafe-16        2658          2721          +2.37%
Benchmark_Decode_MediumStruct_Unmarshal_SegmentioJson-16      5071          5366          +5.82%
Benchmark_Decode_MediumStruct_Unmarshal_GoJson-16             2833          2295          -18.99%
Benchmark_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-16     2803          2372          -15.38%
Benchmark_Decode_MediumStruct_Stream_EncodingJson-16          18059         17934         -0.69%
Benchmark_Decode_MediumStruct_Stream_JsonIter-16              6334          6171          -2.57%
Benchmark_Decode_MediumStruct_Stream_GoJay-16                 4328          4273          -1.27%
Benchmark_Decode_MediumStruct_Stream_SegmentioJson-16         13549         13400         -1.10%
Benchmark_Decode_MediumStruct_Stream_GoJson-16                4670          4089          -12.44%
Benchmark_Decode_LargeStruct_Unmarshal_EncodingJson-16        197295        195806        -0.75%
Benchmark_Decode_LargeStruct_Unmarshal_JsonIter-16            97707         97652         -0.06%
Benchmark_Decode_LargeStruct_Unmarshal_GoJay-16               36738         35992         -2.03%
Benchmark_Decode_LargeStruct_Unmarshal_GoJayUnsafe-16         31821         31463         -1.13%
Benchmark_Decode_LargeStruct_Unmarshal_SegmentioJson-16       89198         89756         +0.63%
Benchmark_Decode_LargeStruct_Unmarshal_GoJson-16              39769         32051         -19.41%
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-16      40516         31836         -21.42%
Benchmark_Decode_LargeStruct_Stream_EncodingJson-16           229008        215475        -5.91%
Benchmark_Decode_LargeStruct_Stream_JsonIter-16               113101        108454        -4.11%
Benchmark_Decode_LargeStruct_Stream_GoJay-16                  45679         43176         -5.48%
Benchmark_Decode_LargeStruct_Stream_SegmentioJson-16          151604        147518        -2.70%
Benchmark_Decode_LargeStruct_Stream_GoJson-16                 70537         56056         -20.53%
```