### PR TITLE
Reduce memory usage at compile

### DIFF
--- a/cover_int16_test.go
+++ b/cover_int16_test.go
@@ -245,7 +245,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a"`
 				B int16 `json:"b"`
 				C int16 `json:"c"`
-			}{A: 1, B: 2, C: 3},
+			}{A: 1, B: -2, C: 3},
 		},
 		{
 			name: "HeadInt16MultiFieldsOmitEmpty",
@@ -253,7 +253,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a,omitempty"`
 				B int16 `json:"b,omitempty"`
 				C int16 `json:"c,omitempty"`
-			}{A: 1, B: 2, C: 3},
+			}{A: 1, B: -2, C: 3},
 		},
 		{
 			name: "HeadInt16MultiFieldsString",
@@ -261,7 +261,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a,string"`
 				B int16 `json:"b,string"`
 				C int16 `json:"c,string"`
-			}{A: 1, B: 2, C: 3},
+			}{A: 1, B: -2, C: 3},
 		},
 
 		// HeadInt16PtrMultiFields
@@ -271,7 +271,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a"`
 				B *int16 `json:"b"`
 				C *int16 `json:"c"`
-			}{A: int16ptr(1), B: int16ptr(2), C: int16ptr(3)},
+			}{A: int16ptr(1), B: int16ptr(-2), C: int16ptr(3)},
 		},
 		{
 			name: "HeadInt16PtrMultiFieldsOmitEmpty",
@@ -279,7 +279,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a,omitempty"`
 				B *int16 `json:"b,omitempty"`
 				C *int16 `json:"c,omitempty"`
-			}{A: int16ptr(1), B: int16ptr(2), C: int16ptr(3)},
+			}{A: int16ptr(1), B: int16ptr(-2), C: int16ptr(3)},
 		},
 		{
 			name: "HeadInt16PtrMultiFieldsString",
@@ -287,7 +287,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a,string"`
 				B *int16 `json:"b,string"`
 				C *int16 `json:"c,string"`
-			}{A: int16ptr(1), B: int16ptr(2), C: int16ptr(3)},
+			}{A: int16ptr(1), B: int16ptr(-2), C: int16ptr(3)},
 		},
 
 		// HeadInt16PtrNilMultiFields
@@ -345,21 +345,21 @@ func TestCoverInt16(t *testing.T) {
 			data: &struct {
 				A int16 `json:"a"`
 				B int16 `json:"b"`
-			}{A: 1, B: 2},
+			}{A: 1, B: -2},
 		},
 		{
 			name: "PtrHeadInt16MultiFieldsOmitEmpty",
 			data: &struct {
 				A int16 `json:"a,omitempty"`
 				B int16 `json:"b,omitempty"`
-			}{A: 1, B: 2},
+			}{A: 1, B: -2},
 		},
 		{
 			name: "PtrHeadInt16MultiFieldsString",
 			data: &struct {
 				A int16 `json:"a,string"`
 				B int16 `json:"b,string"`
-			}{A: 1, B: 2},
+			}{A: 1, B: -2},
 		},
 
 		// PtrHeadInt16PtrMultiFields
@@ -368,21 +368,21 @@ func TestCoverInt16(t *testing.T) {
 			data: &struct {
 				A *int16 `json:"a"`
 				B *int16 `json:"b"`
-			}{A: int16ptr(1), B: int16ptr(2)},
+			}{A: int16ptr(1), B: int16ptr(-2)},
 		},
 		{
 			name: "PtrHeadInt16PtrMultiFieldsOmitEmpty",
 			data: &struct {
 				A *int16 `json:"a,omitempty"`
 				B *int16 `json:"b,omitempty"`
-			}{A: int16ptr(1), B: int16ptr(2)},
+			}{A: int16ptr(1), B: int16ptr(-2)},
 		},
 		{
 			name: "PtrHeadInt16PtrMultiFieldsString",
 			data: &struct {
 				A *int16 `json:"a,string"`
 				B *int16 `json:"b,string"`
-			}{A: int16ptr(1), B: int16ptr(2)},
+			}{A: int16ptr(1), B: int16ptr(-2)},
 		},
 
 		// PtrHeadInt16PtrNilMultiFields
@@ -750,7 +750,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a"`
 			}{A: 1}, B: struct {
 				B int16 `json:"b"`
-			}{B: 2}},
+			}{B: -2}},
 		},
 		{
 			name: "HeadInt16MultiFieldsNotRootOmitEmpty",
@@ -765,7 +765,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a,omitempty"`
 			}{A: 1}, B: struct {
 				B int16 `json:"b,omitempty"`
-			}{B: 2}},
+			}{B: -2}},
 		},
 		{
 			name: "HeadInt16MultiFieldsNotRootString",
@@ -780,7 +780,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a,string"`
 			}{A: 1}, B: struct {
 				B int16 `json:"b,string"`
-			}{B: 2}},
+			}{B: -2}},
 		},
 
 		// HeadInt16PtrMultiFieldsNotRoot
@@ -797,7 +797,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a"`
 			}{A: int16ptr(1)}, B: struct {
 				B *int16 `json:"b"`
-			}{B: int16ptr(2)}},
+			}{B: int16ptr(-2)}},
 		},
 		{
 			name: "HeadInt16PtrMultiFieldsNotRootOmitEmpty",
@@ -812,7 +812,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a,omitempty"`
 			}{A: int16ptr(1)}, B: struct {
 				B *int16 `json:"b,omitempty"`
-			}{B: int16ptr(2)}},
+			}{B: int16ptr(-2)}},
 		},
 		{
 			name: "HeadInt16PtrMultiFieldsNotRootString",
@@ -827,7 +827,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a,string"`
 			}{A: int16ptr(1)}, B: struct {
 				B *int16 `json:"b,string"`
-			}{B: int16ptr(2)}},
+			}{B: int16ptr(-2)}},
 		},
 
 		// HeadInt16PtrNilMultiFieldsNotRoot
@@ -926,7 +926,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a"`
 			}{A: 1}, B: struct {
 				B int16 `json:"b"`
-			}{B: 2}},
+			}{B: -2}},
 		},
 		{
 			name: "PtrHeadInt16MultiFieldsNotRootOmitEmpty",
@@ -941,7 +941,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a,omitempty"`
 			}{A: 1}, B: struct {
 				B int16 `json:"b,omitempty"`
-			}{B: 2}},
+			}{B: -2}},
 		},
 		{
 			name: "PtrHeadInt16MultiFieldsNotRootString",
@@ -956,7 +956,7 @@ func TestCoverInt16(t *testing.T) {
 				A int16 `json:"a,string"`
 			}{A: 1}, B: struct {
 				B int16 `json:"b,string"`
-			}{B: 2}},
+			}{B: -2}},
 		},
 
 		// PtrHeadInt16PtrMultiFieldsNotRoot
@@ -973,7 +973,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a"`
 			}{A: int16ptr(1)}), B: &(struct {
 				B *int16 `json:"b"`
-			}{B: int16ptr(2)})},
+			}{B: int16ptr(-2)})},
 		},
 		{
 			name: "PtrHeadInt16PtrMultiFieldsNotRootOmitEmpty",
@@ -988,7 +988,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a,omitempty"`
 			}{A: int16ptr(1)}), B: &(struct {
 				B *int16 `json:"b,omitempty"`
-			}{B: int16ptr(2)})},
+			}{B: int16ptr(-2)})},
 		},
 		{
 			name: "PtrHeadInt16PtrMultiFieldsNotRootString",
@@ -1003,7 +1003,7 @@ func TestCoverInt16(t *testing.T) {
 				A *int16 `json:"a,string"`
 			}{A: int16ptr(1)}), B: &(struct {
 				B *int16 `json:"b,string"`
-			}{B: int16ptr(2)})},
+			}{B: int16ptr(-2)})},
 		},
 
 		// PtrHeadInt16PtrNilMultiFieldsNotRoot
@@ -1091,7 +1091,7 @@ func TestCoverInt16(t *testing.T) {
 			}{A: &(struct {
 				A int16 `json:"a"`
 				B int16 `json:"b"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: 1, B: -2}), B: &(struct {
 				A int16 `json:"a"`
 				B int16 `json:"b"`
 			}{A: 3, B: 4})},
@@ -1110,7 +1110,7 @@ func TestCoverInt16(t *testing.T) {
 			}{A: &(struct {
 				A int16 `json:"a,omitempty"`
 				B int16 `json:"b,omitempty"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: 1, B: -2}), B: &(struct {
 				A int16 `json:"a,omitempty"`
 				B int16 `json:"b,omitempty"`
 			}{A: 3, B: 4})},
@@ -1129,7 +1129,7 @@ func TestCoverInt16(t *testing.T) {
 			}{A: &(struct {
 				A int16 `json:"a,string"`
 				B int16 `json:"b,string"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: 1, B: -2}), B: &(struct {
 				A int16 `json:"a,string"`
 				B int16 `json:"b,string"`
 			}{A: 3, B: 4})},
@@ -1232,7 +1232,7 @@ func TestCoverInt16(t *testing.T) {
 			}{A: &(struct {
 				A *int16 `json:"a"`
 				B *int16 `json:"b"`
-			}{A: int16ptr(1), B: int16ptr(2)}), B: &(struct {
+			}{A: int16ptr(1), B: int16ptr(-2)}), B: &(struct {
 				A *int16 `json:"a"`
 				B *int16 `json:"b"`
 			}{A: int16ptr(3), B: int16ptr(4)})},
@@ -1251,7 +1251,7 @@ func TestCoverInt16(t *testing.T) {
 			}{A: &(struct {
 				A *int16 `json:"a,omitempty"`
 				B *int16 `json:"b,omitempty"`
-			}{A: int16ptr(1), B: int16ptr(2)}), B: &(struct {
+			}{A: int16ptr(1), B: int16ptr(-2)}), B: &(struct {
 				A *int16 `json:"a,omitempty"`
 				B *int16 `json:"b,omitempty"`
 			}{A: int16ptr(3), B: int16ptr(4)})},
@@ -1270,7 +1270,7 @@ func TestCoverInt16(t *testing.T) {
 			}{A: &(struct {
 				A *int16 `json:"a,string"`
 				B *int16 `json:"b,string"`
-			}{A: int16ptr(1), B: int16ptr(2)}), B: &(struct {
+			}{A: int16ptr(1), B: int16ptr(-2)}), B: &(struct {
 				A *int16 `json:"a,string"`
 				B *int16 `json:"b,string"`
 			}{A: int16ptr(3), B: int16ptr(4)})},
@@ -1366,7 +1366,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b"`
 			}{
 				structInt16: structInt16{A: 1},
-				B:           2,
+				B:           -2,
 			},
 		},
 		{
@@ -1376,7 +1376,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b,omitempty"`
 			}{
 				structInt16OmitEmpty: structInt16OmitEmpty{A: 1},
-				B:                    2,
+				B:                    -2,
 			},
 		},
 		{
@@ -1386,7 +1386,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b,string"`
 			}{
 				structInt16String: structInt16String{A: 1},
-				B:                 2,
+				B:                 -2,
 			},
 		},
 
@@ -1398,7 +1398,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b"`
 			}{
 				structInt16: &structInt16{A: 1},
-				B:           2,
+				B:           -2,
 			},
 		},
 		{
@@ -1408,7 +1408,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b,omitempty"`
 			}{
 				structInt16OmitEmpty: &structInt16OmitEmpty{A: 1},
-				B:                    2,
+				B:                    -2,
 			},
 		},
 		{
@@ -1418,7 +1418,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b,string"`
 			}{
 				structInt16String: &structInt16String{A: 1},
-				B:                 2,
+				B:                 -2,
 			},
 		},
 
@@ -1430,7 +1430,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b"`
 			}{
 				structInt16: nil,
-				B:           2,
+				B:           -2,
 			},
 		},
 		{
@@ -1440,7 +1440,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b,omitempty"`
 			}{
 				structInt16OmitEmpty: nil,
-				B:                    2,
+				B:                    -2,
 			},
 		},
 		{
@@ -1450,7 +1450,7 @@ func TestCoverInt16(t *testing.T) {
 				B int16 `json:"b,string"`
 			}{
 				structInt16String: nil,
-				B:                 2,
+				B:                 -2,
 			},
 		},
 
@@ -1462,7 +1462,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b"`
 			}{
 				structInt16Ptr: structInt16Ptr{A: int16ptr(1)},
-				B:              int16ptr(2),
+				B:              int16ptr(-2),
 			},
 		},
 		{
@@ -1472,7 +1472,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,omitempty"`
 			}{
 				structInt16PtrOmitEmpty: structInt16PtrOmitEmpty{A: int16ptr(1)},
-				B:                       int16ptr(2),
+				B:                       int16ptr(-2),
 			},
 		},
 		{
@@ -1482,7 +1482,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,string"`
 			}{
 				structInt16PtrString: structInt16PtrString{A: int16ptr(1)},
-				B:                    int16ptr(2),
+				B:                    int16ptr(-2),
 			},
 		},
 
@@ -1494,7 +1494,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b"`
 			}{
 				structInt16Ptr: structInt16Ptr{A: nil},
-				B:              int16ptr(2),
+				B:              int16ptr(-2),
 			},
 		},
 		{
@@ -1504,7 +1504,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,omitempty"`
 			}{
 				structInt16PtrOmitEmpty: structInt16PtrOmitEmpty{A: nil},
-				B:                       int16ptr(2),
+				B:                       int16ptr(-2),
 			},
 		},
 		{
@@ -1514,7 +1514,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,string"`
 			}{
 				structInt16PtrString: structInt16PtrString{A: nil},
-				B:                    int16ptr(2),
+				B:                    int16ptr(-2),
 			},
 		},
 
@@ -1526,7 +1526,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b"`
 			}{
 				structInt16Ptr: &structInt16Ptr{A: int16ptr(1)},
-				B:              int16ptr(2),
+				B:              int16ptr(-2),
 			},
 		},
 		{
@@ -1536,7 +1536,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,omitempty"`
 			}{
 				structInt16PtrOmitEmpty: &structInt16PtrOmitEmpty{A: int16ptr(1)},
-				B:                       int16ptr(2),
+				B:                       int16ptr(-2),
 			},
 		},
 		{
@@ -1546,7 +1546,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,string"`
 			}{
 				structInt16PtrString: &structInt16PtrString{A: int16ptr(1)},
-				B:                    int16ptr(2),
+				B:                    int16ptr(-2),
 			},
 		},
 
@@ -1558,7 +1558,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b"`
 			}{
 				structInt16Ptr: nil,
-				B:              int16ptr(2),
+				B:              int16ptr(-2),
 			},
 		},
 		{
@@ -1568,7 +1568,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,omitempty"`
 			}{
 				structInt16PtrOmitEmpty: nil,
-				B:                       int16ptr(2),
+				B:                       int16ptr(-2),
 			},
 		},
 		{
@@ -1578,7 +1578,7 @@ func TestCoverInt16(t *testing.T) {
 				B *int16 `json:"b,string"`
 			}{
 				structInt16PtrString: nil,
-				B:                    int16ptr(2),
+				B:                    int16ptr(-2),
 			},
 		},
 

--- a/cover_int32_test.go
+++ b/cover_int32_test.go
@@ -57,19 +57,19 @@ func TestCoverInt32(t *testing.T) {
 			name: "HeadInt32",
 			data: struct {
 				A int32 `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadInt32OmitEmpty",
 			data: struct {
 				A int32 `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadInt32String",
 			data: struct {
 				A int32 `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// HeadInt32Ptr
@@ -77,19 +77,19 @@ func TestCoverInt32(t *testing.T) {
 			name: "HeadInt32Ptr",
 			data: struct {
 				A *int32 `json:"a"`
-			}{A: int32ptr(1)},
+			}{A: int32ptr(-1)},
 		},
 		{
 			name: "HeadInt32PtrOmitEmpty",
 			data: struct {
 				A *int32 `json:"a,omitempty"`
-			}{A: int32ptr(1)},
+			}{A: int32ptr(-1)},
 		},
 		{
 			name: "HeadInt32PtrString",
 			data: struct {
 				A *int32 `json:"a,string"`
-			}{A: int32ptr(1)},
+			}{A: int32ptr(-1)},
 		},
 
 		// HeadInt32PtrNil
@@ -137,19 +137,19 @@ func TestCoverInt32(t *testing.T) {
 			name: "PtrHeadInt32",
 			data: &struct {
 				A int32 `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadInt32OmitEmpty",
 			data: &struct {
 				A int32 `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadInt32String",
 			data: &struct {
 				A int32 `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// PtrHeadInt32Ptr
@@ -157,19 +157,19 @@ func TestCoverInt32(t *testing.T) {
 			name: "PtrHeadInt32Ptr",
 			data: &struct {
 				A *int32 `json:"a"`
-			}{A: int32ptr(1)},
+			}{A: int32ptr(-1)},
 		},
 		{
 			name: "PtrHeadInt32PtrOmitEmpty",
 			data: &struct {
 				A *int32 `json:"a,omitempty"`
-			}{A: int32ptr(1)},
+			}{A: int32ptr(-1)},
 		},
 		{
 			name: "PtrHeadInt32PtrString",
 			data: &struct {
 				A *int32 `json:"a,string"`
-			}{A: int32ptr(1)},
+			}{A: int32ptr(-1)},
 		},
 
 		// PtrHeadInt32PtrNil
@@ -245,7 +245,7 @@ func TestCoverInt32(t *testing.T) {
 				A int32 `json:"a"`
 				B int32 `json:"b"`
 				C int32 `json:"c"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadInt32MultiFieldsOmitEmpty",
@@ -253,7 +253,7 @@ func TestCoverInt32(t *testing.T) {
 				A int32 `json:"a,omitempty"`
 				B int32 `json:"b,omitempty"`
 				C int32 `json:"c,omitempty"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadInt32MultiFieldsString",
@@ -261,7 +261,7 @@ func TestCoverInt32(t *testing.T) {
 				A int32 `json:"a,string"`
 				B int32 `json:"b,string"`
 				C int32 `json:"c,string"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 
 		// HeadInt32PtrMultiFields
@@ -271,7 +271,7 @@ func TestCoverInt32(t *testing.T) {
 				A *int32 `json:"a"`
 				B *int32 `json:"b"`
 				C *int32 `json:"c"`
-			}{A: int32ptr(1), B: int32ptr(2), C: int32ptr(3)},
+			}{A: int32ptr(-1), B: int32ptr(2), C: int32ptr(3)},
 		},
 		{
 			name: "HeadInt32PtrMultiFieldsOmitEmpty",
@@ -279,7 +279,7 @@ func TestCoverInt32(t *testing.T) {
 				A *int32 `json:"a,omitempty"`
 				B *int32 `json:"b,omitempty"`
 				C *int32 `json:"c,omitempty"`
-			}{A: int32ptr(1), B: int32ptr(2), C: int32ptr(3)},
+			}{A: int32ptr(-1), B: int32ptr(2), C: int32ptr(3)},
 		},
 		{
 			name: "HeadInt32PtrMultiFieldsString",
@@ -287,7 +287,7 @@ func TestCoverInt32(t *testing.T) {
 				A *int32 `json:"a,string"`
 				B *int32 `json:"b,string"`
 				C *int32 `json:"c,string"`
-			}{A: int32ptr(1), B: int32ptr(2), C: int32ptr(3)},
+			}{A: int32ptr(-1), B: int32ptr(2), C: int32ptr(3)},
 		},
 
 		// HeadInt32PtrNilMultiFields
@@ -345,21 +345,21 @@ func TestCoverInt32(t *testing.T) {
 			data: &struct {
 				A int32 `json:"a"`
 				B int32 `json:"b"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadInt32MultiFieldsOmitEmpty",
 			data: &struct {
 				A int32 `json:"a,omitempty"`
 				B int32 `json:"b,omitempty"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadInt32MultiFieldsString",
 			data: &struct {
 				A int32 `json:"a,string"`
 				B int32 `json:"b,string"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 
 		// PtrHeadInt32PtrMultiFields
@@ -368,21 +368,21 @@ func TestCoverInt32(t *testing.T) {
 			data: &struct {
 				A *int32 `json:"a"`
 				B *int32 `json:"b"`
-			}{A: int32ptr(1), B: int32ptr(2)},
+			}{A: int32ptr(-1), B: int32ptr(2)},
 		},
 		{
 			name: "PtrHeadInt32PtrMultiFieldsOmitEmpty",
 			data: &struct {
 				A *int32 `json:"a,omitempty"`
 				B *int32 `json:"b,omitempty"`
-			}{A: int32ptr(1), B: int32ptr(2)},
+			}{A: int32ptr(-1), B: int32ptr(2)},
 		},
 		{
 			name: "PtrHeadInt32PtrMultiFieldsString",
 			data: &struct {
 				A *int32 `json:"a,string"`
 				B *int32 `json:"b,string"`
-			}{A: int32ptr(1), B: int32ptr(2)},
+			}{A: int32ptr(-1), B: int32ptr(2)},
 		},
 
 		// PtrHeadInt32PtrNilMultiFields
@@ -466,7 +466,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadInt32NotRootOmitEmpty",
@@ -476,7 +476,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a,omitempty"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadInt32NotRootString",
@@ -486,7 +486,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a,string"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 
 		// HeadInt32PtrNotRoot
@@ -498,7 +498,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A *int32 `json:"a"`
-			}{int32ptr(1)}},
+			}{int32ptr(-1)}},
 		},
 		{
 			name: "HeadInt32PtrNotRootOmitEmpty",
@@ -508,7 +508,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A *int32 `json:"a,omitempty"`
-			}{int32ptr(1)}},
+			}{int32ptr(-1)}},
 		},
 		{
 			name: "HeadInt32PtrNotRootString",
@@ -518,7 +518,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A *int32 `json:"a,string"`
-			}{int32ptr(1)}},
+			}{int32ptr(-1)}},
 		},
 
 		// HeadInt32PtrNilNotRoot
