### PR TITLE
Optimize decoding of struct field

### DIFF
--- a/decode_struct.go
+++ b/decode_struct.go
@@ -109,8 +109,13 @@ func (d *structDecoder) tryOptimize() {
 		sortedKeys = append(sortedKeys, key)
 	}
 	sort.Strings(sortedKeys)
+
+	// By allocating one extra capacity than `maxKeyLen`,
+	// it is possible to avoid the process of comparing the index of the key with the length of the bitmap each time.
+	bitmapLen := maxKeyLen + 1
 	if len(sortedKeys) <= 8 {
-		keyBitmap := make([][256]int8, maxKeyLen)
+		// maxKeyLen
+		keyBitmap := make([][256]int8, bitmapLen)
 		for i, key := range sortedKeys {
 			for j := 0; j < len(key); j++ {
 				c := key[j]
@@ -122,7 +127,7 @@ func (d *structDecoder) tryOptimize() {
 		d.keyDecoder = decodeKeyByBitmapInt8
 		d.keyStreamDecoder = decodeKeyByBitmapInt8Stream
 	} else {
-		keyBitmap := make([][256]int16, maxKeyLen)
+		keyBitmap := make([][256]int16, bitmapLen)
 		for i, key := range sortedKeys {
 			for j := 0; j < len(key); j++ {
 				c := key[j]
@@ -158,7 +163,6 @@ func decodeKeyByBitmapInt8(d *structDecoder, buf []byte, cursor int64) (int64, *
 			}
 			keyIdx := 0
 			bitmap := d.keyBitmapInt8
-			keyBitmapLen := len(bitmap)
 			start := cursor
 			for {
 				c := char(b, cursor)
@@ -177,23 +181,6 @@ func decodeKeyByBitmapInt8(d *structDecoder, buf []byte, cursor int64) (int64, *
 				case nul:
 					return 0, nil, errUnexpectedEndOfJSON("string", cursor)
 				default:
-					if keyIdx >= keyBitmapLen {
-						for {
-							cursor++
-							switch char(b, cursor) {
-							case '"':
-								cursor++
-								return cursor, field, nil
-							case '\\':
-								cursor++
-								if char(b, cursor) == nul {
-									return 0, nil, errUnexpectedEndOfJSON("string", cursor)
-								}
-							case nul:
-								return 0, nil, errUnexpectedEndOfJSON("string", cursor)
-							}
-						}
-					}
 					curBit &= bitmap[keyIdx][largeToSmallTable[c]]
 					if curBit == 0 {
 						for {
@@ -244,7 +231,6 @@ func decodeKeyByBitmapInt16(d *structDecoder, buf []byte, cursor int64) (int64, 
 			}
 			keyIdx := 0
 			bitmap := d.keyBitmapInt16
-			keyBitmapLen := len(bitmap)
 			start := cursor
 			for {
 				c := char(b, cursor)
@@ -263,23 +249,6 @@ func decodeKeyByBitmapInt16(d *structDecoder, buf []byte, cursor int64) (int64, 
 				case nul:
 					return 0, nil, errUnexpectedEndOfJSON("string", cursor)
 				default:
-					if keyIdx >= keyBitmapLen {
-						for {
-							cursor++
-							switch char(b, cursor) {
-							case '"':
-								cursor++
-								return cursor, field, nil
-							case '\\':
-								cursor++
-								if char(b, cursor) == nul {
-									return 0, nil, errUnexpectedEndOfJSON("string", cursor)
-								}
-							case nul:
-								return 0, nil, errUnexpectedEndOfJSON("string", cursor)
-							}
-						}
-					}
 					curBit &= bitmap[keyIdx][largeToSmallTable[c]]
 					if curBit == 0 {
 						for {
@@ -352,7 +321,6 @@ func decodeKeyByBitmapInt8Stream(d *structDecoder, s *stream) (*structFieldSet, 
 			}
 			keyIdx := 0
 			bitmap := d.keyBitmapInt8
-			keyBitmapLen := len(bitmap)
 			for {
 				c := s.char()
 				switch c {
@@ -373,29 +341,6 @@ func decodeKeyByBitmapInt8Stream(d *structDecoder, s *stream) (*structFieldSet, 
 					}
 					return nil, "", errUnexpectedEndOfJSON("string", s.totalOffset())
 				default:
-					if keyIdx >= keyBitmapLen {
-						for {
-							s.cursor++
-							switch s.char() {
-							case '"':
-								b := s.buf[start:s.cursor]
-								key := *(*string)(unsafe.Pointer(&b))
-								s.cursor++
-								return field, key, nil
-							case '\\':
-								s.cursor++
-								if s.char() == nul {
-									if !s.read() {
-										return nil, "", errUnexpectedEndOfJSON("string", s.totalOffset())
-									}
-								}
-							case nul:
-								if !s.read() {
-									return nil, "", errUnexpectedEndOfJSON("string", s.totalOffset())
-								}
-							}
-						}
-					}
 					curBit &= bitmap[keyIdx][largeToSmallTable[c]]
 					if curBit == 0 {
 						for {
@@ -460,7 +405,6 @@ func decodeKeyByBitmapInt16Stream(d *structDecoder, s *stream) (*structFieldSet,
 			}
 			keyIdx := 0
 			bitmap := d.keyBitmapInt16
-			keyBitmapLen := len(bitmap)
 			for {
 				c := s.char()
 				switch c {
@@ -481,29 +425,6 @@ func decodeKeyByBitmapInt16Stream(d *structDecoder, s *stream) (*structFieldSet,
 					}
 					return nil, "", errUnexpectedEndOfJSON("string", s.totalOffset())
 				default:
-					if keyIdx >= keyBitmapLen {
-						for {
-							s.cursor++
-							switch s.char() {
-							case '"':
-								b := s.buf[start:s.cursor]
-								key := *(*string)(unsafe.Pointer(&b))
-								s.cursor++
-								return field, key, nil
-							case '\\':
-								s.cursor++
-								if s.char() == nul {
-									if !s.read() {
-										return nil, "", errUnexpectedEndOfJSON("string", s.totalOffset())
-									}
-								}
-							case nul:
-								if !s.read() {
-									return nil, "", errUnexpectedEndOfJSON("string", s.totalOffset())
-								}
-							}
-						}
-					}
 					curBit &= bitmap[keyIdx][largeToSmallTable[c]]
 					if curBit == 0 {
 						for {

--- a/decode_struct.go
+++ b/decode_struct.go
@@ -114,7 +114,6 @@ func (d *structDecoder) tryOptimize() {
 	// it is possible to avoid the process of comparing the index of the key with the length of the bitmap each time.
 	bitmapLen := maxKeyLen + 1
 	if len(sortedKeys) <= 8 {
-		// maxKeyLen
 		keyBitmap := make([][256]int8, bitmapLen)
 		for i, key := range sortedKeys {
 			for j := 0; j < len(key); j++ {


### PR DESCRIPTION
Remove the process of comparing `keyIdx` and `keyBitmapLen`

### BEFORE

```
Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson-16            420442              2464 ns/op             400 B/op         10 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_JsonIter-16               1570598               765 ns/op             208 B/op         13 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJay-16                  2670846               462 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJayUnsafe-16            3040153               398 ns/op             112 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_SegmentioJson-16          1203678               993 ns/op             192 B/op          5 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJson-16                 3508008               336 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-16         4303282               278 ns/op             144 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Stream_EncodingJson-16               465931              2725 ns/op            1104 B/op         12 allocs/op
Benchmark_Decode_SmallStruct_Stream_JsonIter-16                  1261759               961 ns/op             872 B/op         16 allocs/op
Benchmark_Decode_SmallStruct_Stream_GoJay-16                     2189396               574 ns/op             720 B/op          3 allocs/op
Benchmark_Decode_SmallStruct_Stream_SegmentioJson-16              203696              5594 ns/op           32960 B/op          6 allocs/op
Benchmark_Decode_SmallStruct_Stream_GoJson-16                    1554121               780 ns/op            1217 B/op          4 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_EncodingJson-16            77126             15511 ns/op             696 B/op         19 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_JsonIter-16               230743              5370 ns/op             792 B/op         82 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJay-16                  359530              3131 ns/op            2448 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJayUnsafe-16            445182              2614 ns/op             144 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_SegmentioJson-16          230827              4987 ns/op             296 B/op          9 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJson-16                 504394              2229 ns/op            2448 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-16         536556              2201 ns/op            2416 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Stream_EncodingJson-16               65360             17987 ns/op            7136 B/op         26 allocs/op
Benchmark_Decode_MediumStruct_Stream_JsonIter-16                  185019              6212 ns/op            1792 B/op         91 allocs/op
Benchmark_Decode_MediumStruct_Stream_GoJay-16                     245170              4140 ns/op            7920 B/op         12 allocs/op
Benchmark_Decode_MediumStruct_Stream_SegmentioJson-16              87806             13397 ns/op           33064 B/op         10 allocs/op
Benchmark_Decode_MediumStruct_Stream_GoJson-16                    283306              4115 ns/op            3304 B/op         11 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_EncodingJson-16              6012            194859 ns/op            6240 B/op        191 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_JsonIter-16                 12528             95515 ns/op           17170 B/op       1271 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJay-16                    32299             36382 ns/op           31236 B/op         77 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJayUnsafe-16              38065             31433 ns/op            2560 B/op         76 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_SegmentioJson-16            13110             92895 ns/op            4400 B/op        132 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJson-16                   35983             31944 ns/op           30731 B/op         67 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-16           37971             32768 ns/op           30699 B/op         66 allocs/op
Benchmark_Decode_LargeStruct_Stream_EncodingJson-16                 5400            225095 ns/op           70016 B/op        201 allocs/op
Benchmark_Decode_LargeStruct_Stream_JsonIter-16                    10000            108670 ns/op           21320 B/op       1398 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJay-16                       28149             43148 ns/op           67680 B/op         84 allocs/op
Benchmark_Decode_LargeStruct_Stream_SegmentioJson-16                8142            147858 ns/op           37168 B/op        133 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJson-16                      20763             56677 ns/op           33885 B/op         73 allocs/op
```

### AFTER

```
Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson-16            440466              2411 ns/op             400 B/op         10 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_JsonIter-16               1588170               752 ns/op             208 B/op         13 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJay-16                  2680398               446 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJayUnsafe-16            3027039               400 ns/op             112 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_SegmentioJson-16          1200670               998 ns/op             192 B/op          5 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJson-16                 3604622               330 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-16         4345796               272 ns/op             144 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Stream_EncodingJson-16               423432              2678 ns/op            1104 B/op         12 allocs/op
Benchmark_Decode_SmallStruct_Stream_JsonIter-16                  1285618               933 ns/op             872 B/op         16 allocs/op
Benchmark_Decode_SmallStruct_Stream_GoJay-16                     2245189               544 ns/op             720 B/op          3 allocs/op
Benchmark_Decode_SmallStruct_Stream_SegmentioJson-16              191907              5531 ns/op           32960 B/op          6 allocs/op
Benchmark_Decode_SmallStruct_Stream_GoJson-16                    1613493               733 ns/op            1217 B/op          4 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_EncodingJson-16            77467             15458 ns/op             696 B/op         19 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_JsonIter-16               219883              5332 ns/op             792 B/op         82 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJay-16                  380986              3016 ns/op            2448 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJayUnsafe-16            448308              2617 ns/op             144 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_SegmentioJson-16          235885              5061 ns/op             296 B/op          9 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJson-16                 516219              2223 ns/op            2448 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-16         530295              2195 ns/op            2416 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Stream_EncodingJson-16               66180             17631 ns/op            7136 B/op         26 allocs/op
Benchmark_Decode_MediumStruct_Stream_JsonIter-16                  190458              6224 ns/op            1792 B/op         91 allocs/op
Benchmark_Decode_MediumStruct_Stream_GoJay-16                     289376              4105 ns/op            7920 B/op         12 allocs/op
Benchmark_Decode_MediumStruct_Stream_SegmentioJson-16              92755             13137 ns/op           33064 B/op         10 allocs/op
Benchmark_Decode_MediumStruct_Stream_GoJson-16                    287592              4012 ns/op            3304 B/op         11 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_EncodingJson-16              5979            196081 ns/op            6240 B/op        191 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_JsonIter-16                 12314             95861 ns/op           17170 B/op       1271 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJay-16                    33466             35485 ns/op           31236 B/op         77 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJayUnsafe-16              37825             31378 ns/op            2560 B/op         76 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_SegmentioJson-16            13416             89536 ns/op            4400 B/op        132 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJson-16                   36884             32170 ns/op           30731 B/op         67 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-16           36096             32816 ns/op           30699 B/op         66 allocs/op
Benchmark_Decode_LargeStruct_Stream_EncodingJson-16                 5701            214530 ns/op           70016 B/op        201 allocs/op
Benchmark_Decode_LargeStruct_Stream_JsonIter-16                    10000            107915 ns/op           21320 B/op       1398 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJay-16                       27692             42573 ns/op           67680 B/op         84 allocs/op
Benchmark_Decode_LargeStruct_Stream_SegmentioJson-16                7724            148370 ns/op           37168 B/op        133 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJson-16                      21406             55023 ns/op           33885 B/op         73 allocs/op
```