### PR TITLE
Add debug mode

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,3 +26,6 @@ comment:
   layout: "header,diff"
   behavior: default
   require_changes: no
+
+ignore:
+  - internal/encoder/vm_debug

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - exhaustive
     - exhaustivestruct
     - errorlint
+    - forbidigo
     - funlen
     - gci
     - gochecknoglobals

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,0 @@
-ignore:
-  - internal/encoder/vm_debug

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,2 @@
 ignore:
-  - encode_optype.go
+  - internal/encoder/vm_debug

--- a/encode.go
+++ b/encode.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/goccy/go-json/internal/encoder"
 	"github.com/goccy/go-json/internal/encoder/vm"
+	"github.com/goccy/go-json/internal/encoder/vm_debug"
 	"github.com/goccy/go-json/internal/encoder/vm_escaped"
 	"github.com/goccy/go-json/internal/encoder/vm_escaped_indent"
 	"github.com/goccy/go-json/internal/encoder/vm_indent"
@@ -31,6 +32,7 @@ const (
 	EncodeOptionHTMLEscape EncodeOption = 1 << iota
 	EncodeOptionIndent
 	EncodeOptionUnorderedMap
+	EncodeOptionDebug
 )
 
 var (
@@ -272,6 +274,9 @@ func encodeIndent(ctx *encoder.RuntimeContext, v interface{}, prefix, indent str
 }
 
 func encodeRunCode(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt EncodeOption) ([]byte, error) {
+	if (opt & EncodeOptionDebug) != 0 {
+		return vm_debug.Run(ctx, b, codeSet, encoder.Option(opt))
+	}
 	if (opt & EncodeOptionHTMLEscape) != 0 {
 		return vm_escaped.Run(ctx, b, codeSet, encoder.Option(opt))
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -410,6 +410,22 @@ func Test_Marshal(t *testing.T) {
 	})
 }
 
+type mustErrTypeForDebug struct{}
+
+func (mustErrTypeForDebug) MarshalJSON() ([]byte, error) {
+	panic("panic")
+	return nil, fmt.Errorf("panic")
+}
+
+func TestDebugMode(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatal("expected error")
+		}
+	}()
+	json.MarshalWithOption(mustErrTypeForDebug{}, json.Debug())
+}
+
 func TestIssue116(t *testing.T) {
 	t.Run("first", func(t *testing.T) {
 		type Boo struct{ B string }

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -65,6 +65,7 @@ func compileToGetCodeSetSlowPath(typeptr uintptr) (*OpcodeSet, error) {
 	code = copyOpcode(code)
 	codeLength := code.TotalLength()
 	codeSet := &OpcodeSet{
+		Type:       copiedType,
 		Code:       code,
 		CodeLength: codeLength,
 	}

--- a/internal/encoder/compiler_norace.go
+++ b/internal/encoder/compiler_norace.go
@@ -30,6 +30,7 @@ func CompileToGetCodeSet(typeptr uintptr) (*OpcodeSet, error) {
 	code = copyOpcode(code)
 	codeLength := code.TotalLength()
 	codeSet := &OpcodeSet{
+		Type:       copiedType,
 		Code:       code,
 		CodeLength: codeLength,
 	}

--- a/internal/encoder/compiler_race.go
+++ b/internal/encoder/compiler_race.go
@@ -36,6 +36,7 @@ func CompileToGetCodeSet(typeptr uintptr) (*OpcodeSet, error) {
 	code = copyOpcode(code)
 	codeLength := code.TotalLength()
 	codeSet := &OpcodeSet{
+		Type:       copiedType,
 		Code:       code,
 		CodeLength: codeLength,
 	}

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -130,6 +130,7 @@ func (t OpType) IsMultipleOpField() bool {
 }
 
 type OpcodeSet struct {
+	Type       *runtime.Type
 	Code       *Opcode
 	CodeLength int
 }

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -10,9 +10,9 @@ import (
 	"github.com/goccy/go-json/internal/runtime"
 
 	// HACK: compile order
-	// `vm`, `vm_escaped`, `vm_indent`, `vm_escaped_indent` packages uses a lot of memory to compile,
+	// `vm`, `vm_escaped`, `vm_indent`, `vm_escaped_indent`, `vm_debug` packages uses a lot of memory to compile,
 	// so forcibly make dependencies and avoid compiling in concurrent.
-	// dependency order: vm => vm_escaped => vm_indent => vm_escaped_indent
+	// dependency order: vm => vm_escaped => vm_indent => vm_escaped_indent => vm_debug
 	_ "github.com/goccy/go-json/internal/encoder/vm_escaped"
 )
 

--- a/internal/encoder/vm_debug/util.go
+++ b/internal/encoder/vm_debug/util.go
@@ -1,0 +1,81 @@
+package vm_debug
+
+import (
+	"encoding/json"
+	"unsafe"
+
+	"github.com/goccy/go-json/internal/encoder"
+	"github.com/goccy/go-json/internal/runtime"
+)
+
+func load(base uintptr, idx uintptr) uintptr {
+	addr := base + idx
+	return **(**uintptr)(unsafe.Pointer(&addr))
+}
+
+func store(base uintptr, idx uintptr, p uintptr) {
+	addr := base + idx
+	**(**uintptr)(unsafe.Pointer(&addr)) = p
+}
+
+func loadNPtr(base uintptr, idx uintptr, ptrNum int) uintptr {
+	addr := base + idx
+	p := **(**uintptr)(unsafe.Pointer(&addr))
+	for i := 0; i < ptrNum; i++ {
+		if p == 0 {
+			return 0
+		}
+		p = ptrToPtr(p)
+	}
+	return p
+}
+
+func ptrToUint64(p uintptr) uint64              { return **(**uint64)(unsafe.Pointer(&p)) }
+func ptrToFloat32(p uintptr) float32            { return **(**float32)(unsafe.Pointer(&p)) }
+func ptrToFloat64(p uintptr) float64            { return **(**float64)(unsafe.Pointer(&p)) }
+func ptrToBool(p uintptr) bool                  { return **(**bool)(unsafe.Pointer(&p)) }
+func ptrToBytes(p uintptr) []byte               { return **(**[]byte)(unsafe.Pointer(&p)) }
+func ptrToNumber(p uintptr) json.Number         { return **(**json.Number)(unsafe.Pointer(&p)) }
+func ptrToString(p uintptr) string              { return **(**string)(unsafe.Pointer(&p)) }
+func ptrToSlice(p uintptr) *runtime.SliceHeader { return *(**runtime.SliceHeader)(unsafe.Pointer(&p)) }
+func ptrToPtr(p uintptr) uintptr {
+	return uintptr(**(**unsafe.Pointer)(unsafe.Pointer(&p)))
+}
+func ptrToNPtr(p uintptr, ptrNum int) uintptr {
+	for i := 0; i < ptrNum; i++ {
+		if p == 0 {
+			return 0
+		}
+		p = ptrToPtr(p)
+	}
+	return p
+}
+
+func ptrToUnsafePtr(p uintptr) unsafe.Pointer {
+	return *(*unsafe.Pointer)(unsafe.Pointer(&p))
+}
+func ptrToInterface(code *encoder.Opcode, p uintptr) interface{} {
+	return *(*interface{})(unsafe.Pointer(&emptyInterface{
+		typ: code.Type,
+		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&p)),
+	}))
+}
+
+func appendBool(b []byte, v bool) []byte {
+	if v {
+		return append(b, "true"...)
+	}
+	return append(b, "false"...)
+}
+
+func appendNull(b []byte) []byte {
+	return append(b, "null"...)
+}
+
+func appendComma(b []byte) []byte {
+	return append(b, ',')
+}
+
+func appendStructEnd(b []byte) []byte {
+	return append(b, '}', ',')
+}

--- a/internal/encoder/vm_debug/vm.go
+++ b/internal/encoder/vm_debug/vm.go
@@ -45,6 +45,9 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Println("=============[DEBUG]===============")
+			fmt.Println("* [TYPE]")
+			fmt.Println(codeSet.Type)
+			fmt.Printf("\n")
 			fmt.Println("* [ALL OPCODE]")
 			fmt.Println(codeSet.Code.Dump())
 			fmt.Printf("\n")

--- a/internal/encoder/vm_escaped/vm.go
+++ b/internal/encoder/vm_escaped/vm.go
@@ -10,9 +10,9 @@ import (
 	"github.com/goccy/go-json/internal/runtime"
 
 	// HACK: compile order
-	// `vm`, `vm_escaped`, `vm_indent`, `vm_escaped_indent` packages uses a lot of memory to compile,
+	// `vm`, `vm_escaped`, `vm_indent`, `vm_escaped_indent`, `vm_debug` packages uses a lot of memory to compile,
 	// so forcibly make dependencies and avoid compiling in concurrent.
-	// dependency order: vm => vm_escaped => vm_indent => vm_escaped_indent
+	// dependency order: vm => vm_escaped => vm_indent => vm_escaped_indent => vm_debug
 	_ "github.com/goccy/go-json/internal/encoder/vm_indent"
 )
 

--- a/internal/encoder/vm_escaped_indent/vm.go
+++ b/internal/encoder/vm_escaped_indent/vm.go
@@ -9,6 +9,12 @@ import (
 
 	"github.com/goccy/go-json/internal/encoder"
 	"github.com/goccy/go-json/internal/runtime"
+
+	// HACK: compile order
+	// `vm`, `vm_escaped`, `vm_indent`, `vm_escaped_indent`, `vm_debug` packages uses a lot of memory to compile,
+	// so forcibly make dependencies and avoid compiling in concurrent.
+	// dependency order: vm => vm_escaped => vm_indent => vm_escaped_indent => vm_debug
+	_ "github.com/goccy/go-json/internal/encoder/vm_debug"
 )
 
 const uintptrSize = 4 << (^uintptr(0) >> 63)

--- a/option.go
+++ b/option.go
@@ -7,3 +7,9 @@ func UnorderedMap() func(EncodeOption) EncodeOption {
 		return opt | EncodeOptionUnorderedMap
 	}
 }
+
+func Debug() func(EncodeOption) EncodeOption {
+	return func(opt EncodeOption) EncodeOption {
+		return opt | EncodeOptionDebug
+	}
+}


### PR DESCRIPTION
Add `json.Debug()` option for `json.MarshalWithOption` .

```go
type mustErrTypeForDebug struct{}

func (mustErrTypeForDebug) MarshalJSON() ([]byte, error) {
	panic("panic")
	return nil, fmt.Errorf("panic")
}

func TestDebugMode(t *testing.T) {
	defer func() {
		if err := recover(); err == nil {
			t.Fatal("expected error")
		}
	}()
	json.MarshalWithOption(mustErrTypeForDebug{}, json.Debug())
}
```

The above code cause panic. In this case, go-json catch error and output debug information like the following:

```
=============[DEBUG]===============
* [TYPE]
json_test.mustErrTypeForDebug

* [ALL OPCODE]
[0]MarshalJSON ([idx:0])

* [CURRENT OPCODE]
&{Op:MarshalJSON Type:json_test.mustErrTypeForDebug DisplayIdx:0 Key:[] EscapedKey:[] PtrNum:0 DisplayKey: IsTaggedKey:false AnonymousKey:false AnonymousHead:false Indirect:false Nilcheck:false AddrForMarshaler:false IsNextOpPtrType:false IsNilableType:false RshiftNum:0 Mask:0 Indent:0 Idx:0 HeadIdx:0 ElemIdx:0 Length:0 MapIter:0 MapPos:0 Offset:0 Size:0 MapKey:<nil> MapValue:<nil> Elem:<nil> End:<nil> PrevField:<nil> NextField:<nil> Next:0xc0009be400 Jmp:<nil>}

* [CONTEXT]
&{Buf:[] Ptrs:[27239792 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] KeepRefs:[0x19fa570] SeenPtr:[] BaseIndent:0 Prefix:[] IndentStr:[]}
===================================
```