@@ -588,7 +588,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int32 `json:"a"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadInt32NotRootOmitEmpty",
@@ -598,7 +598,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int32 `json:"a,omitempty"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadInt32NotRootString",
@@ -608,7 +608,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int32 `json:"a,string"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 
 		// PtrHeadInt32PtrNotRoot
@@ -620,7 +620,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int32 `json:"a"`
-			}{A: int32ptr(1)})},
+			}{A: int32ptr(-1)})},
 		},
 		{
 			name: "PtrHeadInt32PtrNotRootOmitEmpty",
@@ -630,7 +630,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int32 `json:"a,omitempty"`
-			}{A: int32ptr(1)})},
+			}{A: int32ptr(-1)})},
 		},
 		{
 			name: "PtrHeadInt32PtrNotRootString",
@@ -640,7 +640,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int32 `json:"a,string"`
-			}{A: int32ptr(1)})},
+			}{A: int32ptr(-1)})},
 		},
 
 		// PtrHeadInt32PtrNilNotRoot
@@ -748,7 +748,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int32 `json:"b"`
 			}{B: 2}},
 		},
@@ -763,7 +763,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int32 `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -778,7 +778,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int32 `json:"b,string"`
 			}{B: 2}},
 		},
@@ -795,7 +795,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A *int32 `json:"a"`
-			}{A: int32ptr(1)}, B: struct {
+			}{A: int32ptr(-1)}, B: struct {
 				B *int32 `json:"b"`
 			}{B: int32ptr(2)}},
 		},
@@ -810,7 +810,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A *int32 `json:"a,omitempty"`
-			}{A: int32ptr(1)}, B: struct {
+			}{A: int32ptr(-1)}, B: struct {
 				B *int32 `json:"b,omitempty"`
 			}{B: int32ptr(2)}},
 		},
@@ -825,7 +825,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A *int32 `json:"a,string"`
-			}{A: int32ptr(1)}, B: struct {
+			}{A: int32ptr(-1)}, B: struct {
 				B *int32 `json:"b,string"`
 			}{B: int32ptr(2)}},
 		},
@@ -924,7 +924,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int32 `json:"b"`
 			}{B: 2}},
 		},
@@ -939,7 +939,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int32 `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -954,7 +954,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: struct {
 				A int32 `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int32 `json:"b,string"`
 			}{B: 2}},
 		},
@@ -971,7 +971,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int32 `json:"a"`
-			}{A: int32ptr(1)}), B: &(struct {
+			}{A: int32ptr(-1)}), B: &(struct {
 				B *int32 `json:"b"`
 			}{B: int32ptr(2)})},
 		},
@@ -986,7 +986,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int32 `json:"a,omitempty"`
-			}{A: int32ptr(1)}), B: &(struct {
+			}{A: int32ptr(-1)}), B: &(struct {
 				B *int32 `json:"b,omitempty"`
 			}{B: int32ptr(2)})},
 		},
@@ -1001,7 +1001,7 @@ func TestCoverInt32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int32 `json:"a,string"`
-			}{A: int32ptr(1)}), B: &(struct {
+			}{A: int32ptr(-1)}), B: &(struct {
 				B *int32 `json:"b,string"`
 			}{B: int32ptr(2)})},
 		},
@@ -1091,7 +1091,7 @@ func TestCoverInt32(t *testing.T) {
 			}{A: &(struct {
 				A int32 `json:"a"`
 				B int32 `json:"b"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int32 `json:"a"`
 				B int32 `json:"b"`
 			}{A: 3, B: 4})},
@@ -1110,7 +1110,7 @@ func TestCoverInt32(t *testing.T) {
 			}{A: &(struct {
 				A int32 `json:"a,omitempty"`
 				B int32 `json:"b,omitempty"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int32 `json:"a,omitempty"`
 				B int32 `json:"b,omitempty"`
 			}{A: 3, B: 4})},
@@ -1129,7 +1129,7 @@ func TestCoverInt32(t *testing.T) {
 			}{A: &(struct {
 				A int32 `json:"a,string"`
 				B int32 `json:"b,string"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int32 `json:"a,string"`
 				B int32 `json:"b,string"`
 			}{A: 3, B: 4})},
@@ -1232,7 +1232,7 @@ func TestCoverInt32(t *testing.T) {
 			}{A: &(struct {
 				A *int32 `json:"a"`
 				B *int32 `json:"b"`
-			}{A: int32ptr(1), B: int32ptr(2)}), B: &(struct {
+			}{A: int32ptr(-1), B: int32ptr(2)}), B: &(struct {
 				A *int32 `json:"a"`
 				B *int32 `json:"b"`
 			}{A: int32ptr(3), B: int32ptr(4)})},
@@ -1251,7 +1251,7 @@ func TestCoverInt32(t *testing.T) {
 			}{A: &(struct {
 				A *int32 `json:"a,omitempty"`
 				B *int32 `json:"b,omitempty"`
-			}{A: int32ptr(1), B: int32ptr(2)}), B: &(struct {
+			}{A: int32ptr(-1), B: int32ptr(2)}), B: &(struct {
 				A *int32 `json:"a,omitempty"`
 				B *int32 `json:"b,omitempty"`
 			}{A: int32ptr(3), B: int32ptr(4)})},
@@ -1270,7 +1270,7 @@ func TestCoverInt32(t *testing.T) {
 			}{A: &(struct {
 				A *int32 `json:"a,string"`
 				B *int32 `json:"b,string"`
-			}{A: int32ptr(1), B: int32ptr(2)}), B: &(struct {
+			}{A: int32ptr(-1), B: int32ptr(2)}), B: &(struct {
 				A *int32 `json:"a,string"`
 				B *int32 `json:"b,string"`
 			}{A: int32ptr(3), B: int32ptr(4)})},
@@ -1365,7 +1365,7 @@ func TestCoverInt32(t *testing.T) {
 				structInt32
 				B int32 `json:"b"`
 			}{
-				structInt32: structInt32{A: 1},
+				structInt32: structInt32{A: -1},
 				B:           2,
 			},
 		},
@@ -1375,7 +1375,7 @@ func TestCoverInt32(t *testing.T) {
 				structInt32OmitEmpty
 				B int32 `json:"b,omitempty"`
 			}{
-				structInt32OmitEmpty: structInt32OmitEmpty{A: 1},
+				structInt32OmitEmpty: structInt32OmitEmpty{A: -1},
 				B:                    2,
 			},
 		},
@@ -1385,7 +1385,7 @@ func TestCoverInt32(t *testing.T) {
 				structInt32String
 				B int32 `json:"b,string"`
 			}{
-				structInt32String: structInt32String{A: 1},
+				structInt32String: structInt32String{A: -1},
 				B:                 2,
 			},
 		},
@@ -1397,7 +1397,7 @@ func TestCoverInt32(t *testing.T) {
 				*structInt32
 				B int32 `json:"b"`
 			}{
-				structInt32: &structInt32{A: 1},
+				structInt32: &structInt32{A: -1},
 				B:           2,
 			},
 		},
@@ -1407,7 +1407,7 @@ func TestCoverInt32(t *testing.T) {
 				*structInt32OmitEmpty
 				B int32 `json:"b,omitempty"`
 			}{
-				structInt32OmitEmpty: &structInt32OmitEmpty{A: 1},
+				structInt32OmitEmpty: &structInt32OmitEmpty{A: -1},
 				B:                    2,
 			},
 		},
@@ -1417,7 +1417,7 @@ func TestCoverInt32(t *testing.T) {
 				*structInt32String
 				B int32 `json:"b,string"`
 			}{
-				structInt32String: &structInt32String{A: 1},
+				structInt32String: &structInt32String{A: -1},
 				B:                 2,
 			},
 		},
@@ -1461,7 +1461,7 @@ func TestCoverInt32(t *testing.T) {
 				structInt32Ptr
 				B *int32 `json:"b"`
 			}{
-				structInt32Ptr: structInt32Ptr{A: int32ptr(1)},
+				structInt32Ptr: structInt32Ptr{A: int32ptr(-1)},
 				B:              int32ptr(2),
 			},
 		},
@@ -1471,7 +1471,7 @@ func TestCoverInt32(t *testing.T) {
 				structInt32PtrOmitEmpty
 				B *int32 `json:"b,omitempty"`
 			}{
-				structInt32PtrOmitEmpty: structInt32PtrOmitEmpty{A: int32ptr(1)},
+				structInt32PtrOmitEmpty: structInt32PtrOmitEmpty{A: int32ptr(-1)},
 				B:                       int32ptr(2),
 			},
 		},
@@ -1481,7 +1481,7 @@ func TestCoverInt32(t *testing.T) {
 				structInt32PtrString
 				B *int32 `json:"b,string"`
 			}{
-				structInt32PtrString: structInt32PtrString{A: int32ptr(1)},
+				structInt32PtrString: structInt32PtrString{A: int32ptr(-1)},
 				B:                    int32ptr(2),
 			},
 		},
@@ -1525,7 +1525,7 @@ func TestCoverInt32(t *testing.T) {
 				*structInt32Ptr
 				B *int32 `json:"b"`
 			}{
-				structInt32Ptr: &structInt32Ptr{A: int32ptr(1)},
+				structInt32Ptr: &structInt32Ptr{A: int32ptr(-1)},
 				B:              int32ptr(2),
 			},
 		},
@@ -1535,7 +1535,7 @@ func TestCoverInt32(t *testing.T) {
 				*structInt32PtrOmitEmpty
 				B *int32 `json:"b,omitempty"`
 			}{
-				structInt32PtrOmitEmpty: &structInt32PtrOmitEmpty{A: int32ptr(1)},
+				structInt32PtrOmitEmpty: &structInt32PtrOmitEmpty{A: int32ptr(-1)},
 				B:                       int32ptr(2),
 			},
 		},
@@ -1545,7 +1545,7 @@ func TestCoverInt32(t *testing.T) {
 				*structInt32PtrString
 				B *int32 `json:"b,string"`
 			}{
-				structInt32PtrString: &structInt32PtrString{A: int32ptr(1)},
+				structInt32PtrString: &structInt32PtrString{A: int32ptr(-1)},
 				B:                    int32ptr(2),
 			},
 		},
@@ -1588,7 +1588,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				structInt32
 			}{
-				structInt32: structInt32{A: 1},
+				structInt32: structInt32{A: -1},
 			},
 		},
 		{
@@ -1596,7 +1596,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				structInt32OmitEmpty
 			}{
-				structInt32OmitEmpty: structInt32OmitEmpty{A: 1},
+				structInt32OmitEmpty: structInt32OmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1604,7 +1604,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				structInt32String
 			}{
-				structInt32String: structInt32String{A: 1},
+				structInt32String: structInt32String{A: -1},
 			},
 		},
 
@@ -1614,7 +1614,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				*structInt32
 			}{
-				structInt32: &structInt32{A: 1},
+				structInt32: &structInt32{A: -1},
 			},
 		},
 		{
@@ -1622,7 +1622,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				*structInt32OmitEmpty
 			}{
-				structInt32OmitEmpty: &structInt32OmitEmpty{A: 1},
+				structInt32OmitEmpty: &structInt32OmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1630,7 +1630,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				*structInt32String
 			}{
-				structInt32String: &structInt32String{A: 1},
+				structInt32String: &structInt32String{A: -1},
 			},
 		},
 
@@ -1666,7 +1666,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				structInt32Ptr
 			}{
-				structInt32Ptr: structInt32Ptr{A: int32ptr(1)},
+				structInt32Ptr: structInt32Ptr{A: int32ptr(-1)},
 			},
 		},
 		{
@@ -1674,7 +1674,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				structInt32PtrOmitEmpty
 			}{
-				structInt32PtrOmitEmpty: structInt32PtrOmitEmpty{A: int32ptr(1)},
+				structInt32PtrOmitEmpty: structInt32PtrOmitEmpty{A: int32ptr(-1)},
 			},
 		},
 		{
@@ -1682,7 +1682,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				structInt32PtrString
 			}{
-				structInt32PtrString: structInt32PtrString{A: int32ptr(1)},
+				structInt32PtrString: structInt32PtrString{A: int32ptr(-1)},
 			},
 		},
 
@@ -1718,7 +1718,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				*structInt32Ptr
 			}{
-				structInt32Ptr: &structInt32Ptr{A: int32ptr(1)},
+				structInt32Ptr: &structInt32Ptr{A: int32ptr(-1)},
 			},
 		},
 		{
@@ -1726,7 +1726,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				*structInt32PtrOmitEmpty
 			}{
-				structInt32PtrOmitEmpty: &structInt32PtrOmitEmpty{A: int32ptr(1)},
+				structInt32PtrOmitEmpty: &structInt32PtrOmitEmpty{A: int32ptr(-1)},
 			},
 		},
 		{
@@ -1734,7 +1734,7 @@ func TestCoverInt32(t *testing.T) {
 			data: struct {
 				*structInt32PtrString
 			}{
-				structInt32PtrString: &structInt32PtrString{A: int32ptr(1)},
+				structInt32PtrString: &structInt32PtrString{A: int32ptr(-1)},
 			},
 		},
 

--- a/cover_int64_test.go
+++ b/cover_int64_test.go
@@ -57,19 +57,19 @@ func TestCoverInt64(t *testing.T) {
 			name: "HeadInt64",
 			data: struct {
 				A int64 `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadInt64OmitEmpty",
 			data: struct {
 				A int64 `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadInt64String",
 			data: struct {
 				A int64 `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// HeadInt64Ptr
@@ -77,19 +77,19 @@ func TestCoverInt64(t *testing.T) {
 			name: "HeadInt64Ptr",
 			data: struct {
 				A *int64 `json:"a"`
-			}{A: int64ptr(1)},
+			}{A: int64ptr(-1)},
 		},
 		{
 			name: "HeadInt64PtrOmitEmpty",
 			data: struct {
 				A *int64 `json:"a,omitempty"`
-			}{A: int64ptr(1)},
+			}{A: int64ptr(-1)},
 		},
 		{
 			name: "HeadInt64PtrString",
 			data: struct {
 				A *int64 `json:"a,string"`
-			}{A: int64ptr(1)},
+			}{A: int64ptr(-1)},
 		},
 
 		// HeadInt64PtrNil
@@ -137,19 +137,19 @@ func TestCoverInt64(t *testing.T) {
 			name: "PtrHeadInt64",
 			data: &struct {
 				A int64 `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadInt64OmitEmpty",
 			data: &struct {
 				A int64 `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadInt64String",
 			data: &struct {
 				A int64 `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// PtrHeadInt64Ptr
@@ -157,19 +157,19 @@ func TestCoverInt64(t *testing.T) {
 			name: "PtrHeadInt64Ptr",
 			data: &struct {
 				A *int64 `json:"a"`
-			}{A: int64ptr(1)},
+			}{A: int64ptr(-1)},
 		},
 		{
 			name: "PtrHeadInt64PtrOmitEmpty",
 			data: &struct {
 				A *int64 `json:"a,omitempty"`
-			}{A: int64ptr(1)},
+			}{A: int64ptr(-1)},
 		},
 		{
 			name: "PtrHeadInt64PtrString",
 			data: &struct {
 				A *int64 `json:"a,string"`
-			}{A: int64ptr(1)},
+			}{A: int64ptr(-1)},
 		},
 
 		// PtrHeadInt64PtrNil
@@ -245,7 +245,7 @@ func TestCoverInt64(t *testing.T) {
 				A int64 `json:"a"`
 				B int64 `json:"b"`
 				C int64 `json:"c"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadInt64MultiFieldsOmitEmpty",
@@ -253,7 +253,7 @@ func TestCoverInt64(t *testing.T) {
 				A int64 `json:"a,omitempty"`
 				B int64 `json:"b,omitempty"`
 				C int64 `json:"c,omitempty"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadInt64MultiFieldsString",
@@ -261,7 +261,7 @@ func TestCoverInt64(t *testing.T) {
 				A int64 `json:"a,string"`
 				B int64 `json:"b,string"`
 				C int64 `json:"c,string"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 
 		// HeadInt64PtrMultiFields
@@ -271,7 +271,7 @@ func TestCoverInt64(t *testing.T) {
 				A *int64 `json:"a"`
 				B *int64 `json:"b"`
 				C *int64 `json:"c"`
-			}{A: int64ptr(1), B: int64ptr(2), C: int64ptr(3)},
+			}{A: int64ptr(-1), B: int64ptr(2), C: int64ptr(3)},
 		},
 		{
 			name: "HeadInt64PtrMultiFieldsOmitEmpty",
@@ -279,7 +279,7 @@ func TestCoverInt64(t *testing.T) {
 				A *int64 `json:"a,omitempty"`
 				B *int64 `json:"b,omitempty"`
 				C *int64 `json:"c,omitempty"`
-			}{A: int64ptr(1), B: int64ptr(2), C: int64ptr(3)},
+			}{A: int64ptr(-1), B: int64ptr(2), C: int64ptr(3)},
 		},
 		{
 			name: "HeadInt64PtrMultiFieldsString",
@@ -287,7 +287,7 @@ func TestCoverInt64(t *testing.T) {
 				A *int64 `json:"a,string"`
 				B *int64 `json:"b,string"`
 				C *int64 `json:"c,string"`
-			}{A: int64ptr(1), B: int64ptr(2), C: int64ptr(3)},
+			}{A: int64ptr(-1), B: int64ptr(2), C: int64ptr(3)},
 		},
 
 		// HeadInt64PtrNilMultiFields
@@ -345,21 +345,21 @@ func TestCoverInt64(t *testing.T) {
 			data: &struct {
 				A int64 `json:"a"`
 				B int64 `json:"b"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadInt64MultiFieldsOmitEmpty",
 			data: &struct {
 				A int64 `json:"a,omitempty"`
 				B int64 `json:"b,omitempty"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadInt64MultiFieldsString",
 			data: &struct {
 				A int64 `json:"a,string"`
 				B int64 `json:"b,string"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 
 		// PtrHeadInt64PtrMultiFields
@@ -368,21 +368,21 @@ func TestCoverInt64(t *testing.T) {
 			data: &struct {
 				A *int64 `json:"a"`
 				B *int64 `json:"b"`
-			}{A: int64ptr(1), B: int64ptr(2)},
+			}{A: int64ptr(-1), B: int64ptr(2)},
 		},
 		{
 			name: "PtrHeadInt64PtrMultiFieldsOmitEmpty",
 			data: &struct {
 				A *int64 `json:"a,omitempty"`
 				B *int64 `json:"b,omitempty"`
-			}{A: int64ptr(1), B: int64ptr(2)},
+			}{A: int64ptr(-1), B: int64ptr(2)},
 		},
 		{
 			name: "PtrHeadInt64PtrMultiFieldsString",
 			data: &struct {
 				A *int64 `json:"a,string"`
 				B *int64 `json:"b,string"`
-			}{A: int64ptr(1), B: int64ptr(2)},
+			}{A: int64ptr(-1), B: int64ptr(2)},
 		},
 
 		// PtrHeadInt64PtrNilMultiFields
@@ -466,7 +466,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadInt64NotRootOmitEmpty",
@@ -476,7 +476,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a,omitempty"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadInt64NotRootString",
@@ -486,7 +486,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a,string"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 
 		// HeadInt64PtrNotRoot
@@ -498,7 +498,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A *int64 `json:"a"`
-			}{int64ptr(1)}},
+			}{int64ptr(-1)}},
 		},
 		{
 			name: "HeadInt64PtrNotRootOmitEmpty",
@@ -508,7 +508,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A *int64 `json:"a,omitempty"`
-			}{int64ptr(1)}},
+			}{int64ptr(-1)}},
 		},
 		{
 			name: "HeadInt64PtrNotRootString",
@@ -518,7 +518,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A *int64 `json:"a,string"`
-			}{int64ptr(1)}},
+			}{int64ptr(-1)}},
 		},
 
 		// HeadInt64PtrNilNotRoot
@@ -588,7 +588,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int64 `json:"a"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadInt64NotRootOmitEmpty",
@@ -598,7 +598,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int64 `json:"a,omitempty"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadInt64NotRootString",
@@ -608,7 +608,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int64 `json:"a,string"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 
 		// PtrHeadInt64PtrNotRoot
@@ -620,7 +620,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int64 `json:"a"`
-			}{A: int64ptr(1)})},
+			}{A: int64ptr(-1)})},
 		},
 		{
 			name: "PtrHeadInt64PtrNotRootOmitEmpty",
@@ -630,7 +630,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int64 `json:"a,omitempty"`
-			}{A: int64ptr(1)})},
+			}{A: int64ptr(-1)})},
 		},
 		{
 			name: "PtrHeadInt64PtrNotRootString",
@@ -640,7 +640,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int64 `json:"a,string"`
-			}{A: int64ptr(1)})},
+			}{A: int64ptr(-1)})},
 		},
 
 		// PtrHeadInt64PtrNilNotRoot
