### PR TITLE
Fix broken links to segmentio/encoding and jettison

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Replace import statement from `encoding/json` to `github.com/goccy/go-json`
 | [json-iterator/go](https://github.com/json-iterator/go) | ○ | ○ | △ |
 | [easyjson](https://github.com/mailru/easyjson) | ○ | ○ |  ✗ |
 | [gojay](https://github.com/francoispqt/gojay) | ○ | ○ |  ✗ |
-| [segmentio/encoding/json](github.com/segmentio/encoding/json) | ○ | ○ | ○ |
-| [jettison](github.com/wI2L/jettison) | ○ | ✗ | ✗ |
+| [segmentio/encoding/json](https://github.com/segmentio/encoding/tree/master/json) | ○ | ○ | ○ |
+| [jettison](https://github.com/wI2L/jettison) | ○ | ✗ | ✗ |
 | [simdjson-go](https://github.com/minio/simdjson-go) | ✗ | ○ | ✗ |
 | go-json | ○ | ○ | ○ |
 


### PR DESCRIPTION
I pointed segmentio/encoding/json to `/tree/master/json`. Should it just be straight to the encoding repository root instead?