### PR TITLE
Fix encoding of nested map

### DIFF
--- a/cover_map_test.go
+++ b/cover_map_test.go
@@ -50,6 +50,10 @@ func TestCoverMap(t *testing.T) {
 		name string
 		data interface{}
 	}{
+		{
+			name: "NestedMap",
+			data: map[string]map[string]int{"a": {"b": 1}},
+		},
 		// HeadMapZero
 		{
 			name: "HeadMapZero",

--- a/encode_compile.go
+++ b/encode_compile.go
@@ -726,8 +726,7 @@ func encodeCompileMap(ctx *encodeCompileContext) (*opcode, error) {
 	value := newMapValueCode(ctx, header)
 	ctx.incIndex()
 
-	valueType := typ.Elem()
-	valueCode, err := encodeCompile(ctx.withType(valueType), false)
+	valueCode, err := encodeCompileMapValue(ctx.withType(typ.Elem()))
 	if err != nil {
 		return nil, err
 	}
@@ -754,6 +753,15 @@ func encodeCompileMap(ctx *encodeCompileContext) (*opcode, error) {
 	value.end = end
 
 	return (*opcode)(unsafe.Pointer(header)), nil
+}
+
+func encodeCompileMapValue(ctx *encodeCompileContext) (*opcode, error) {
+	switch ctx.typ.Kind() {
+	case reflect.Map:
+		return encodeCompilePtr(ctx.withType(rtype_ptrTo(ctx.typ)))
+	default:
+		return encodeCompile(ctx, false)
+	}
 }
 
 func encodeTypeToHeaderType(code *opcode) opType {

--- a/encode_vm_escaped_indent.go
+++ b/encode_vm_escaped_indent.go
@@ -278,6 +278,16 @@ func encodeRunEscapedIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcode
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
+		case opMapPtr:
+			p := load(ctxptr, code.idx)
+			if p == 0 {
+				b = encodeNull(b)
+				b = encodeComma(b)
+				code = code.end.next
+				break
+			}
+			store(ctxptr, code.idx, ptrToPtr(p))
+			fallthrough
 		case opMap:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {

--- a/encode_vm_indent.go
+++ b/encode_vm_indent.go
@@ -278,6 +278,16 @@ func encodeRunIndent(ctx *encodeRuntimeContext, b []byte, codeSet *opcodeSet, op
 				b = append(b, ']', ',', '\n')
 				code = code.end.next
 			}
+		case opMapPtr:
+			p := load(ctxptr, code.idx)
+			if p == 0 {
+				b = encodeNull(b)
+				b = encodeComma(b)
+				code = code.end.next
+				break
+			}
+			store(ctxptr, code.idx, ptrToPtr(p))
+			fallthrough
 		case opMap:
 			ptr := load(ctxptr, code.idx)
 			if ptr == 0 {


### PR DESCRIPTION
I noticed that nested map type needs to dereference .