@@ -748,7 +748,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int64 `json:"b"`
 			}{B: 2}},
 		},
@@ -763,7 +763,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int64 `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -778,7 +778,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int64 `json:"b,string"`
 			}{B: 2}},
 		},
@@ -795,7 +795,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A *int64 `json:"a"`
-			}{A: int64ptr(1)}, B: struct {
+			}{A: int64ptr(-1)}, B: struct {
 				B *int64 `json:"b"`
 			}{B: int64ptr(2)}},
 		},
@@ -810,7 +810,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A *int64 `json:"a,omitempty"`
-			}{A: int64ptr(1)}, B: struct {
+			}{A: int64ptr(-1)}, B: struct {
 				B *int64 `json:"b,omitempty"`
 			}{B: int64ptr(2)}},
 		},
@@ -825,7 +825,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A *int64 `json:"a,string"`
-			}{A: int64ptr(1)}, B: struct {
+			}{A: int64ptr(-1)}, B: struct {
 				B *int64 `json:"b,string"`
 			}{B: int64ptr(2)}},
 		},
@@ -924,7 +924,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int64 `json:"b"`
 			}{B: 2}},
 		},
@@ -939,7 +939,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int64 `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -954,7 +954,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: struct {
 				A int64 `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int64 `json:"b,string"`
 			}{B: 2}},
 		},
@@ -971,7 +971,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int64 `json:"a"`
-			}{A: int64ptr(1)}), B: &(struct {
+			}{A: int64ptr(-1)}), B: &(struct {
 				B *int64 `json:"b"`
 			}{B: int64ptr(2)})},
 		},
@@ -986,7 +986,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int64 `json:"a,omitempty"`
-			}{A: int64ptr(1)}), B: &(struct {
+			}{A: int64ptr(-1)}), B: &(struct {
 				B *int64 `json:"b,omitempty"`
 			}{B: int64ptr(2)})},
 		},
@@ -1001,7 +1001,7 @@ func TestCoverInt64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int64 `json:"a,string"`
-			}{A: int64ptr(1)}), B: &(struct {
+			}{A: int64ptr(-1)}), B: &(struct {
 				B *int64 `json:"b,string"`
 			}{B: int64ptr(2)})},
 		},
@@ -1091,7 +1091,7 @@ func TestCoverInt64(t *testing.T) {
 			}{A: &(struct {
 				A int64 `json:"a"`
 				B int64 `json:"b"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int64 `json:"a"`
 				B int64 `json:"b"`
 			}{A: 3, B: 4})},
@@ -1110,7 +1110,7 @@ func TestCoverInt64(t *testing.T) {
 			}{A: &(struct {
 				A int64 `json:"a,omitempty"`
 				B int64 `json:"b,omitempty"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int64 `json:"a,omitempty"`
 				B int64 `json:"b,omitempty"`
 			}{A: 3, B: 4})},
@@ -1129,7 +1129,7 @@ func TestCoverInt64(t *testing.T) {
 			}{A: &(struct {
 				A int64 `json:"a,string"`
 				B int64 `json:"b,string"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int64 `json:"a,string"`
 				B int64 `json:"b,string"`
 			}{A: 3, B: 4})},
@@ -1232,7 +1232,7 @@ func TestCoverInt64(t *testing.T) {
 			}{A: &(struct {
 				A *int64 `json:"a"`
 				B *int64 `json:"b"`
-			}{A: int64ptr(1), B: int64ptr(2)}), B: &(struct {
+			}{A: int64ptr(-1), B: int64ptr(2)}), B: &(struct {
 				A *int64 `json:"a"`
 				B *int64 `json:"b"`
 			}{A: int64ptr(3), B: int64ptr(4)})},
@@ -1251,7 +1251,7 @@ func TestCoverInt64(t *testing.T) {
 			}{A: &(struct {
 				A *int64 `json:"a,omitempty"`
 				B *int64 `json:"b,omitempty"`
-			}{A: int64ptr(1), B: int64ptr(2)}), B: &(struct {
+			}{A: int64ptr(-1), B: int64ptr(2)}), B: &(struct {
 				A *int64 `json:"a,omitempty"`
 				B *int64 `json:"b,omitempty"`
 			}{A: int64ptr(3), B: int64ptr(4)})},
@@ -1270,7 +1270,7 @@ func TestCoverInt64(t *testing.T) {
 			}{A: &(struct {
 				A *int64 `json:"a,string"`
 				B *int64 `json:"b,string"`
-			}{A: int64ptr(1), B: int64ptr(2)}), B: &(struct {
+			}{A: int64ptr(-1), B: int64ptr(2)}), B: &(struct {
 				A *int64 `json:"a,string"`
 				B *int64 `json:"b,string"`
 			}{A: int64ptr(3), B: int64ptr(4)})},
@@ -1365,7 +1365,7 @@ func TestCoverInt64(t *testing.T) {
 				structInt64
 				B int64 `json:"b"`
 			}{
-				structInt64: structInt64{A: 1},
+				structInt64: structInt64{A: -1},
 				B:           2,
 			},
 		},
@@ -1375,7 +1375,7 @@ func TestCoverInt64(t *testing.T) {
 				structInt64OmitEmpty
 				B int64 `json:"b,omitempty"`
 			}{
-				structInt64OmitEmpty: structInt64OmitEmpty{A: 1},
+				structInt64OmitEmpty: structInt64OmitEmpty{A: -1},
 				B:                    2,
 			},
 		},
@@ -1385,7 +1385,7 @@ func TestCoverInt64(t *testing.T) {
 				structInt64String
 				B int64 `json:"b,string"`
 			}{
-				structInt64String: structInt64String{A: 1},
+				structInt64String: structInt64String{A: -1},
 				B:                 2,
 			},
 		},
@@ -1397,7 +1397,7 @@ func TestCoverInt64(t *testing.T) {
 				*structInt64
 				B int64 `json:"b"`
 			}{
-				structInt64: &structInt64{A: 1},
+				structInt64: &structInt64{A: -1},
 				B:           2,
 			},
 		},
@@ -1407,7 +1407,7 @@ func TestCoverInt64(t *testing.T) {
 				*structInt64OmitEmpty
 				B int64 `json:"b,omitempty"`
 			}{
-				structInt64OmitEmpty: &structInt64OmitEmpty{A: 1},
+				structInt64OmitEmpty: &structInt64OmitEmpty{A: -1},
 				B:                    2,
 			},
 		},
@@ -1417,7 +1417,7 @@ func TestCoverInt64(t *testing.T) {
 				*structInt64String
 				B int64 `json:"b,string"`
 			}{
-				structInt64String: &structInt64String{A: 1},
+				structInt64String: &structInt64String{A: -1},
 				B:                 2,
 			},
 		},
@@ -1461,7 +1461,7 @@ func TestCoverInt64(t *testing.T) {
 				structInt64Ptr
 				B *int64 `json:"b"`
 			}{
-				structInt64Ptr: structInt64Ptr{A: int64ptr(1)},
+				structInt64Ptr: structInt64Ptr{A: int64ptr(-1)},
 				B:              int64ptr(2),
 			},
 		},
@@ -1471,7 +1471,7 @@ func TestCoverInt64(t *testing.T) {
 				structInt64PtrOmitEmpty
 				B *int64 `json:"b,omitempty"`
 			}{
-				structInt64PtrOmitEmpty: structInt64PtrOmitEmpty{A: int64ptr(1)},
+				structInt64PtrOmitEmpty: structInt64PtrOmitEmpty{A: int64ptr(-1)},
 				B:                       int64ptr(2),
 			},
 		},
@@ -1481,7 +1481,7 @@ func TestCoverInt64(t *testing.T) {
 				structInt64PtrString
 				B *int64 `json:"b,string"`
 			}{
-				structInt64PtrString: structInt64PtrString{A: int64ptr(1)},
+				structInt64PtrString: structInt64PtrString{A: int64ptr(-1)},
 				B:                    int64ptr(2),
 			},
 		},
@@ -1525,7 +1525,7 @@ func TestCoverInt64(t *testing.T) {
 				*structInt64Ptr
 				B *int64 `json:"b"`
 			}{
-				structInt64Ptr: &structInt64Ptr{A: int64ptr(1)},
+				structInt64Ptr: &structInt64Ptr{A: int64ptr(-1)},
 				B:              int64ptr(2),
 			},
 		},
@@ -1535,7 +1535,7 @@ func TestCoverInt64(t *testing.T) {
 				*structInt64PtrOmitEmpty
 				B *int64 `json:"b,omitempty"`
 			}{
-				structInt64PtrOmitEmpty: &structInt64PtrOmitEmpty{A: int64ptr(1)},
+				structInt64PtrOmitEmpty: &structInt64PtrOmitEmpty{A: int64ptr(-1)},
 				B:                       int64ptr(2),
 			},
 		},
@@ -1545,7 +1545,7 @@ func TestCoverInt64(t *testing.T) {
 				*structInt64PtrString
 				B *int64 `json:"b,string"`
 			}{
-				structInt64PtrString: &structInt64PtrString{A: int64ptr(1)},
+				structInt64PtrString: &structInt64PtrString{A: int64ptr(-1)},
 				B:                    int64ptr(2),
 			},
 		},
@@ -1588,7 +1588,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				structInt64
 			}{
-				structInt64: structInt64{A: 1},
+				structInt64: structInt64{A: -1},
 			},
 		},
 		{
@@ -1596,7 +1596,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				structInt64OmitEmpty
 			}{
-				structInt64OmitEmpty: structInt64OmitEmpty{A: 1},
+				structInt64OmitEmpty: structInt64OmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1604,7 +1604,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				structInt64String
 			}{
-				structInt64String: structInt64String{A: 1},
+				structInt64String: structInt64String{A: -1},
 			},
 		},
 
@@ -1614,7 +1614,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				*structInt64
 			}{
-				structInt64: &structInt64{A: 1},
+				structInt64: &structInt64{A: -1},
 			},
 		},
 		{
@@ -1622,7 +1622,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				*structInt64OmitEmpty
 			}{
-				structInt64OmitEmpty: &structInt64OmitEmpty{A: 1},
+				structInt64OmitEmpty: &structInt64OmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1630,7 +1630,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				*structInt64String
 			}{
-				structInt64String: &structInt64String{A: 1},
+				structInt64String: &structInt64String{A: -1},
 			},
 		},
 
@@ -1666,7 +1666,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				structInt64Ptr
 			}{
-				structInt64Ptr: structInt64Ptr{A: int64ptr(1)},
+				structInt64Ptr: structInt64Ptr{A: int64ptr(-1)},
 			},
 		},
 		{
@@ -1674,7 +1674,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				structInt64PtrOmitEmpty
 			}{
-				structInt64PtrOmitEmpty: structInt64PtrOmitEmpty{A: int64ptr(1)},
+				structInt64PtrOmitEmpty: structInt64PtrOmitEmpty{A: int64ptr(-1)},
 			},
 		},
 		{
@@ -1682,7 +1682,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				structInt64PtrString
 			}{
-				structInt64PtrString: structInt64PtrString{A: int64ptr(1)},
+				structInt64PtrString: structInt64PtrString{A: int64ptr(-1)},
 			},
 		},
 
