### PR TITLE
feat: reduce WriteByte to improve Compact's performance

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -4,48 +4,78 @@ import (
 	"bytes"
 )
 
+type asciiSet [8]uint32
+
+func makeASCIISet(chars string) asciiSet {
+	var as asciiSet
+	for _, c := range chars {
+		as[c>>5] |= 1 << uint(c&31)
+	}
+	return as
+}
+
+func (as *asciiSet) Contains(c byte) bool {
+	return (as[c>>5] & (1 << uint(c&31))) != 0
+}
+
+var flushSet = makeASCIISet("\" \t\n\r")
+var escapeSet = makeASCIISet("<>&")
+
 func compact(dst *bytes.Buffer, src []byte, escape bool) error {
-	length := len(src)
-	for cursor := 0; cursor < length; cursor++ {
-		c := src[cursor]
-		switch c {
-		case ' ', '\t', '\n', '\r':
-			continue
-		case '"':
-			if err := dst.WriteByte(c); err != nil {
-				return err
-			}
-			for {
-				cursor++
-				c := src[cursor]
-				if escape && (c == '<' || c == '>' || c == '&') {
-					if _, err := dst.WriteString(`\u00`); err != nil {
-						return err
-					}
-					if _, err := dst.Write([]byte{hex[c>>4], hex[c&0xF]}); err != nil {
-						return err
-					}
-				} else if err := dst.WriteByte(c); err != nil {
-					return err
-				}
-				switch c {
-				case '\\':
-					cursor++
-					if err := dst.WriteByte(src[cursor]); err != nil {
-						return err
-					}
-				case '"':
-					goto LOOP_END
-				case nul:
-					return errUnexpectedEndOfJSON("string", int64(length))
-				}
-			}
-		default:
-			if err := dst.WriteByte(c); err != nil {
-				return err
+	start := 0
+	cursor := 0
+	for {
+		offset := -1
+		flushSet := flushSet
+		for i, c := range src[cursor:] {
+			if flushSet.Contains(c) {
+				offset = i
+				break
 			}
 		}
-	LOOP_END:
+		if offset == -1 {
+			break
+		}
+		cursor += offset
+		c := src[cursor]
+		if c == '"' { // string literal
+			cursor++
+			escapeSet := escapeSet
+			for escaped := false; cursor < len(src); cursor++ {
+				c := src[cursor]
+				if !escaped {
+					if c == '"' {
+						break
+					}
+					if c == '\\' {
+						escaped = true
+					} else if escape && escapeSet.Contains(c) {
+						if start < cursor {
+							dst.Write(src[start:cursor])
+						}
+						start = cursor + 1
+						dst.Write([]byte{'\\', 'u', '0', '0', hex[c>>4], hex[c&0xf]})
+					}
+				} else {
+					escaped = false
+					if escape && escapeSet.Contains(c) {
+						return errInvalidCharacter(c, "escaped string", int64(cursor))
+					}
+				}
+			}
+			if cursor == len(src) {
+				return errUnexpectedEndOfJSON("string", int64(len(src)))
+			}
+		} else { // whitespaces
+			if start < cursor {
+				dst.Write(src[start:cursor])
+			}
+			start = cursor + 1
+		}
+		cursor++
+	}
+	if start < len(src) {
+		dst.Write(src[start:])
 	}
 	return nil
 }


### PR DESCRIPTION
I reduced WriteByte to improve Compact's performance.

## go-json benchmarks
```
name                          old time/op    new time/op    delta
_Encode_MarshalJSON_GoJson-8     100ns ± 2%      92ns ± 1%  -8.17%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
_Encode_MarshalJSON_GoJson-8     16.0B ± 0%     16.0B ± 0%    ~     (all equal)

name                          old allocs/op  new allocs/op  delta
_Encode_MarshalJSON_GoJson-8      2.00 ± 0%      2.00 ± 0%    ~     (all equal)
```

## lestrrat-go/jwx benchmarks
```
name                                                    old time/op    new time/op    delta
JWE/Serialization/JSON/json.Marshal                       13.4µs ± 2%    13.2µs ± 1%   -1.47%  (p=0.006 n=9+9)
JWK/Serialization/RSA/PublicKey/json.Marshal              5.97µs ± 2%    5.06µs ± 2%  -15.26%  (p=0.000 n=9+10)
JWK/Serialization/RSA/PrivateKey/json.Marshal             17.2µs ± 1%    13.5µs ± 1%  -21.49%  (p=0.000 n=10+10)
JWK/Serialization/EC/PublicKey/json.Marshal               5.56µs ± 2%    5.05µs ± 1%   -9.25%  (p=0.000 n=9+10)
JWK/Serialization/EC/PrivateKey/json.Marshal              6.59µs ± 1%    5.83µs ± 1%  -11.57%  (p=0.000 n=10+10)
JWK/Serialization/Symmetric/PublicKey/json.Marshal        3.85µs ± 1%    3.52µs ± 1%   -8.73%  (p=0.000 n=9+10)
JWK/Serialization/Symmetric/PrivateKey/json.Marshal       3.84µs ± 1%    3.51µs ± 1%   -8.61%  (p=0.000 n=10+10)
JWS/Serialization/JSON/json.Marshal                       14.2µs ± 1%    14.2µs ± 1%     ~     (p=0.870 n=10+10)
JWT/Serialization/JSON/json.Marshal                       3.00µs ± 2%    3.00µs ± 1%     ~     (p=0.504 n=9+9)
```