@@ -1718,7 +1718,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				*structInt64Ptr
 			}{
-				structInt64Ptr: &structInt64Ptr{A: int64ptr(1)},
+				structInt64Ptr: &structInt64Ptr{A: int64ptr(-1)},
 			},
 		},
 		{
@@ -1726,7 +1726,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				*structInt64PtrOmitEmpty
 			}{
-				structInt64PtrOmitEmpty: &structInt64PtrOmitEmpty{A: int64ptr(1)},
+				structInt64PtrOmitEmpty: &structInt64PtrOmitEmpty{A: int64ptr(-1)},
 			},
 		},
 		{
@@ -1734,7 +1734,7 @@ func TestCoverInt64(t *testing.T) {
 			data: struct {
 				*structInt64PtrString
 			}{
-				structInt64PtrString: &structInt64PtrString{A: int64ptr(1)},
+				structInt64PtrString: &structInt64PtrString{A: int64ptr(-1)},
 			},
 		},
 

--- a/cover_int8_test.go
+++ b/cover_int8_test.go
@@ -57,19 +57,19 @@ func TestCoverInt8(t *testing.T) {
 			name: "HeadInt8",
 			data: struct {
 				A int8 `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadInt8OmitEmpty",
 			data: struct {
 				A int8 `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadInt8String",
 			data: struct {
 				A int8 `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// HeadInt8Ptr
@@ -77,19 +77,19 @@ func TestCoverInt8(t *testing.T) {
 			name: "HeadInt8Ptr",
 			data: struct {
 				A *int8 `json:"a"`
-			}{A: int8ptr(1)},
+			}{A: int8ptr(-1)},
 		},
 		{
 			name: "HeadInt8PtrOmitEmpty",
 			data: struct {
 				A *int8 `json:"a,omitempty"`
-			}{A: int8ptr(1)},
+			}{A: int8ptr(-1)},
 		},
 		{
 			name: "HeadInt8PtrString",
 			data: struct {
 				A *int8 `json:"a,string"`
-			}{A: int8ptr(1)},
+			}{A: int8ptr(-1)},
 		},
 
 		// HeadInt8PtrNil
@@ -137,19 +137,19 @@ func TestCoverInt8(t *testing.T) {
 			name: "PtrHeadInt8",
 			data: &struct {
 				A int8 `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadInt8OmitEmpty",
 			data: &struct {
 				A int8 `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadInt8String",
 			data: &struct {
 				A int8 `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// PtrHeadInt8Ptr
@@ -157,19 +157,19 @@ func TestCoverInt8(t *testing.T) {
 			name: "PtrHeadInt8Ptr",
 			data: &struct {
 				A *int8 `json:"a"`
-			}{A: int8ptr(1)},
+			}{A: int8ptr(-1)},
 		},
 		{
 			name: "PtrHeadInt8PtrOmitEmpty",
 			data: &struct {
 				A *int8 `json:"a,omitempty"`
-			}{A: int8ptr(1)},
+			}{A: int8ptr(-1)},
 		},
 		{
 			name: "PtrHeadInt8PtrString",
 			data: &struct {
 				A *int8 `json:"a,string"`
-			}{A: int8ptr(1)},
+			}{A: int8ptr(-1)},
 		},
 
 		// PtrHeadInt8PtrNil
@@ -245,7 +245,7 @@ func TestCoverInt8(t *testing.T) {
 				A int8 `json:"a"`
 				B int8 `json:"b"`
 				C int8 `json:"c"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadInt8MultiFieldsOmitEmpty",
@@ -253,7 +253,7 @@ func TestCoverInt8(t *testing.T) {
 				A int8 `json:"a,omitempty"`
 				B int8 `json:"b,omitempty"`
 				C int8 `json:"c,omitempty"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadInt8MultiFieldsString",
@@ -261,7 +261,7 @@ func TestCoverInt8(t *testing.T) {
 				A int8 `json:"a,string"`
 				B int8 `json:"b,string"`
 				C int8 `json:"c,string"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 
 		// HeadInt8PtrMultiFields
@@ -271,7 +271,7 @@ func TestCoverInt8(t *testing.T) {
 				A *int8 `json:"a"`
 				B *int8 `json:"b"`
 				C *int8 `json:"c"`
-			}{A: int8ptr(1), B: int8ptr(2), C: int8ptr(3)},
+			}{A: int8ptr(-1), B: int8ptr(2), C: int8ptr(3)},
 		},
 		{
 			name: "HeadInt8PtrMultiFieldsOmitEmpty",
@@ -279,7 +279,7 @@ func TestCoverInt8(t *testing.T) {
 				A *int8 `json:"a,omitempty"`
 				B *int8 `json:"b,omitempty"`
 				C *int8 `json:"c,omitempty"`
-			}{A: int8ptr(1), B: int8ptr(2), C: int8ptr(3)},
+			}{A: int8ptr(-1), B: int8ptr(2), C: int8ptr(3)},
 		},
 		{
 			name: "HeadInt8PtrMultiFieldsString",
@@ -287,7 +287,7 @@ func TestCoverInt8(t *testing.T) {
 				A *int8 `json:"a,string"`
 				B *int8 `json:"b,string"`
 				C *int8 `json:"c,string"`
-			}{A: int8ptr(1), B: int8ptr(2), C: int8ptr(3)},
+			}{A: int8ptr(-1), B: int8ptr(2), C: int8ptr(3)},
 		},
 
 		// HeadInt8PtrNilMultiFields
@@ -345,21 +345,21 @@ func TestCoverInt8(t *testing.T) {
 			data: &struct {
 				A int8 `json:"a"`
 				B int8 `json:"b"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadInt8MultiFieldsOmitEmpty",
 			data: &struct {
 				A int8 `json:"a,omitempty"`
 				B int8 `json:"b,omitempty"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadInt8MultiFieldsString",
 			data: &struct {
 				A int8 `json:"a,string"`
 				B int8 `json:"b,string"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 
 		// PtrHeadInt8PtrMultiFields
@@ -368,21 +368,21 @@ func TestCoverInt8(t *testing.T) {
 			data: &struct {
 				A *int8 `json:"a"`
 				B *int8 `json:"b"`
-			}{A: int8ptr(1), B: int8ptr(2)},
+			}{A: int8ptr(-1), B: int8ptr(2)},
 		},
 		{
 			name: "PtrHeadInt8PtrMultiFieldsOmitEmpty",
 			data: &struct {
 				A *int8 `json:"a,omitempty"`
 				B *int8 `json:"b,omitempty"`
-			}{A: int8ptr(1), B: int8ptr(2)},
+			}{A: int8ptr(-1), B: int8ptr(2)},
 		},
 		{
 			name: "PtrHeadInt8PtrMultiFieldsString",
 			data: &struct {
 				A *int8 `json:"a,string"`
 				B *int8 `json:"b,string"`
-			}{A: int8ptr(1), B: int8ptr(2)},
+			}{A: int8ptr(-1), B: int8ptr(2)},
 		},
 
 		// PtrHeadInt8PtrNilMultiFields
@@ -466,7 +466,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadInt8NotRootOmitEmpty",
@@ -476,7 +476,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a,omitempty"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadInt8NotRootString",
@@ -486,7 +486,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a,string"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 
 		// HeadInt8PtrNotRoot
@@ -498,7 +498,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A *int8 `json:"a"`
-			}{int8ptr(1)}},
+			}{int8ptr(-1)}},
 		},
 		{
 			name: "HeadInt8PtrNotRootOmitEmpty",
@@ -508,7 +508,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A *int8 `json:"a,omitempty"`
-			}{int8ptr(1)}},
+			}{int8ptr(-1)}},
 		},
 		{
 			name: "HeadInt8PtrNotRootString",
@@ -518,7 +518,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A *int8 `json:"a,string"`
-			}{int8ptr(1)}},
+			}{int8ptr(-1)}},
 		},
 
 		// HeadInt8PtrNilNotRoot
@@ -588,7 +588,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int8 `json:"a"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadInt8NotRootOmitEmpty",
@@ -598,7 +598,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int8 `json:"a,omitempty"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadInt8NotRootString",
@@ -608,7 +608,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int8 `json:"a,string"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 
 		// PtrHeadInt8PtrNotRoot
@@ -620,7 +620,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int8 `json:"a"`
-			}{A: int8ptr(1)})},
+			}{A: int8ptr(-1)})},
 		},
 		{
 			name: "PtrHeadInt8PtrNotRootOmitEmpty",
@@ -630,7 +630,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int8 `json:"a,omitempty"`
-			}{A: int8ptr(1)})},
+			}{A: int8ptr(-1)})},
 		},
 		{
 			name: "PtrHeadInt8PtrNotRootString",
@@ -640,7 +640,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int8 `json:"a,string"`
-			}{A: int8ptr(1)})},
+			}{A: int8ptr(-1)})},
 		},
 
 		// PtrHeadInt8PtrNilNotRoot
@@ -748,7 +748,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int8 `json:"b"`
 			}{B: 2}},
 		},
@@ -763,7 +763,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int8 `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -778,7 +778,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int8 `json:"b,string"`
 			}{B: 2}},
 		},
@@ -795,7 +795,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A *int8 `json:"a"`
-			}{A: int8ptr(1)}, B: struct {
+			}{A: int8ptr(-1)}, B: struct {
 				B *int8 `json:"b"`
 			}{B: int8ptr(2)}},
 		},
@@ -810,7 +810,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A *int8 `json:"a,omitempty"`
-			}{A: int8ptr(1)}, B: struct {
+			}{A: int8ptr(-1)}, B: struct {
 				B *int8 `json:"b,omitempty"`
 			}{B: int8ptr(2)}},
 		},
@@ -825,7 +825,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A *int8 `json:"a,string"`
-			}{A: int8ptr(1)}, B: struct {
+			}{A: int8ptr(-1)}, B: struct {
 				B *int8 `json:"b,string"`
 			}{B: int8ptr(2)}},
 		},
@@ -924,7 +924,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int8 `json:"b"`
 			}{B: 2}},
 		},
@@ -939,7 +939,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int8 `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -954,7 +954,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: struct {
 				A int8 `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int8 `json:"b,string"`
 			}{B: 2}},
 		},
@@ -971,7 +971,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int8 `json:"a"`
-			}{A: int8ptr(1)}), B: &(struct {
+			}{A: int8ptr(-1)}), B: &(struct {
 				B *int8 `json:"b"`
 			}{B: int8ptr(2)})},
 		},
@@ -986,7 +986,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int8 `json:"a,omitempty"`
-			}{A: int8ptr(1)}), B: &(struct {
+			}{A: int8ptr(-1)}), B: &(struct {
 				B *int8 `json:"b,omitempty"`
 			}{B: int8ptr(2)})},
 		},
@@ -1001,7 +1001,7 @@ func TestCoverInt8(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int8 `json:"a,string"`
-			}{A: int8ptr(1)}), B: &(struct {
+			}{A: int8ptr(-1)}), B: &(struct {
 				B *int8 `json:"b,string"`
 			}{B: int8ptr(2)})},
 		},
@@ -1091,7 +1091,7 @@ func TestCoverInt8(t *testing.T) {
 			}{A: &(struct {
 				A int8 `json:"a"`
 				B int8 `json:"b"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int8 `json:"a"`
 				B int8 `json:"b"`
 			}{A: 3, B: 4})},
@@ -1110,7 +1110,7 @@ func TestCoverInt8(t *testing.T) {
 			}{A: &(struct {
 				A int8 `json:"a,omitempty"`
 				B int8 `json:"b,omitempty"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int8 `json:"a,omitempty"`
 				B int8 `json:"b,omitempty"`
 			}{A: 3, B: 4})},
@@ -1129,7 +1129,7 @@ func TestCoverInt8(t *testing.T) {
 			}{A: &(struct {
 				A int8 `json:"a,string"`
 				B int8 `json:"b,string"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int8 `json:"a,string"`
 				B int8 `json:"b,string"`
 			}{A: 3, B: 4})},
@@ -1232,7 +1232,7 @@ func TestCoverInt8(t *testing.T) {
 			}{A: &(struct {
 				A *int8 `json:"a"`
 				B *int8 `json:"b"`
-			}{A: int8ptr(1), B: int8ptr(2)}), B: &(struct {
+			}{A: int8ptr(-1), B: int8ptr(2)}), B: &(struct {
 				A *int8 `json:"a"`
 				B *int8 `json:"b"`
 			}{A: int8ptr(3), B: int8ptr(4)})},
@@ -1251,7 +1251,7 @@ func TestCoverInt8(t *testing.T) {
 			}{A: &(struct {
 				A *int8 `json:"a,omitempty"`
 				B *int8 `json:"b,omitempty"`
-			}{A: int8ptr(1), B: int8ptr(2)}), B: &(struct {
+			}{A: int8ptr(-1), B: int8ptr(2)}), B: &(struct {
 				A *int8 `json:"a,omitempty"`
 				B *int8 `json:"b,omitempty"`
 			}{A: int8ptr(3), B: int8ptr(4)})},
@@ -1270,7 +1270,7 @@ func TestCoverInt8(t *testing.T) {
 			}{A: &(struct {
 				A *int8 `json:"a,string"`
 				B *int8 `json:"b,string"`
-			}{A: int8ptr(1), B: int8ptr(2)}), B: &(struct {
+			}{A: int8ptr(-1), B: int8ptr(2)}), B: &(struct {
 				A *int8 `json:"a,string"`
 				B *int8 `json:"b,string"`
 			}{A: int8ptr(3), B: int8ptr(4)})},
@@ -1365,7 +1365,7 @@ func TestCoverInt8(t *testing.T) {
 				structInt8
 				B int8 `json:"b"`
 			}{
-				structInt8: structInt8{A: 1},
+				structInt8: structInt8{A: -1},
 				B:          2,
 			},
 		},
@@ -1375,7 +1375,7 @@ func TestCoverInt8(t *testing.T) {
 				structInt8OmitEmpty
 				B int8 `json:"b,omitempty"`
 			}{
-				structInt8OmitEmpty: structInt8OmitEmpty{A: 1},
+				structInt8OmitEmpty: structInt8OmitEmpty{A: -1},
 				B:                   2,
 			},
 		},
@@ -1385,7 +1385,7 @@ func TestCoverInt8(t *testing.T) {
 				structInt8String
 				B int8 `json:"b,string"`
 			}{
-				structInt8String: structInt8String{A: 1},
+				structInt8String: structInt8String{A: -1},
 				B:                2,
 			},
 		},
@@ -1397,7 +1397,7 @@ func TestCoverInt8(t *testing.T) {
 				*structInt8
 				B int8 `json:"b"`
 			}{
-				structInt8: &structInt8{A: 1},
+				structInt8: &structInt8{A: -1},
 				B:          2,
 			},
 		},
@@ -1407,7 +1407,7 @@ func TestCoverInt8(t *testing.T) {
 				*structInt8OmitEmpty
 				B int8 `json:"b,omitempty"`
 			}{
-				structInt8OmitEmpty: &structInt8OmitEmpty{A: 1},
+				structInt8OmitEmpty: &structInt8OmitEmpty{A: -1},
 				B:                   2,
 			},
 		},
@@ -1417,7 +1417,7 @@ func TestCoverInt8(t *testing.T) {
 				*structInt8String
 				B int8 `json:"b,string"`
 			}{
-				structInt8String: &structInt8String{A: 1},
+				structInt8String: &structInt8String{A: -1},
 				B:                2,
 			},
 		},
@@ -1461,7 +1461,7 @@ func TestCoverInt8(t *testing.T) {
 				structInt8Ptr
 				B *int8 `json:"b"`
 			}{
-				structInt8Ptr: structInt8Ptr{A: int8ptr(1)},
+				structInt8Ptr: structInt8Ptr{A: int8ptr(-1)},
 				B:             int8ptr(2),
 			},
 		},
@@ -1471,7 +1471,7 @@ func TestCoverInt8(t *testing.T) {
 				structInt8PtrOmitEmpty
 				B *int8 `json:"b,omitempty"`
 			}{
-				structInt8PtrOmitEmpty: structInt8PtrOmitEmpty{A: int8ptr(1)},
+				structInt8PtrOmitEmpty: structInt8PtrOmitEmpty{A: int8ptr(-1)},
 				B:                      int8ptr(2),
 			},
 		},
@@ -1481,7 +1481,7 @@ func TestCoverInt8(t *testing.T) {
 				structInt8PtrString
 				B *int8 `json:"b,string"`
 			}{
-				structInt8PtrString: structInt8PtrString{A: int8ptr(1)},
+				structInt8PtrString: structInt8PtrString{A: int8ptr(-1)},
 				B:                   int8ptr(2),
 			},
 		},
@@ -1525,7 +1525,7 @@ func TestCoverInt8(t *testing.T) {
 				*structInt8Ptr
 				B *int8 `json:"b"`
 			}{
-				structInt8Ptr: &structInt8Ptr{A: int8ptr(1)},
+				structInt8Ptr: &structInt8Ptr{A: int8ptr(-1)},
 				B:             int8ptr(2),
 			},
 		},
@@ -1535,7 +1535,7 @@ func TestCoverInt8(t *testing.T) {
 				*structInt8PtrOmitEmpty
 				B *int8 `json:"b,omitempty"`
 			}{
-				structInt8PtrOmitEmpty: &structInt8PtrOmitEmpty{A: int8ptr(1)},
+				structInt8PtrOmitEmpty: &structInt8PtrOmitEmpty{A: int8ptr(-1)},
 				B:                      int8ptr(2),
 			},
 		},
@@ -1545,7 +1545,7 @@ func TestCoverInt8(t *testing.T) {
 				*structInt8PtrString
 				B *int8 `json:"b,string"`
 			}{
-				structInt8PtrString: &structInt8PtrString{A: int8ptr(1)},
+				structInt8PtrString: &structInt8PtrString{A: int8ptr(-1)},
 				B:                   int8ptr(2),
 			},
 		},
@@ -1588,7 +1588,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				structInt8
 			}{
-				structInt8: structInt8{A: 1},
+				structInt8: structInt8{A: -1},
 			},
 		},
 		{
@@ -1596,7 +1596,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				structInt8OmitEmpty
 			}{
-				structInt8OmitEmpty: structInt8OmitEmpty{A: 1},
+				structInt8OmitEmpty: structInt8OmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1604,7 +1604,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				structInt8String
 			}{
-				structInt8String: structInt8String{A: 1},
+				structInt8String: structInt8String{A: -1},
 			},
 		},
 
@@ -1614,7 +1614,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				*structInt8
 			}{
-				structInt8: &structInt8{A: 1},
+				structInt8: &structInt8{A: -1},
 			},
 		},
 		{
@@ -1622,7 +1622,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				*structInt8OmitEmpty
 			}{
-				structInt8OmitEmpty: &structInt8OmitEmpty{A: 1},
+				structInt8OmitEmpty: &structInt8OmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1630,7 +1630,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				*structInt8String
 			}{
-				structInt8String: &structInt8String{A: 1},
+				structInt8String: &structInt8String{A: -1},
 			},
 		},
 
@@ -1666,7 +1666,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				structInt8Ptr
 			}{
-				structInt8Ptr: structInt8Ptr{A: int8ptr(1)},
+				structInt8Ptr: structInt8Ptr{A: int8ptr(-1)},
 			},
 		},
 		{
@@ -1674,7 +1674,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				structInt8PtrOmitEmpty
 			}{
-				structInt8PtrOmitEmpty: structInt8PtrOmitEmpty{A: int8ptr(1)},
+				structInt8PtrOmitEmpty: structInt8PtrOmitEmpty{A: int8ptr(-1)},
 			},
 		},
 		{
@@ -1682,7 +1682,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				structInt8PtrString
 			}{
-				structInt8PtrString: structInt8PtrString{A: int8ptr(1)},
+				structInt8PtrString: structInt8PtrString{A: int8ptr(-1)},
 			},
 		},
 
@@ -1718,7 +1718,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				*structInt8Ptr
 			}{
-				structInt8Ptr: &structInt8Ptr{A: int8ptr(1)},
+				structInt8Ptr: &structInt8Ptr{A: int8ptr(-1)},
 			},
 		},
 		{
@@ -1726,7 +1726,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				*structInt8PtrOmitEmpty
 			}{
-				structInt8PtrOmitEmpty: &structInt8PtrOmitEmpty{A: int8ptr(1)},
+				structInt8PtrOmitEmpty: &structInt8PtrOmitEmpty{A: int8ptr(-1)},
 			},
 		},
 		{
@@ -1734,7 +1734,7 @@ func TestCoverInt8(t *testing.T) {
 			data: struct {
 				*structInt8PtrString
 			}{
-				structInt8PtrString: &structInt8PtrString{A: int8ptr(1)},
+				structInt8PtrString: &structInt8PtrString{A: int8ptr(-1)},
 			},
 		},
 

--- a/cover_int_test.go
+++ b/cover_int_test.go
@@ -57,19 +57,19 @@ func TestCoverInt(t *testing.T) {
 			name: "HeadInt",
 			data: struct {
 				A int `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadIntOmitEmpty",
 			data: struct {
 				A int `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "HeadIntString",
 			data: struct {
 				A int `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// HeadIntPtr
@@ -77,19 +77,19 @@ func TestCoverInt(t *testing.T) {
 			name: "HeadIntPtr",
 			data: struct {
 				A *int `json:"a"`
-			}{A: intptr(1)},
+			}{A: intptr(-1)},
 		},
 		{
 			name: "HeadIntPtrOmitEmpty",
 			data: struct {
 				A *int `json:"a,omitempty"`
-			}{A: intptr(1)},
+			}{A: intptr(-1)},
 		},
 		{
 			name: "HeadIntPtrString",
 			data: struct {
 				A *int `json:"a,string"`
-			}{A: intptr(1)},
+			}{A: intptr(-1)},
 		},
 
 		// HeadIntPtrNil
@@ -137,19 +137,19 @@ func TestCoverInt(t *testing.T) {
 			name: "PtrHeadInt",
 			data: &struct {
 				A int `json:"a"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadIntOmitEmpty",
 			data: &struct {
 				A int `json:"a,omitempty"`
-			}{A: 1},
+			}{A: -1},
 		},
 		{
 			name: "PtrHeadIntString",
 			data: &struct {
 				A int `json:"a,string"`
-			}{A: 1},
+			}{A: -1},
 		},
 
 		// PtrHeadIntPtr
@@ -157,19 +157,19 @@ func TestCoverInt(t *testing.T) {
 			name: "PtrHeadIntPtr",
 			data: &struct {
 				A *int `json:"a"`
-			}{A: intptr(1)},
+			}{A: intptr(-1)},
 		},
 		{
 			name: "PtrHeadIntPtrOmitEmpty",
 			data: &struct {
 				A *int `json:"a,omitempty"`
-			}{A: intptr(1)},
+			}{A: intptr(-1)},
 		},
 		{
 			name: "PtrHeadIntPtrString",
 			data: &struct {
 				A *int `json:"a,string"`
-			}{A: intptr(1)},
+			}{A: intptr(-1)},
 		},
 
 		// PtrHeadIntPtrNil
@@ -245,7 +245,7 @@ func TestCoverInt(t *testing.T) {
 				A int `json:"a"`
 				B int `json:"b"`
 				C int `json:"c"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadIntMultiFieldsOmitEmpty",
@@ -253,7 +253,7 @@ func TestCoverInt(t *testing.T) {
 				A int `json:"a,omitempty"`
 				B int `json:"b,omitempty"`
 				C int `json:"c,omitempty"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 		{
 			name: "HeadIntMultiFieldsString",
@@ -261,7 +261,7 @@ func TestCoverInt(t *testing.T) {
 				A int `json:"a,string"`
 				B int `json:"b,string"`
 				C int `json:"c,string"`
-			}{A: 1, B: 2, C: 3},
+			}{A: -1, B: 2, C: 3},
 		},
 
 		// HeadIntPtrMultiFields
@@ -271,7 +271,7 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a"`
 				B *int `json:"b"`
 				C *int `json:"c"`
-			}{A: intptr(1), B: intptr(2), C: intptr(3)},
+			}{A: intptr(-1), B: intptr(2), C: intptr(3)},
 		},
 		{
 			name: "HeadIntPtrMultiFieldsOmitEmpty",
@@ -279,7 +279,7 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,omitempty"`
 				B *int `json:"b,omitempty"`
 				C *int `json:"c,omitempty"`
-			}{A: intptr(1), B: intptr(2), C: intptr(3)},
+			}{A: intptr(-1), B: intptr(2), C: intptr(3)},
 		},
 		{
 			name: "HeadIntPtrMultiFieldsString",
@@ -287,7 +287,7 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
 				C *int `json:"c,string"`
-			}{A: intptr(1), B: intptr(2), C: intptr(3)},
+			}{A: intptr(-1), B: intptr(2), C: intptr(3)},
 		},
 
 		// HeadIntPtrNilMultiFields
@@ -345,21 +345,21 @@ func TestCoverInt(t *testing.T) {
 			data: &struct {
 				A int `json:"a"`
 				B int `json:"b"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadIntMultiFieldsOmitEmpty",
 			data: &struct {
 				A int `json:"a,omitempty"`
 				B int `json:"b,omitempty"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 		{
 			name: "PtrHeadIntMultiFieldsString",
 			data: &struct {
 				A int `json:"a,string"`
 				B int `json:"b,string"`
-			}{A: 1, B: 2},
+			}{A: -1, B: 2},
 		},
 
 		// PtrHeadIntPtrMultiFields
@@ -368,21 +368,21 @@ func TestCoverInt(t *testing.T) {
 			data: &struct {
 				A *int `json:"a"`
 				B *int `json:"b"`
-			}{A: intptr(1), B: intptr(2)},
+			}{A: intptr(-1), B: intptr(2)},
 		},
 		{
 			name: "PtrHeadIntPtrMultiFieldsOmitEmpty",
 			data: &struct {
 				A *int `json:"a,omitempty"`
 				B *int `json:"b,omitempty"`
-			}{A: intptr(1), B: intptr(2)},
+			}{A: intptr(-1), B: intptr(2)},
 		},
 		{
 			name: "PtrHeadIntPtrMultiFieldsString",
 			data: &struct {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
-			}{A: intptr(1), B: intptr(2)},
+			}{A: intptr(-1), B: intptr(2)},
 		},
 
 		// PtrHeadIntPtrNilMultiFields
@@ -466,7 +466,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadIntNotRootOmitEmpty",
@@ -476,7 +476,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a,omitempty"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 		{
 			name: "HeadIntNotRootString",
@@ -486,7 +486,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a,string"`
-			}{A: 1}},
+			}{A: -1}},
 		},
 
 		// HeadIntPtrNotRoot
@@ -498,7 +498,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A *int `json:"a"`
-			}{intptr(1)}},
+			}{intptr(-1)}},
 		},
 		{
 			name: "HeadIntPtrNotRootOmitEmpty",
@@ -508,7 +508,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A *int `json:"a,omitempty"`
-			}{intptr(1)}},
+			}{intptr(-1)}},
 		},
 		{
 			name: "HeadIntPtrNotRootString",
@@ -518,7 +518,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A *int `json:"a,string"`
-			}{intptr(1)}},
+			}{intptr(-1)}},
 		},
 
 		// HeadIntPtrNilNotRoot
@@ -588,7 +588,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int `json:"a"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadIntNotRootOmitEmpty",
@@ -598,7 +598,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int `json:"a,omitempty"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 		{
 			name: "PtrHeadIntNotRootString",
@@ -608,7 +608,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int `json:"a,string"`
-			}{A: 1})},
+			}{A: -1})},
 		},
 
 		// PtrHeadIntPtrNotRoot
@@ -620,7 +620,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int `json:"a"`
-			}{A: intptr(1)})},
+			}{A: intptr(-1)})},
 		},
 		{
 			name: "PtrHeadIntPtrNotRootOmitEmpty",
@@ -630,7 +630,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int `json:"a,omitempty"`
-			}{A: intptr(1)})},
+			}{A: intptr(-1)})},
 		},
 		{
 			name: "PtrHeadIntPtrNotRootString",
@@ -640,7 +640,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int `json:"a,string"`
-			}{A: intptr(1)})},
+			}{A: intptr(-1)})},
 		},
 
 		// PtrHeadIntPtrNilNotRoot
@@ -748,7 +748,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int `json:"b"`
 			}{B: 2}},
 		},
@@ -763,7 +763,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -778,7 +778,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int `json:"b,string"`
 			}{B: 2}},
 		},
@@ -795,7 +795,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A *int `json:"a"`
-			}{A: intptr(1)}, B: struct {
+			}{A: intptr(-1)}, B: struct {
 				B *int `json:"b"`
 			}{B: intptr(2)}},
 		},
@@ -810,7 +810,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A *int `json:"a,omitempty"`
-			}{A: intptr(1)}, B: struct {
+			}{A: intptr(-1)}, B: struct {
 				B *int `json:"b,omitempty"`
 			}{B: intptr(2)}},
 		},
@@ -825,7 +825,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A *int `json:"a,string"`
-			}{A: intptr(1)}, B: struct {
+			}{A: intptr(-1)}, B: struct {
 				B *int `json:"b,string"`
 			}{B: intptr(2)}},
 		},
@@ -924,7 +924,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int `json:"b"`
 			}{B: 2}},
 		},
@@ -939,7 +939,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a,omitempty"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int `json:"b,omitempty"`
 			}{B: 2}},
 		},
@@ -954,7 +954,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: struct {
 				A int `json:"a,string"`
-			}{A: 1}, B: struct {
+			}{A: -1}, B: struct {
 				B int `json:"b,string"`
 			}{B: 2}},
 		},
@@ -971,7 +971,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int `json:"a"`
-			}{A: intptr(1)}), B: &(struct {
+			}{A: intptr(-1)}), B: &(struct {
 				B *int `json:"b"`
 			}{B: intptr(2)})},
 		},
@@ -986,7 +986,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int `json:"a,omitempty"`
-			}{A: intptr(1)}), B: &(struct {
+			}{A: intptr(-1)}), B: &(struct {
 				B *int `json:"b,omitempty"`
 			}{B: intptr(2)})},
 		},
@@ -1001,7 +1001,7 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A *int `json:"a,string"`
-			}{A: intptr(1)}), B: &(struct {
+			}{A: intptr(-1)}), B: &(struct {
 				B *int `json:"b,string"`
 			}{B: intptr(2)})},
 		},
@@ -1091,7 +1091,7 @@ func TestCoverInt(t *testing.T) {
 			}{A: &(struct {
 				A int `json:"a"`
 				B int `json:"b"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int `json:"a"`
 				B int `json:"b"`
 			}{A: 3, B: 4})},
@@ -1110,7 +1110,7 @@ func TestCoverInt(t *testing.T) {
 			}{A: &(struct {
 				A int `json:"a,omitempty"`
 				B int `json:"b,omitempty"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int `json:"a,omitempty"`
 				B int `json:"b,omitempty"`
 			}{A: 3, B: 4})},
@@ -1129,7 +1129,7 @@ func TestCoverInt(t *testing.T) {
 			}{A: &(struct {
 				A int `json:"a,string"`
 				B int `json:"b,string"`
-			}{A: 1, B: 2}), B: &(struct {
+			}{A: -1, B: 2}), B: &(struct {
 				A int `json:"a,string"`
 				B int `json:"b,string"`
 			}{A: 3, B: 4})},
@@ -1232,7 +1232,7 @@ func TestCoverInt(t *testing.T) {
 			}{A: &(struct {
 				A *int `json:"a"`
 				B *int `json:"b"`
-			}{A: intptr(1), B: intptr(2)}), B: &(struct {
+			}{A: intptr(-1), B: intptr(2)}), B: &(struct {
 				A *int `json:"a"`
 				B *int `json:"b"`
 			}{A: intptr(3), B: intptr(4)})},
@@ -1251,7 +1251,7 @@ func TestCoverInt(t *testing.T) {
 			}{A: &(struct {
 				A *int `json:"a,omitempty"`
 				B *int `json:"b,omitempty"`
-			}{A: intptr(1), B: intptr(2)}), B: &(struct {
+			}{A: intptr(-1), B: intptr(2)}), B: &(struct {
 				A *int `json:"a,omitempty"`
 				B *int `json:"b,omitempty"`
 			}{A: intptr(3), B: intptr(4)})},
@@ -1270,7 +1270,7 @@ func TestCoverInt(t *testing.T) {
 			}{A: &(struct {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
-			}{A: intptr(1), B: intptr(2)}), B: &(struct {
+			}{A: intptr(-1), B: intptr(2)}), B: &(struct {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
 			}{A: intptr(3), B: intptr(4)})},
@@ -1365,7 +1365,7 @@ func TestCoverInt(t *testing.T) {
 				structInt
 				B int `json:"b"`
 			}{
-				structInt: structInt{A: 1},
+				structInt: structInt{A: -1},
 				B:         2,
 			},
 		},
@@ -1375,7 +1375,7 @@ func TestCoverInt(t *testing.T) {
 				structIntOmitEmpty
 				B int `json:"b,omitempty"`
 			}{
-				structIntOmitEmpty: structIntOmitEmpty{A: 1},
+				structIntOmitEmpty: structIntOmitEmpty{A: -1},
 				B:                  2,
 			},
 		},
@@ -1385,7 +1385,7 @@ func TestCoverInt(t *testing.T) {
 				structIntString
 				B int `json:"b,string"`
 			}{
-				structIntString: structIntString{A: 1},
+				structIntString: structIntString{A: -1},
 				B:               2,
 			},
 		},
@@ -1397,7 +1397,7 @@ func TestCoverInt(t *testing.T) {
 				*structInt
 				B int `json:"b"`
 			}{
-				structInt: &structInt{A: 1},
+				structInt: &structInt{A: -1},
 				B:         2,
 			},
 		},
@@ -1407,7 +1407,7 @@ func TestCoverInt(t *testing.T) {
 				*structIntOmitEmpty
 				B int `json:"b,omitempty"`
 			}{
-				structIntOmitEmpty: &structIntOmitEmpty{A: 1},
+				structIntOmitEmpty: &structIntOmitEmpty{A: -1},
 				B:                  2,
 			},
 		},
@@ -1417,7 +1417,7 @@ func TestCoverInt(t *testing.T) {
 				*structIntString
 				B int `json:"b,string"`
 			}{
-				structIntString: &structIntString{A: 1},
+				structIntString: &structIntString{A: -1},
 				B:               2,
 			},
 		},
@@ -1461,7 +1461,7 @@ func TestCoverInt(t *testing.T) {
 				structIntPtr
 				B *int `json:"b"`
 			}{
-				structIntPtr: structIntPtr{A: intptr(1)},
+				structIntPtr: structIntPtr{A: intptr(-1)},
 				B:            intptr(2),
 			},
 		},
@@ -1471,7 +1471,7 @@ func TestCoverInt(t *testing.T) {
 				structIntPtrOmitEmpty
 				B *int `json:"b,omitempty"`
 			}{
-				structIntPtrOmitEmpty: structIntPtrOmitEmpty{A: intptr(1)},
+				structIntPtrOmitEmpty: structIntPtrOmitEmpty{A: intptr(-1)},
 				B:                     intptr(2),
 			},
 		},
@@ -1481,7 +1481,7 @@ func TestCoverInt(t *testing.T) {
 				structIntPtrString
 				B *int `json:"b,string"`
 			}{
-				structIntPtrString: structIntPtrString{A: intptr(1)},
+				structIntPtrString: structIntPtrString{A: intptr(-1)},
 				B:                  intptr(2),
 			},
 		},
@@ -1525,7 +1525,7 @@ func TestCoverInt(t *testing.T) {
 				*structIntPtr
 				B *int `json:"b"`
 			}{
-				structIntPtr: &structIntPtr{A: intptr(1)},
+				structIntPtr: &structIntPtr{A: intptr(-1)},
 				B:            intptr(2),
 			},
 		},
@@ -1535,7 +1535,7 @@ func TestCoverInt(t *testing.T) {
 				*structIntPtrOmitEmpty
 				B *int `json:"b,omitempty"`
 			}{
-				structIntPtrOmitEmpty: &structIntPtrOmitEmpty{A: intptr(1)},
+				structIntPtrOmitEmpty: &structIntPtrOmitEmpty{A: intptr(-1)},
 				B:                     intptr(2),
 			},
 		},
@@ -1545,7 +1545,7 @@ func TestCoverInt(t *testing.T) {
 				*structIntPtrString
 				B *int `json:"b,string"`
 			}{
-				structIntPtrString: &structIntPtrString{A: intptr(1)},
+				structIntPtrString: &structIntPtrString{A: intptr(-1)},
 				B:                  intptr(2),
 			},
 		},
@@ -1588,7 +1588,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				structInt
 			}{
-				structInt: structInt{A: 1},
+				structInt: structInt{A: -1},
 			},
 		},
 		{
@@ -1596,7 +1596,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				structIntOmitEmpty
 			}{
-				structIntOmitEmpty: structIntOmitEmpty{A: 1},
+				structIntOmitEmpty: structIntOmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1604,7 +1604,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				structIntString
 			}{
-				structIntString: structIntString{A: 1},
+				structIntString: structIntString{A: -1},
 			},
 		},
 
@@ -1614,7 +1614,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				*structInt
 			}{
-				structInt: &structInt{A: 1},
+				structInt: &structInt{A: -1},
 			},
 		},
 		{
@@ -1622,7 +1622,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				*structIntOmitEmpty
 			}{
-				structIntOmitEmpty: &structIntOmitEmpty{A: 1},
+				structIntOmitEmpty: &structIntOmitEmpty{A: -1},
 			},
 		},
 		{
@@ -1630,7 +1630,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				*structIntString
 			}{
-				structIntString: &structIntString{A: 1},
+				structIntString: &structIntString{A: -1},
 			},
 		},
 
@@ -1666,7 +1666,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				structIntPtr
 			}{
-				structIntPtr: structIntPtr{A: intptr(1)},
+				structIntPtr: structIntPtr{A: intptr(-1)},
 			},
 		},
 		{
@@ -1674,7 +1674,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				structIntPtrOmitEmpty
 			}{
-				structIntPtrOmitEmpty: structIntPtrOmitEmpty{A: intptr(1)},
+				structIntPtrOmitEmpty: structIntPtrOmitEmpty{A: intptr(-1)},
 			},
 		},
 		{
@@ -1682,7 +1682,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				structIntPtrString
 			}{
-				structIntPtrString: structIntPtrString{A: intptr(1)},
+				structIntPtrString: structIntPtrString{A: intptr(-1)},
 			},
 		},
 
@@ -1718,7 +1718,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				*structIntPtr
 			}{
-				structIntPtr: &structIntPtr{A: intptr(1)},
+				structIntPtr: &structIntPtr{A: intptr(-1)},
 			},
 		},
 		{
@@ -1726,7 +1726,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				*structIntPtrOmitEmpty
 			}{
-				structIntPtrOmitEmpty: &structIntPtrOmitEmpty{A: intptr(1)},
+				structIntPtrOmitEmpty: &structIntPtrOmitEmpty{A: intptr(-1)},
 			},
 		},
 		{
@@ -1734,7 +1734,7 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				*structIntPtrString
 			}{
-				structIntPtrString: &structIntPtrString{A: intptr(1)},
+				structIntPtrString: &structIntPtrString{A: intptr(-1)},
 			},
 		},
 

--- a/encode_compile.go
+++ b/encode_compile.go
@@ -3,6 +3,7 @@ package json
 import (
 	"encoding"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"unsafe"
@@ -393,122 +394,188 @@ func encodeCompileMarshalTextPtr(ctx *encodeCompileContext) (*opcode, error) {
 	return code, nil
 }
 
+const intSize = 32 << (^uint(0) >> 63)
+
 func encodeCompileInt(ctx *encodeCompileContext) (*opcode, error) {
 	code := newOpCode(ctx, opInt)
+	switch intSize {
+	case 32:
+		code.mask = math.MaxUint32
+		code.rshiftNum = 31
+	default:
+		code.mask = math.MaxUint64
+		code.rshiftNum = 63
+	}
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt8(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt8)
+	code := newOpCode(ctx, opInt)
+	code.mask = math.MaxUint8
+	code.rshiftNum = 7
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt16(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt16)
+	code := newOpCode(ctx, opInt)
+	code.mask = math.MaxUint16
+	code.rshiftNum = 15
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt32(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt32)
+	code := newOpCode(ctx, opInt)
+	code.mask = math.MaxUint32
+	code.rshiftNum = 31
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt64(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt64)
+	code := newOpCode(ctx, opInt)
+	code.mask = math.MaxUint64
+	code.rshiftNum = 63
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint(ctx *encodeCompileContext) (*opcode, error) {
 	code := newOpCode(ctx, opUint)
+	switch intSize {
+	case 32:
+		code.mask = math.MaxUint32
+		code.rshiftNum = 31
+	default:
+		code.mask = math.MaxUint64
+		code.rshiftNum = 63
+	}
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint8(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint8)
+	code := newOpCode(ctx, opUint)
+	code.mask = math.MaxUint8
+	code.rshiftNum = 7
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint16(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint16)
+	code := newOpCode(ctx, opUint)
+	code.mask = math.MaxUint16
+	code.rshiftNum = 15
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint32(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint32)
+	code := newOpCode(ctx, opUint)
+	code.mask = math.MaxUint32
+	code.rshiftNum = 31
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint64(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint64)
+	code := newOpCode(ctx, opUint)
+	code.mask = math.MaxUint64
+	code.rshiftNum = 63
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileIntString(ctx *encodeCompileContext) (*opcode, error) {
 	code := newOpCode(ctx, opIntString)
+	switch intSize {
+	case 32:
+		code.mask = math.MaxUint32
+		code.rshiftNum = 31
+	default:
+		code.mask = math.MaxUint64
+		code.rshiftNum = 63
+	}
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt8String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt8String)
+	code := newOpCode(ctx, opIntString)
+	code.mask = math.MaxUint8
+	code.rshiftNum = 7
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt16String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt16String)
+	code := newOpCode(ctx, opIntString)
+	code.mask = math.MaxUint16
+	code.rshiftNum = 15
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt32String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt32String)
+	code := newOpCode(ctx, opIntString)
+	code.mask = math.MaxUint32
+	code.rshiftNum = 31
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileInt64String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opInt64String)
+	code := newOpCode(ctx, opIntString)
+	code.mask = math.MaxUint64
+	code.rshiftNum = 63
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUintString(ctx *encodeCompileContext) (*opcode, error) {
 	code := newOpCode(ctx, opUintString)
+	switch intSize {
+	case 32:
+		code.mask = math.MaxUint32
+		code.rshiftNum = 31
+	default:
+		code.mask = math.MaxUint64
+		code.rshiftNum = 63
+	}
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint8String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint8String)
+	code := newOpCode(ctx, opUintString)
+	code.mask = math.MaxUint8
+	code.rshiftNum = 7
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint16String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint16String)
+	code := newOpCode(ctx, opUintString)
+	code.mask = math.MaxUint16
+	code.rshiftNum = 15
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint32String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint32String)
+	code := newOpCode(ctx, opUintString)
+	code.mask = math.MaxUint32
+	code.rshiftNum = 31
 	ctx.incIndex()
 	return code, nil
 }
 
 func encodeCompileUint64String(ctx *encodeCompileContext) (*opcode, error) {
-	code := newOpCode(ctx, opUint64String)
+	code := newOpCode(ctx, opUintString)
+	code.mask = math.MaxUint64
+	code.rshiftNum = 63
 	ctx.incIndex()
 	return code, nil
 }
@@ -697,25 +764,12 @@ func encodeTypeToHeaderType(ctx *encodeCompileContext, code *opcode) opType {
 		if ptrNum > 1 {
 			switch code.next.op {
 			case opInt:
+				c.mask = code.next.mask
+				c.rshiftNum = code.next.rshiftNum
 				return opStructFieldHeadIntNPtr
-			case opInt8:
-				return opStructFieldHeadInt8NPtr
-			case opInt16:
-				return opStructFieldHeadInt16NPtr
-			case opInt32:
-				return opStructFieldHeadInt32NPtr
-			case opInt64:
-				return opStructFieldHeadInt64NPtr
 			case opUint:
+				c.mask = code.next.mask
 				return opStructFieldHeadUintNPtr
-			case opUint8:
-				return opStructFieldHeadUint8NPtr
-			case opUint16:
-				return opStructFieldHeadUint16NPtr
-			case opUint32:
-				return opStructFieldHeadUint32NPtr
-			case opUint64:
-				return opStructFieldHeadUint64NPtr
 			case opFloat32:
 				return opStructFieldHeadFloat32NPtr
 			case opFloat64:
@@ -728,25 +782,12 @@ func encodeTypeToHeaderType(ctx *encodeCompileContext, code *opcode) opType {
 		} else {
 			switch code.next.op {
 			case opInt:
+				c.mask = code.next.mask
+				c.rshiftNum = code.next.rshiftNum
 				return opStructFieldHeadIntPtr
-			case opInt8:
-				return opStructFieldHeadInt8Ptr
-			case opInt16:
-				return opStructFieldHeadInt16Ptr
-			case opInt32:
-				return opStructFieldHeadInt32Ptr
-			case opInt64:
-				return opStructFieldHeadInt64Ptr
 			case opUint:
+				c.mask = code.next.mask
 				return opStructFieldHeadUintPtr
-			case opUint8:
-				return opStructFieldHeadUint8Ptr
-			case opUint16:
-				return opStructFieldHeadUint16Ptr
-			case opUint32:
-				return opStructFieldHeadUint32Ptr
-			case opUint64:
-				return opStructFieldHeadUint64Ptr
 			case opFloat32:
 				return opStructFieldHeadFloat32Ptr
 			case opFloat64:
@@ -759,24 +800,8 @@ func encodeTypeToHeaderType(ctx *encodeCompileContext, code *opcode) opType {
 		}
 	case opInt:
 		return opStructFieldHeadInt
-	case opInt8:
-		return opStructFieldHeadInt8
-	case opInt16:
-		return opStructFieldHeadInt16
-	case opInt32:
-		return opStructFieldHeadInt32
-	case opInt64:
-		return opStructFieldHeadInt64
 	case opUint:
 		return opStructFieldHeadUint
-	case opUint8:
-		return opStructFieldHeadUint8
-	case opUint16:
-		return opStructFieldHeadUint16
-	case opUint32:
-		return opStructFieldHeadUint32
-	case opUint64:
-		return opStructFieldHeadUint64
 	case opFloat32:
 		return opStructFieldHeadFloat32
 	case opFloat64:
@@ -822,25 +847,12 @@ func encodeTypeToFieldType(ctx *encodeCompileContext, code *opcode) opType {
 		if ptrNum > 1 {
 			switch code.next.op {
 			case opInt:
+				c.mask = code.next.mask
+				c.rshiftNum = code.next.rshiftNum
 				return opStructFieldIntNPtr
-			case opInt8:
-				return opStructFieldInt8NPtr
-			case opInt16:
-				return opStructFieldInt16NPtr
-			case opInt32:
-				return opStructFieldInt32NPtr
-			case opInt64:
-				return opStructFieldInt64NPtr
 			case opUint:
+				c.mask = code.next.mask
 				return opStructFieldUintNPtr
-			case opUint8:
-				return opStructFieldUint8NPtr
-			case opUint16:
-				return opStructFieldUint16NPtr
-			case opUint32:
-				return opStructFieldUint32NPtr
-			case opUint64:
-				return opStructFieldUint64NPtr
 			case opFloat32:
 				return opStructFieldFloat32NPtr
 			case opFloat64:
@@ -853,25 +865,12 @@ func encodeTypeToFieldType(ctx *encodeCompileContext, code *opcode) opType {
 		} else {
 			switch code.next.op {
 			case opInt:
+				c.mask = code.next.mask
+				c.rshiftNum = code.next.rshiftNum
 				return opStructFieldIntPtr
-			case opInt8:
-				return opStructFieldInt8Ptr
-			case opInt16:
-				return opStructFieldInt16Ptr
-			case opInt32:
-				return opStructFieldInt32Ptr
-			case opInt64:
-				return opStructFieldInt64Ptr
 			case opUint:
+				c.mask = code.next.mask
 				return opStructFieldUintPtr
-			case opUint8:
-				return opStructFieldUint8Ptr
-			case opUint16:
-				return opStructFieldUint16Ptr
-			case opUint32:
-				return opStructFieldUint32Ptr
-			case opUint64:
-				return opStructFieldUint64Ptr
 			case opFloat32:
 				return opStructFieldFloat32Ptr
 			case opFloat64:
@@ -884,24 +883,8 @@ func encodeTypeToFieldType(ctx *encodeCompileContext, code *opcode) opType {
 		}
 	case opInt:
 		return opStructFieldInt
-	case opInt8:
-		return opStructFieldInt8
-	case opInt16:
-		return opStructFieldInt16
-	case opInt32:
-		return opStructFieldInt32
-	case opInt64:
-		return opStructFieldInt64
 	case opUint:
 		return opStructFieldUint
-	case opUint8:
-		return opStructFieldUint8
-	case opUint16:
-		return opStructFieldUint16
-	case opUint32:
-		return opStructFieldUint32
-	case opUint64:
-		return opStructFieldUint64
 	case opFloat32:
 		return opStructFieldFloat32
 	case opFloat64:
@@ -969,6 +952,8 @@ func encodeStructHeader(ctx *encodeCompileContext, fieldCode *opcode, valueCode 
 	fieldCode.indent--
 	op := encodeOptimizeStructHeader(ctx, valueCode, tag)
 	fieldCode.op = op
+	fieldCode.mask = valueCode.mask
+	fieldCode.rshiftNum = valueCode.rshiftNum
 	fieldCode.ptrNum = valueCode.ptrNum
 	switch op {
 	case opStructFieldHead,
@@ -995,6 +980,8 @@ func encodeStructField(ctx *encodeCompileContext, fieldCode *opcode, valueCode *
 	op := encodeOptimizeStructField(ctx, valueCode, tag)
 	fieldCode.op = op
 	fieldCode.ptrNum = valueCode.ptrNum
+	fieldCode.mask = valueCode.mask
+	fieldCode.rshiftNum = valueCode.rshiftNum
 	switch op {
 	case opStructField,
 		opStructFieldSlice,

--- a/encode_opcode.go
+++ b/encode_opcode.go
@@ -19,9 +19,9 @@ type opcode struct {
 	isTaggedKey  bool   // whether tagged key
 	anonymousKey bool   // whether anonymous key
 	root         bool   // whether root
-	indent       int    // indent number
 	rshiftNum    uint8  // use to take bit for judging whether negative integer or not
 	mask         uint64 // mask for number
+	indent       int    // indent number
 
 	idx     uintptr // offset to access ptr
 	headIdx uintptr // offset to access slice/struct head

--- a/encode_opcode.go
+++ b/encode_opcode.go
@@ -20,6 +20,8 @@ type opcode struct {
 	anonymousKey bool   // whether anonymous key
 	root         bool   // whether root
 	indent       int    // indent number
+	rshiftNum    uint8  // use to take bit for judging whether negative integer or not
+	mask         uint64 // mask for number
 
 	idx     uintptr // offset to access ptr
 	headIdx uintptr // offset to access slice/struct head
@@ -84,6 +86,8 @@ func (c *opcode) copy(codeMap map[uintptr]*opcode) *opcode {
 		escapedKey:   c.escapedKey,
 		displayKey:   c.displayKey,
 		ptrNum:       c.ptrNum,
+		mask:         c.mask,
+		rshiftNum:    c.rshiftNum,
 		isTaggedKey:  c.isTaggedKey,
 		anonymousKey: c.anonymousKey,
 		root:         c.root,

--- a/encode_vm.go
+++ b/encode_vm.go
@@ -24,15 +24,6 @@ func store(base uintptr, idx uintptr, p uintptr) {
 	**(**uintptr)(unsafe.Pointer(&addr)) = p
 }
 
-func ptrToInt(p uintptr) int            { return **(**int)(unsafe.Pointer(&p)) }
-func ptrToInt8(p uintptr) int8          { return **(**int8)(unsafe.Pointer(&p)) }
-func ptrToInt16(p uintptr) int16        { return **(**int16)(unsafe.Pointer(&p)) }
-func ptrToInt32(p uintptr) int32        { return **(**int32)(unsafe.Pointer(&p)) }
-func ptrToInt64(p uintptr) int64        { return **(**int64)(unsafe.Pointer(&p)) }
-func ptrToUint(p uintptr) uint          { return **(**uint)(unsafe.Pointer(&p)) }
-func ptrToUint8(p uintptr) uint8        { return **(**uint8)(unsafe.Pointer(&p)) }
-func ptrToUint16(p uintptr) uint16      { return **(**uint16)(unsafe.Pointer(&p)) }
-func ptrToUint32(p uintptr) uint32      { return **(**uint32)(unsafe.Pointer(&p)) }
 func ptrToUint64(p uintptr) uint64      { return **(**uint64)(unsafe.Pointer(&p)) }
 func ptrToFloat32(p uintptr) float32    { return **(**float32)(unsafe.Pointer(&p)) }
 func ptrToFloat64(p uintptr) float64    { return **(**float64)(unsafe.Pointer(&p)) }

--- a/encode_vm.go
+++ b/encode_vm.go
@@ -93,102 +93,22 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			code = code.next
 			store(ctxptr, code.idx, ptrToPtr(ptr))
 		case opInt:
-			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opInt8:
-			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opInt16:
-			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opInt32:
-			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opInt64:
-			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = encodeComma(b)
 			code = code.next
 		case opUint:
-			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opUint8:
-			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opUint16:
-			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opUint32:
-			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
-			b = encodeComma(b)
-			code = code.next
-		case opUint64:
-			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = encodeComma(b)
 			code = code.next
 		case opIntString:
 			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opInt8String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opInt16String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opInt32String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opInt64String:
-			b = append(b, '"')
-			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
 		case opUintString:
 			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opUint8String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opUint16String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opUint32String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opUint64String:
-			b = append(b, '"')
-			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
@@ -696,7 +616,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, '{')
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -714,12 +634,13 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeComma(b)
 					code = code.next
 				}
@@ -740,7 +661,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = append(b, '{')
 				b = append(b, code.key...)
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -749,16 +670,17 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt(p)))
+			b = appendInt(b, ptrToUint64(p), code)
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntOnly, opStructFieldHeadOmitEmptyIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := int64(ptrToInt(p))
+			u64 := ptrToUint64(p)
+			v := u64 & code.mask
 			if v != 0 {
 				b = append(b, code.key...)
-				b = appendInt(b, v)
+				b = appendInt(b, u64, code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -767,7 +689,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			b = append(b, '{')
 			b = append(b, code.key...)
 			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt(p)))
+			b = appendInt(b, ptrToUint64(p), code)
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
@@ -784,11 +706,11 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, '{')
 				b = append(b, code.key...)
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeComma(b)
@@ -804,10 +726,10 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p != 0 {
 					b = append(b, code.key...)
-					b = appendInt(b, int64(ptrToInt(p)))
+					b = appendInt(b, ptrToUint64(p), code)
 					b = encodeComma(b)
 				}
 				code = code.next
@@ -825,12 +747,12 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, '{')
 				b = append(b, code.key...)
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 					b = append(b, '"')
 				}
 			}
@@ -853,7 +775,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p+code.offset), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -872,7 +794,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -894,7 +816,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -915,7 +837,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeComma(b)
@@ -929,7 +851,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -944,12 +866,13 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeComma(b)
 					code = code.next
 				}
@@ -967,7 +890,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, code.key...)
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -978,7 +901,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -987,12 +910,13 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeComma(b)
 					code = code.next
 				}
@@ -1004,7 +928,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, code.key...)
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -1019,11 +943,11 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				break
 			}
 			b = append(b, code.key...)
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1036,12 +960,12 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 				break
 			}
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1055,12 +979,12 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				break
 			}
 			b = append(b, code.key...)
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -1079,7 +1003,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p+code.offset), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -1097,7 +1021,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.nextField
 			} else {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -1116,1755 +1040,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt8(p)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8Only, opStructFieldHeadOmitEmptyInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := int64(ptrToInt8(p))
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt8(p)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(ptrToInt8(p)))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadInt8NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt8Only, opStructFieldAnonymousHeadInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Only, opStructFieldAnonymousHeadOmitEmptyInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8Only, opStructFieldAnonymousHeadStringTagInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt16(p)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16Only, opStructFieldHeadOmitEmptyInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := int64(ptrToInt16(p))
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt16(p)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(ptrToInt16(p)))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadInt16NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt16Only, opStructFieldAnonymousHeadInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Only, opStructFieldAnonymousHeadOmitEmptyInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16Only, opStructFieldAnonymousHeadStringTagInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt32(p)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32Only, opStructFieldHeadOmitEmptyInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := int64(ptrToInt32(p))
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt32(p)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(ptrToInt32(p)))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadInt32NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt32Only, opStructFieldAnonymousHeadInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Only, opStructFieldAnonymousHeadOmitEmptyInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, int64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32Only, opStructFieldAnonymousHeadStringTagInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, v)
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendInt(b, ptrToInt64(p))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64Only, opStructFieldHeadOmitEmptyInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := ptrToInt64(p)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, ptrToInt64(p))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, ptrToInt64(p+code.offset))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendInt(b, ptrToInt64(p))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, ptrToInt64(p+code.offset))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadInt64NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, ptrToInt64(p+code.offset))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, v)
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt64Only, opStructFieldAnonymousHeadInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Only, opStructFieldAnonymousHeadOmitEmptyInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendInt(b, v)
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64Only, opStructFieldAnonymousHeadStringTagInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(p))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToUint64(p+code.offset), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -2881,7 +1057,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, '{')
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -2899,12 +1075,13 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeComma(b)
 					code = code.next
 				}
@@ -2925,7 +1102,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = append(b, '{')
 				b = append(b, code.key...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -2934,16 +1111,17 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
 			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint(p)))
+			b = appendUint(b, ptrToUint64(p), code)
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintOnly, opStructFieldHeadOmitEmptyUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{')
-			v := uint64(ptrToUint(p))
+			u64 := ptrToUint64(p)
+			v := u64 & code.mask
 			if v != 0 {
 				b = append(b, code.key...)
-				b = appendUint(b, v)
+				b = appendUint(b, u64, code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -2952,7 +1130,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			b = append(b, '{')
 			b = append(b, code.key...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint(p)))
+			b = appendUint(b, ptrToUint64(p), code)
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
@@ -2969,11 +1147,11 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, '{')
 				b = append(b, code.key...)
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeComma(b)
@@ -2989,10 +1167,10 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, '{')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p != 0 {
 					b = append(b, code.key...)
-					b = appendUint(b, uint64(ptrToUint(p)))
+					b = appendUint(b, ptrToUint64(p), code)
 					b = encodeComma(b)
 				}
 				code = code.next
@@ -3010,12 +1188,12 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, '{')
 				b = append(b, code.key...)
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 					b = append(b, '"')
 				}
 			}
@@ -3038,7 +1216,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p+code.offset), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3057,7 +1235,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := load(ctxptr, code.idx)
 			if p != 0 {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p+code.offset), code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -3079,7 +1257,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p+code.offset), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3100,7 +1278,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeComma(b)
@@ -3114,7 +1292,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3129,12 +1307,13 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeComma(b)
 					code = code.next
 				}
@@ -3152,7 +1331,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, code.key...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3163,7 +1342,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 			} else {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3172,12 +1351,13 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeComma(b)
 					code = code.next
 				}
@@ -3189,7 +1369,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			} else {
 				b = append(b, code.key...)
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeComma(b)
 				code = code.next
@@ -3204,11 +1384,11 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				break
 			}
 			b = append(b, code.key...)
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3221,12 +1401,12 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.end.next
 				break
 			}
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3240,12 +1420,12 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				break
 			}
 			b = append(b, code.key...)
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -3264,7 +1444,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p+code.offset), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -3282,7 +1462,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				code = code.nextField
 			} else {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p+code.offset), code)
 				b = encodeComma(b)
 				code = code.next
 			}
@@ -3301,1755 +1481,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint8(p)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8Only, opStructFieldHeadOmitEmptyUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := uint64(ptrToUint8(p))
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint8(p)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(ptrToUint8(p)))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadUint8NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint8Only, opStructFieldAnonymousHeadUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Only, opStructFieldAnonymousHeadOmitEmptyUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8Only, opStructFieldAnonymousHeadStringTagUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint16(p)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16Only, opStructFieldHeadOmitEmptyUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := uint64(ptrToUint16(p))
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint16(p)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(ptrToUint16(p)))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadUint16NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint16Only, opStructFieldAnonymousHeadUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Only, opStructFieldAnonymousHeadOmitEmptyUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16Only, opStructFieldAnonymousHeadStringTagUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint32(p)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32Only, opStructFieldHeadOmitEmptyUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := uint64(ptrToUint32(p))
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint32(p)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(ptrToUint32(p)))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadUint32NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint32Only, opStructFieldAnonymousHeadUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Only, opStructFieldAnonymousHeadOmitEmptyUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, uint64(v))
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32Only, opStructFieldAnonymousHeadStringTagUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, v)
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = appendUint(b, ptrToUint64(p))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64Only, opStructFieldHeadOmitEmptyUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			v := ptrToUint64(p)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, ptrToUint64(p))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, ptrToUint64(p+code.offset))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = append(b, code.key...)
-					b = appendUint(b, ptrToUint64(p))
-					b = encodeComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, ptrToUint64(p+code.offset))
-					b = append(b, '"')
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64PtrOnly:
-			b = append(b, '{')
-			p := load(ctxptr, code.idx)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{')
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldHeadUint64NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{')
-				b = append(b, code.key...)
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, ptrToUint64(p+code.offset))
-				}
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, v)
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint64Only, opStructFieldAnonymousHeadUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Only, opStructFieldAnonymousHeadOmitEmptyUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = append(b, code.key...)
-					b = appendUint(b, v)
-					b = encodeComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64Only, opStructFieldAnonymousHeadStringTagUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = append(b, code.key...)
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(p))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = append(b, code.key...)
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = encodeComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p+code.offset), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -7594,15 +4026,16 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 		case opStructFieldInt:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
+				b = appendInt(b, u64, code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -7610,7 +4043,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
 			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
@@ -7621,7 +4054,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -7630,7 +4063,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -7642,7 +4075,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -7660,246 +4093,23 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt8(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt8Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt16(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt16Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt32(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt32Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt64(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldInt64Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(p))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p))
-				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldUint:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = encodeComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
+				b = appendUint(b, u64, code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -7907,7 +4117,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = encodeComma(b)
 			code = code.next
@@ -7918,7 +4128,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeComma(b)
 			code = code.next
@@ -7927,7 +4137,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeComma(b)
 			}
 			code = code.next
@@ -7939,231 +4149,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint8(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint8Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint16(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint16Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint32(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint32Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = append(b, '"')
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint64(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, v)
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = append(b, '"')
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldUint64Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
-			}
-			b = encodeComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(p))
-				b = encodeComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = append(b, code.key...)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeComma(b)
@@ -8656,15 +4642,16 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 		case opStructEndInt:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
+				b = appendInt(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8680,7 +4667,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
 			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
@@ -8691,7 +4678,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = appendStructEnd(b)
 			code = code.next
@@ -8700,7 +4687,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -8720,7 +4707,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -8738,378 +4725,23 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt8(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt8Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt8Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt8NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt16(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt16Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt16Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt16NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt32(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(v))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt32Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt32Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt32NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt64(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, v)
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt64Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendInt(b, ptrToInt64(p))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagInt64Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndInt64NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndUint:
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = appendStructEnd(b)
 			code = code.next
 		case opStructEndOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
+				b = appendUint(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -9125,7 +4757,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			ptr := load(ctxptr, code.headIdx)
 			b = append(b, code.key...)
 			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
 			code = code.next
@@ -9136,7 +4768,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = appendStructEnd(b)
 			code = code.next
@@ -9145,7 +4777,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			p := ptrToPtr(ptr + code.offset)
 			if p != 0 {
 				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
 				last := len(b) - 1
@@ -9165,7 +4797,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
@@ -9183,363 +4815,7 @@ func encodeRun(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, opt Enco
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint8(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint8Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint8Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint8NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint16(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint16Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint16Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint16NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint32(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(v))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint32Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint32Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint32NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint64(ptr + code.offset)
-			if v != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, v)
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = append(b, code.key...)
-			b = append(b, '"')
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = append(b, '"')
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint64Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndOmitEmptyUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = append(b, code.key...)
-				b = appendUint(b, ptrToUint64(p))
-				b = appendStructEnd(b)
-			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = encodeComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
-			}
-			code = code.next
-		case opStructEndStringTagUint64Ptr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p))
-				b = append(b, '"')
-			}
-			b = appendStructEnd(b)
-			code = code.next
-		case opStructEndUint64NPtr:
-			b = append(b, code.key...)
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			for i := 0; i < code.ptrNum-1; i++ {
-				if p == 0 {
-					break
-				}
-				p = ptrToPtr(p)
-			}
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = appendStructEnd(b)
 			code = code.next

--- a/encode_vm_escaped_indent.go
+++ b/encode_vm_escaped_indent.go
@@ -26,102 +26,22 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			code = code.next
 			store(ctxptr, code.idx, ptrToPtr(ptr))
 		case opInt:
-			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt8:
-			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt16:
-			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt32:
-			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt64:
-			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint:
-			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint8:
-			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint16:
-			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint32:
-			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint64:
-			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opIntString:
 			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt8String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt16String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt32String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt64String:
-			b = append(b, '"')
-			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUintString:
 			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint8String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint16String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint32String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint64String:
-			b = append(b, '"')
-			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -659,7 +579,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -677,14 +597,15 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -706,7 +627,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -717,18 +638,19 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt(p)))
+			b = appendInt(b, ptrToUint64(p), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntOnly, opStructFieldHeadOmitEmptyIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(ptrToInt(p))
+			u64 := ptrToUint64(p)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, v)
+				b = appendInt(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -738,7 +660,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt(p)))
+			b = appendInt(b, ptrToUint64(p), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -757,11 +679,11 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -777,12 +699,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p != 0 {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt(p)))
+					b = appendInt(b, ptrToUint64(p), code)
 					b = encodeIndentComma(b)
 				}
 				code = code.next
@@ -802,12 +724,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 					b = append(b, '"')
 				}
 			}
@@ -832,7 +754,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -853,7 +775,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -877,7 +799,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -900,7 +822,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -916,7 +838,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -928,14 +850,15 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -952,7 +875,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -965,7 +888,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -974,14 +897,15 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -995,7 +919,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1012,11 +936,11 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1029,14 +953,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1052,12 +976,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1078,7 +1002,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1098,7 +1022,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1119,1923 +1043,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt8(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8Only, opStructFieldHeadOmitEmptyInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := int64(ptrToInt8(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt8(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt8(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt8NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt8Only, opStructFieldAnonymousHeadInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Only, opStructFieldAnonymousHeadOmitEmptyInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8Only, opStructFieldAnonymousHeadStringTagInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt16(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16Only, opStructFieldHeadOmitEmptyInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := int64(ptrToInt16(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt16(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt16(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt16NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt16Only, opStructFieldAnonymousHeadInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Only, opStructFieldAnonymousHeadOmitEmptyInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16Only, opStructFieldAnonymousHeadStringTagInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt32(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32Only, opStructFieldHeadOmitEmptyInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := int64(ptrToInt32(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt32(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt32(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt32NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt32Only, opStructFieldAnonymousHeadInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Only, opStructFieldAnonymousHeadOmitEmptyInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32Only, opStructFieldAnonymousHeadStringTagInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(ptr))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendInt(b, ptrToInt64(p))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64Only, opStructFieldHeadOmitEmptyInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := ptrToInt64(p)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, ptrToInt64(p))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, ptrToInt64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, ptrToInt64(p))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, ptrToInt64(p+code.offset))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt64NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, ptrToInt64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt64Only, opStructFieldAnonymousHeadInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Only, opStructFieldAnonymousHeadOmitEmptyInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendInt(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64Only, opStructFieldAnonymousHeadStringTagInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3054,7 +1062,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3072,14 +1080,15 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -3101,7 +1110,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3112,18 +1121,19 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint(p)))
+			b = appendUint(b, ptrToUint64(p), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintOnly, opStructFieldHeadOmitEmptyUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(ptrToUint(p))
+			u64 := ptrToUint64(p)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, v)
+				b = appendUint(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3133,7 +1143,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint(p)))
+			b = appendUint(b, ptrToUint64(p), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3152,11 +1162,11 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -3172,12 +1182,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p != 0 {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint(p)))
+					b = appendUint(b, ptrToUint64(p), code)
 					b = encodeIndentComma(b)
 				}
 				code = code.next
@@ -3197,12 +1207,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 					b = append(b, '"')
 				}
 			}
@@ -3227,7 +1237,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3248,7 +1258,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3272,7 +1282,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3295,7 +1305,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -3311,7 +1321,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3323,14 +1333,15 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -3347,7 +1358,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3360,7 +1371,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3369,14 +1380,15 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.escapedKey...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -3390,7 +1402,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3407,11 +1419,11 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3424,14 +1436,14 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				code = code.end.next
 				break
 			}
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3447,12 +1459,12 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3473,7 +1485,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3493,7 +1505,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3514,1923 +1526,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint8(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8Only, opStructFieldHeadOmitEmptyUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := uint64(ptrToUint8(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint8(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint8(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint8NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint8Only, opStructFieldAnonymousHeadUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Only, opStructFieldAnonymousHeadOmitEmptyUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8Only, opStructFieldAnonymousHeadStringTagUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint16(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16Only, opStructFieldHeadOmitEmptyUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := uint64(ptrToUint16(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint16(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint16(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint16NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint16Only, opStructFieldAnonymousHeadUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Only, opStructFieldAnonymousHeadOmitEmptyUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16Only, opStructFieldAnonymousHeadStringTagUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint32(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32Only, opStructFieldHeadOmitEmptyUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := uint64(ptrToUint32(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint32(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint32(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint32NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint32Only, opStructFieldAnonymousHeadUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Only, opStructFieldAnonymousHeadOmitEmptyUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32Only, opStructFieldAnonymousHeadStringTagUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(ptr))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			b = appendUint(b, ptrToUint64(p))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64Only, opStructFieldHeadOmitEmptyUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := ptrToUint64(p)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, ptrToUint64(p))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, ptrToUint64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, ptrToUint64(p))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, ptrToUint64(p+code.offset))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint64NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, ptrToUint64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint64Only, opStructFieldAnonymousHeadUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Only, opStructFieldAnonymousHeadOmitEmptyUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.escapedKey...)
-					b = append(b, ' ')
-					b = appendUint(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64Only, opStructFieldAnonymousHeadStringTagUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -7559,17 +3655,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(v))
+				b = appendInt(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7578,7 +3675,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7591,7 +3688,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7602,7 +3699,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7616,275 +3713,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -7894,17 +3723,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
+				b = appendUint(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7913,7 +3743,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7926,7 +3756,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7937,7 +3767,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7951,275 +3781,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -8832,17 +4394,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(v))
+				b = appendInt(b, u64, code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -8865,7 +4428,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -8878,7 +4441,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -8889,7 +4452,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -8917,387 +4480,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)
@@ -9307,17 +4490,18 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
+				b = appendUint(b, u64, code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -9340,7 +4524,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.escapedKey...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -9353,7 +4537,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -9364,7 +4548,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.escapedKey...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -9392,387 +4576,7 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.escapedKey...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.escapedKey...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)

--- a/encode_vm_indent.go
+++ b/encode_vm_indent.go
@@ -26,102 +26,22 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			code = code.next
 			store(ctxptr, code.idx, ptrToPtr(ptr))
 		case opInt:
-			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt8:
-			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt16:
-			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt32:
-			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt64:
-			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUint:
-			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint8:
-			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint16:
-			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint32:
-			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint64:
-			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opIntString:
 			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt8String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt8(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt16String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt16(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt32String:
-			b = append(b, '"')
-			b = appendInt(b, int64(ptrToInt32(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opInt64String:
-			b = append(b, '"')
-			b = appendInt(b, ptrToInt64(load(ctxptr, code.idx)))
+			b = appendInt(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
 		case opUintString:
 			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint8String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint8(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint16String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint16(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint32String:
-			b = append(b, '"')
-			b = appendUint(b, uint64(ptrToUint32(load(ctxptr, code.idx))))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opUint64String:
-			b = append(b, '"')
-			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)))
+			b = appendUint(b, ptrToUint64(load(ctxptr, code.idx)), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -659,7 +579,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -677,14 +597,15 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -706,7 +627,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -717,18 +638,19 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt(p)))
+			b = appendInt(b, ptrToUint64(p), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyIntOnly, opStructFieldHeadOmitEmptyIntOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := int64(ptrToInt(p))
+			u64 := ptrToUint64(p)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, v)
+				b = appendInt(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -738,7 +660,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt(p)))
+			b = appendInt(b, ptrToUint64(p), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -757,11 +679,11 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -777,12 +699,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p != 0 {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt(p)))
+					b = appendInt(b, ptrToUint64(p), code)
 					b = encodeIndentComma(b)
 				}
 				code = code.next
@@ -802,12 +724,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 					b = append(b, '"')
 				}
 			}
@@ -832,7 +754,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -853,7 +775,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -877,7 +799,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -900,7 +822,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendInt(b, int64(ptrToInt(p+code.offset)))
+					b = appendInt(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -916,7 +838,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -928,14 +850,15 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -952,7 +875,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -965,7 +888,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -974,14 +897,15 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToInt(ptr + code.offset)
+				u64 := ptrToUint64(ptr)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendInt(b, int64(v))
+					b = appendInt(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -995,7 +919,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+				b = appendInt(b, ptrToUint64(ptr), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -1012,11 +936,11 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1029,14 +953,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1052,12 +976,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -1078,7 +1002,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -1098,7 +1022,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -1119,1923 +1043,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt8Only, opStructFieldHeadInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt8(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8Only, opStructFieldHeadOmitEmptyInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := int64(ptrToInt8(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt8Only, opStructFieldHeadStringTagInt8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt8(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt8(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt8NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt8Only, opStructFieldAnonymousHeadInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Only, opStructFieldAnonymousHeadOmitEmptyInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8Only, opStructFieldAnonymousHeadStringTagInt8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt16Only, opStructFieldHeadInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt16(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16Only, opStructFieldHeadOmitEmptyInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := int64(ptrToInt16(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt16Only, opStructFieldHeadStringTagInt16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt16(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt16(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt16NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt16Only, opStructFieldAnonymousHeadInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Only, opStructFieldAnonymousHeadOmitEmptyInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16Only, opStructFieldAnonymousHeadStringTagInt16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt32Only, opStructFieldHeadInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendInt(b, int64(ptrToInt32(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32Only, opStructFieldHeadOmitEmptyInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := int64(ptrToInt32(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt32Only, opStructFieldHeadStringTagInt32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt32(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(ptrToInt32(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt32NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt32Only, opStructFieldAnonymousHeadInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Only, opStructFieldAnonymousHeadOmitEmptyInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, int64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32Only, opStructFieldAnonymousHeadStringTagInt32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(ptr))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadInt64Only, opStructFieldHeadInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendInt(b, ptrToInt64(p))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64Only, opStructFieldHeadOmitEmptyInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := ptrToInt64(p)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt64Only, opStructFieldHeadStringTagInt64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, ptrToInt64(p))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, ptrToInt64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, ptrToInt64(p))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendInt(b, ptrToInt64(p+code.offset))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadInt64NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendInt(b, ptrToInt64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt64Only, opStructFieldAnonymousHeadInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Only, opStructFieldAnonymousHeadOmitEmptyInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToInt64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendInt(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64Only, opStructFieldAnonymousHeadStringTagInt64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagInt64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p+code.offset))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3054,7 +1062,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3072,14 +1080,15 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -3101,7 +1110,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3112,18 +1121,19 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint(p)))
+			b = appendUint(b, ptrToUint64(p), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldPtrHeadOmitEmptyUintOnly, opStructFieldHeadOmitEmptyUintOnly:
 			p := load(ctxptr, code.idx)
 			b = append(b, '{', '\n')
-			v := uint64(ptrToUint(p))
+			u64 := ptrToUint64(p)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, v)
+				b = appendUint(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3133,7 +1143,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent+1)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint(p)))
+			b = appendUint(b, ptrToUint64(p), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3152,11 +1162,11 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -3172,12 +1182,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 			} else {
 				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p != 0 {
 					b = appendIndent(ctx, b, code.indent+1)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint(p)))
+					b = appendUint(b, ptrToUint64(p), code)
 					b = encodeIndentComma(b)
 				}
 				code = code.next
@@ -3197,12 +1207,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				p = ptrToPtr(p)
+				p = ptrToPtr(p + code.offset)
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
 					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 					b = append(b, '"')
 				}
 			}
@@ -3227,7 +1237,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3248,7 +1258,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent+1)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -3272,7 +1282,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3295,7 +1305,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				if p == 0 {
 					b = encodeNull(b)
 				} else {
-					b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+					b = appendUint(b, ptrToUint64(p), code)
 				}
 			}
 			b = encodeIndentComma(b)
@@ -3311,7 +1321,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3323,14 +1333,15 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr + code.offset)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -3347,7 +1358,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3360,7 +1371,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3369,14 +1380,15 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if ptr == 0 {
 				code = code.end.next
 			} else {
-				v := ptrToUint(ptr + code.offset)
+				u64 := ptrToUint64(ptr)
+				v := u64 & code.mask
 				if v == 0 {
 					code = code.nextField
 				} else {
 					b = appendIndent(ctx, b, code.indent)
 					b = append(b, code.key...)
 					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
+					b = appendUint(b, u64, code)
 					b = encodeIndentComma(b)
 					code = code.next
 				}
@@ -3390,7 +1402,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, code.key...)
 				b = append(b, ' ')
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+				b = appendUint(b, ptrToUint64(ptr), code)
 				b = append(b, '"')
 				b = encodeIndentComma(b)
 				code = code.next
@@ -3407,11 +1419,11 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3424,14 +1436,14 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				code = code.end.next
 				break
 			}
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				code = code.nextField
 			} else {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3447,12 +1459,12 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ')
-			p = ptrToPtr(p)
+			p = ptrToPtr(p + code.offset)
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -3473,7 +1485,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -3493,7 +1505,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 				code = code.next
 			}
@@ -3514,1923 +1526,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint8Only, opStructFieldHeadUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint8(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8Only, opStructFieldHeadOmitEmptyUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := uint64(ptrToUint8(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint8Only, opStructFieldHeadStringTagUint8Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint8(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint8(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint8NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint8Only, opStructFieldAnonymousHeadUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Only, opStructFieldAnonymousHeadOmitEmptyUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint8(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8Only, opStructFieldAnonymousHeadStringTagUint8Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint8PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint16Only, opStructFieldHeadUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint16(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16Only, opStructFieldHeadOmitEmptyUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := uint64(ptrToUint16(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint16Only, opStructFieldHeadStringTagUint16Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint16(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint16(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint16NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint16Only, opStructFieldAnonymousHeadUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Only, opStructFieldAnonymousHeadOmitEmptyUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint16(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16Only, opStructFieldAnonymousHeadStringTagUint16Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint16PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(ptr)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint32Only, opStructFieldHeadUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendUint(b, uint64(ptrToUint32(p)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32Only, opStructFieldHeadOmitEmptyUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := uint64(ptrToUint32(p))
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint32Only, opStructFieldHeadStringTagUint32Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint32(p)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(ptrToUint32(p)))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint32NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint32Only, opStructFieldAnonymousHeadUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Only, opStructFieldAnonymousHeadOmitEmptyUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint32(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, uint64(v))
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32Only, opStructFieldAnonymousHeadStringTagUint32Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint32PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p+code.offset)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(ptr))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr != 0 {
-				store(ctxptr, code.idx, ptrToPtr(ptr))
-			}
-			fallthrough
-		case opStructFieldHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ', '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrHeadUint64Only, opStructFieldHeadUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			b = appendUint(b, ptrToUint64(p))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64Only, opStructFieldHeadOmitEmptyUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			v := ptrToUint64(p)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint64Only, opStructFieldHeadStringTagUint64Only:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, ptrToUint64(p))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, ptrToUint64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-			} else {
-				b = append(b, '{', '\n')
-				p = ptrToPtr(p)
-				if p != 0 {
-					b = appendIndent(ctx, b, code.indent+1)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, ptrToUint64(p))
-					b = encodeIndentComma(b)
-				}
-				code = code.next
-			}
-		case opStructFieldPtrHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldHeadStringTagUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				p = ptrToPtr(p)
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = append(b, '"')
-					b = appendUint(b, ptrToUint64(p+code.offset))
-					b = append(b, '"')
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldPtrHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-				b = encodeIndentComma(b)
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = append(b, '{', '\n')
-			b = appendIndent(ctx, b, code.indent+1)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldHeadUint64NPtr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '{', '\n')
-				b = appendIndent(ctx, b, code.indent+1)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				for i := 0; i < code.ptrNum; i++ {
-					if p == 0 {
-						break
-					}
-					p = ptrToPtr(p)
-				}
-				if p == 0 {
-					b = encodeNull(b)
-				} else {
-					b = appendUint(b, ptrToUint64(p+code.offset))
-				}
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint64Only, opStructFieldAnonymousHeadUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Only, opStructFieldAnonymousHeadOmitEmptyUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				v := ptrToUint64(ptr + code.offset)
-				if v == 0 {
-					code = code.nextField
-				} else {
-					b = appendIndent(ctx, b, code.indent)
-					b = append(b, code.key...)
-					b = append(b, ' ')
-					b = appendUint(b, v)
-					b = encodeIndentComma(b)
-					code = code.next
-				}
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64Only, opStructFieldAnonymousHeadStringTagUint64Only:
-			ptr := load(ctxptr, code.idx)
-			if ptr == 0 {
-				code = code.end.next
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(ptr+code.offset))
-				b = append(b, '"')
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			p = ptrToPtr(p)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64Ptr:
-			store(ctxptr, code.idx, ptrToPtr(load(ctxptr, code.idx)))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64Ptr:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			p = ptrToPtr(p)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p+code.offset))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldPtrAnonymousHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadOmitEmptyUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.nextField
-			} else {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p+code.offset))
-				b = encodeIndentComma(b)
-				code = code.next
-			}
-		case opStructFieldPtrAnonymousHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			if p == 0 {
-				code = code.end.next
-				break
-			}
-			store(ctxptr, code.idx, ptrToPtr(p))
-			fallthrough
-		case opStructFieldAnonymousHeadStringTagUint64PtrOnly:
-			p := load(ctxptr, code.idx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p+code.offset))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -7559,17 +3655,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(v))
+				b = appendInt(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7578,7 +3675,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7591,7 +3688,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7602,7 +3699,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7616,275 +3713,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldInt64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -7894,17 +3723,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = encodeIndentComma(b)
 			code = code.next
 		case opStructFieldOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
+				b = appendUint(b, u64, code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7913,7 +3743,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7926,7 +3756,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = encodeIndentComma(b)
 			code = code.next
@@ -7937,7 +3767,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = encodeIndentComma(b)
 			}
 			code = code.next
@@ -7951,275 +3781,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = append(b, '"')
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = append(b, '"')
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldUint64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
-			}
-			b = encodeIndentComma(b)
-			code = code.next
-		case opStructFieldOmitEmptyUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p))
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructFieldStringTagUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = encodeIndentComma(b)
@@ -8831,17 +4393,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyInt:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(v))
+				b = appendInt(b, u64, code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -8864,7 +4427,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt(ptr+code.offset)))
+			b = appendInt(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -8877,7 +4440,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -8888,7 +4451,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt(p)))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -8916,387 +4479,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt8(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt8(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt8(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt16(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt16(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt16(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, int64(ptrToInt32(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, int64(ptrToInt32(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, int64(ptrToInt32(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToInt64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, v)
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendInt(b, ptrToInt64(ptr+code.offset))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndInt64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendInt(b, ptrToInt64(p))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyInt64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendInt(b, ptrToInt64(p))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagInt64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendInt(b, ptrToInt64(p))
+				b = appendInt(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)
@@ -9306,17 +4489,18 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = append(b, code.key...)
 			b = append(b, ' ')
 			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
 		case opStructEndOmitEmptyUint:
 			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint(ptr + code.offset)
+			u64 := ptrToUint64(ptr + code.offset)
+			v := u64 & code.mask
 			if v != 0 {
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
+				b = appendUint(b, u64, code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -9339,7 +4523,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			b = appendIndent(ctx, b, code.indent)
 			b = append(b, code.key...)
 			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint(ptr+code.offset)))
+			b = appendUint(b, ptrToUint64(ptr+code.offset), code)
 			b = append(b, '"')
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -9352,7 +4536,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 			if p == 0 {
 				b = encodeNull(b)
 			} else {
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)
 			code = code.next
@@ -9363,7 +4547,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = appendIndent(ctx, b, code.indent)
 				b = append(b, code.key...)
 				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint(p)))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEndIndent(ctx, b, code.indent-1)
 			} else {
 				last := len(b) - 1
@@ -9391,387 +4575,7 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = encodeNull(b)
 			} else {
 				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint8:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint8:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint8(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint8:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint8(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint8(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint8Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint8Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint8(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint16:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint16:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint16(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint16:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint16(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint16(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint16Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint16Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint16(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint32:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint32:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint32(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(v))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint32:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, uint64(ptrToUint32(ptr+code.offset)))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, uint64(ptrToUint32(p)))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint32Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint32Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, uint64(ptrToUint32(p)))
-				b = append(b, '"')
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint64:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint64:
-			ptr := load(ctxptr, code.headIdx)
-			v := ptrToUint64(ptr + code.offset)
-			if v != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, v)
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint64:
-			ptr := load(ctxptr, code.headIdx)
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ', '"')
-			b = appendUint(b, ptrToUint64(ptr+code.offset))
-			b = append(b, '"')
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndUint64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = appendUint(b, ptrToUint64(p))
-			}
-			b = appendStructEndIndent(ctx, b, code.indent-1)
-			code = code.next
-		case opStructEndOmitEmptyUint64Ptr:
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p != 0 {
-				b = appendIndent(ctx, b, code.indent)
-				b = append(b, code.key...)
-				b = append(b, ' ')
-				b = appendUint(b, ptrToUint64(p))
-				b = appendStructEndIndent(ctx, b, code.indent-1)
-			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.indent-1)
-					b = append(b, '}')
-				}
-				b = encodeIndentComma(b)
-			}
-			code = code.next
-		case opStructEndStringTagUint64Ptr:
-			b = appendIndent(ctx, b, code.indent)
-			b = append(b, code.key...)
-			b = append(b, ' ')
-			ptr := load(ctxptr, code.headIdx)
-			p := ptrToPtr(ptr + code.offset)
-			if p == 0 {
-				b = encodeNull(b)
-			} else {
-				b = append(b, '"')
-				b = appendUint(b, ptrToUint64(p))
+				b = appendUint(b, ptrToUint64(p), code)
 				b = append(b, '"')
 			}
 			b = appendStructEndIndent(ctx, b, code.indent-1)


### PR DESCRIPTION
fix #139 

Integrate int/int8/int16/int32/int64 operation to int and also integrate uint/uint8/uint16/uint32/uint64 operation to uint .
This reduces switch-case branching on numbers by 4/5 .

### Approach

All numbers are retrieved as uint64 value and then properly masked and used by bitwise operations.

### After Benchmark

Has almost no performance impact 😄 

```
$ go test -bench Encode_
goos: darwin
goarch: amd64
pkg: benchmark
Benchmark_Encode_SmallStruct_EncodingJson-16                     2218426               544 ns/op             256 B/op          2 allocs/op
Benchmark_Encode_SmallStruct_JsonIter-16                         2123742               564 ns/op             264 B/op          3 allocs/op
Benchmark_Encode_SmallStruct_EasyJson-16                         2350054               509 ns/op             720 B/op          4 allocs/op
Benchmark_Encode_SmallStruct_Jettison-16                         2794364               436 ns/op             256 B/op          2 allocs/op
Benchmark_Encode_SmallStruct_GoJay-16                            2884944               409 ns/op             624 B/op          2 allocs/op
Benchmark_Encode_SmallStruct_SegmentioJson-16                    4335901               274 ns/op             256 B/op          2 allocs/op
Benchmark_Encode_SmallStruct_GoJson-16                           4618237               259 ns/op             256 B/op          2 allocs/op
Benchmark_Encode_SmallStruct_GoJsonNoEscape-16                   6173409               193 ns/op             144 B/op          1 allocs/op
Benchmark_Encode_SmallStructCached_EncodingJson-16               2506315               473 ns/op             144 B/op          1 allocs/op
Benchmark_Encode_SmallStructCached_JsonIter-16                   2396437               501 ns/op             152 B/op          2 allocs/op
Benchmark_Encode_SmallStructCached_EasyJson-16                   2330235               499 ns/op             720 B/op          4 allocs/op
Benchmark_Encode_SmallStructCached_Jettison-16                   3278575               363 ns/op             144 B/op          1 allocs/op
Benchmark_Encode_SmallStructCached_GoJay-16                      3332101               356 ns/op             512 B/op          1 allocs/op
Benchmark_Encode_SmallStructCached_SegmentioJson-16              5227630               219 ns/op             144 B/op          1 allocs/op
Benchmark_Encode_SmallStructCached_GoJson-16                     6183429               197 ns/op             144 B/op          1 allocs/op
Benchmark_Encode_SmallStructCached_GoJsonNoEscape-16             6166045               191 ns/op             144 B/op          1 allocs/op
Benchmark_Encode_MediumStruct_EncodingJson-16                     787209              1574 ns/op             632 B/op         15 allocs/op
Benchmark_Encode_MediumStruct_JsonIter-16                         880426              1445 ns/op             640 B/op         16 allocs/op
Benchmark_Encode_MediumStruct_EasyJson-16                        1395132               856 ns/op             896 B/op          4 allocs/op
Benchmark_Encode_MediumStruct_Jettison-16                         895564              1385 ns/op             632 B/op         15 allocs/op
Benchmark_Encode_MediumStruct_GoJay-16                           1000000              1068 ns/op             824 B/op         15 allocs/op
Benchmark_Encode_MediumStruct_SegmentioJson-16                   1213646               987 ns/op             632 B/op         15 allocs/op
Benchmark_Encode_MediumStruct_GoJson-16                          1450502               818 ns/op             632 B/op         15 allocs/op
Benchmark_Encode_MediumStruct_GoJsonNoEscape-16                  2725455               438 ns/op             320 B/op          1 allocs/op
Benchmark_Encode_MediumStructCached_EncodingJson-16              1000000              1066 ns/op             320 B/op          1 allocs/op
Benchmark_Encode_MediumStructCached_JsonIter-16                  1000000              1005 ns/op             328 B/op          2 allocs/op
Benchmark_Encode_MediumStructCached_EasyJson-16                  1464342               824 ns/op             896 B/op          4 allocs/op
Benchmark_Encode_MediumStructCached_Jettison-16                  1350500               904 ns/op             320 B/op          1 allocs/op
Benchmark_Encode_MediumStructCached_GoJay-16                     1806687               668 ns/op             512 B/op          1 allocs/op
Benchmark_Encode_MediumStructCached_SegmentioJson-16             1941903               611 ns/op             320 B/op          1 allocs/op
Benchmark_Encode_MediumStructCached_GoJson-16                    2781020               435 ns/op             320 B/op          1 allocs/op
Benchmark_Encode_MediumStructCached_GoJsonNoEscape-16            2751859               430 ns/op             320 B/op          1 allocs/op
Benchmark_Encode_LargeStruct_EncodingJson-16                       43549             26565 ns/op           14622 B/op        319 allocs/op
Benchmark_Encode_LargeStruct_JsonIter-16                           46770             26044 ns/op           14638 B/op        320 allocs/op
Benchmark_Encode_LargeStruct_EasyJson-16                           57874             21143 ns/op           15321 B/op        326 allocs/op
Benchmark_Encode_LargeStruct_Jettison-16                           53610             22125 ns/op           14612 B/op        319 allocs/op
Benchmark_Encode_LargeStruct_GoJay-16                              51416             23136 ns/op           28037 B/op        323 allocs/op
Benchmark_Encode_LargeStruct_SegmentioJson-16                      62659             19369 ns/op           14610 B/op        319 allocs/op
Benchmark_Encode_LargeStruct_GoJson-16                             70260             17102 ns/op           14634 B/op        319 allocs/op
Benchmark_Encode_LargeStruct_GoJsonNoEscape-16                     69862             17101 ns/op           14635 B/op        319 allocs/op
Benchmark_Encode_LargeStructCached_EncodingJson-16                 73185             16465 ns/op            4865 B/op          1 allocs/op
Benchmark_Encode_LargeStructCached_JsonIter-16                     80211             14865 ns/op            4873 B/op          2 allocs/op
Benchmark_Encode_LargeStructCached_EasyJson-16                    119904              9783 ns/op            5574 B/op          8 allocs/op
Benchmark_Encode_LargeStructCached_Jettison-16                    107131             10817 ns/op            4865 B/op          1 allocs/op
Benchmark_Encode_LargeStructCached_GoJay-16                        89059             12517 ns/op           18306 B/op          5 allocs/op
Benchmark_Encode_LargeStructCached_SegmentioJson-16               142260              8263 ns/op            4864 B/op          1 allocs/op
Benchmark_Encode_LargeStructCached_GoJson-16                      194556              6139 ns/op            4865 B/op          1 allocs/op
Benchmark_Encode_LargeStructCached_GoJsonNoEscape-16              193088              6132 ns/op            4865 B/op          1 allocs/op
Benchmark_Encode_MapInterface_EncodingJson-16                     742786              1685 ns/op             768 B/op         17 allocs/op
Benchmark_Encode_MapInterface_JsonIter-16                         822240              1534 ns/op             824 B/op          9 allocs/op
Benchmark_Encode_MapInterface_Jettison-16                        1648610               723 ns/op              48 B/op          1 allocs/op
Benchmark_Encode_MapInterface_SegmentioJson-16                   2545714               465 ns/op              48 B/op          1 allocs/op
Benchmark_Encode_MapInterface_GoJson-16                          1627086               732 ns/op             144 B/op          2 allocs/op
Benchmark_Encode_Interface_SegmentioJson-16                     11242137               103 ns/op              35 B/op          2 allocs/op
Benchmark_Encode_Interface_GoJson-16                            11012883               109 ns/op              35 B/op          2 allocs/op
Benchmark_Encode_Bool_EncodingJson-16                           15165300                80.9 ns/op            19 B/op          0 allocs/op
Benchmark_Encode_Bool_JsonIter-16                               15466372                77.2 ns/op            26 B/op          0 allocs/op
Benchmark_Encode_Bool_SegmentioJson-16                          29867682                42.3 ns/op            19 B/op          0 allocs/op
Benchmark_Encode_Bool_GoJson-16                                 27084482                40.9 ns/op            10 B/op          0 allocs/op
Benchmark_Encode_Int_EncodingJson-16                            12255070                97.5 ns/op             8 B/op          1 allocs/op
Benchmark_Encode_Int_JsonIter-16                                15604448                76.8 ns/op             1 B/op          1 allocs/op
Benchmark_Encode_Int_Jettison-16                                22596178                54.1 ns/op             1 B/op          1 allocs/op
Benchmark_Encode_Int_SegmentioJson-16                           28808984                43.2 ns/op             1 B/op          1 allocs/op
Benchmark_Encode_Int_GoJson-16                                  25921364                48.6 ns/op             1 B/op          1 allocs/op
Benchmark_Encode_MarshalJSON_EncodingJson-16                     6559339               188 ns/op              16 B/op          2 allocs/op
Benchmark_Encode_MarshalJSON_JsonIter-16                         9164743               126 ns/op              24 B/op          3 allocs/op
Benchmark_Encode_MarshalJSON_Jettison-16                         7393448               163 ns/op              16 B/op          2 allocs/op
Benchmark_Encode_MarshalJSON_SegmentioJson-16                    7567838               152 ns/op              16 B/op          2 allocs/op
Benchmark_Encode_MarshalJSON_GoJson-16                          11623873               100 ns/op              16 B/op          2 allocs/op
PASS
ok      benchmark       163.014s
```