### PR TITLE
Fix decoding of slice of pointer type

### DIFF
--- a/decode_slice.go
+++ b/decode_slice.go
@@ -33,7 +33,7 @@ func newSliceDecoder(dec decoder, elemType *rtype, size uintptr, structName, fie
 	return &sliceDecoder{
 		valueDecoder:      dec,
 		elemType:          elemType,
-		isElemPointerType: elemType.Kind() == reflect.Ptr,
+		isElemPointerType: elemType.Kind() == reflect.Ptr || elemType.Kind() == reflect.Map,
 		size:              size,
 		arrayPool: sync.Pool{
 			New: func() interface{} {

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -114,7 +114,9 @@ func (d *sliceDecoder) decodeStream(s *stream, depth int64, p unsafe.Pointer) er
 					dst := sliceHeader{data: data, len: idx, cap: capacity}
 					copySlice(d.elemType, dst, src)
 				}
-				if err := d.valueDecoder.decodeStream(s, depth, unsafe.Pointer(uintptr(data)+uintptr(idx)*d.size)); err != nil {
+				ep := unsafe.Pointer(uintptr(data) + uintptr(idx)*d.size)
+				*(*unsafe.Pointer)(ep) = nil // initialize elem pointer
+				if err := d.valueDecoder.decodeStream(s, depth, ep); err != nil {
 					return err
 				}
 				s.skipWhiteSpace()
@@ -224,7 +226,9 @@ func (d *sliceDecoder) decode(buf []byte, cursor, depth int64, p unsafe.Pointer)
 					dst := sliceHeader{data: data, len: idx, cap: capacity}
 					copySlice(d.elemType, dst, src)
 				}
-				c, err := d.valueDecoder.decode(buf, cursor, depth, unsafe.Pointer(uintptr(data)+uintptr(idx)*d.size))
+				ep := unsafe.Pointer(uintptr(data) + uintptr(idx)*d.size)
+				*(*unsafe.Pointer)(ep) = nil // initialize elem pointer
+				c, err := d.valueDecoder.decode(buf, cursor, depth, ep)
 				if err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
fix https://github.com/goccy/go-json/issues/166

- https://github.com/goccy/go-json/blob/master/decode_ptr.go#L47-L53
- https://github.com/goccy/go-json/blob/master/decode_ptr.go#L82-L88

If there is a pointer value, go-json will use it. (This behavior is necessary to achieve the ability to prioritize pre-populated values). However, since slices are reused internally, there was a bug that referred to the previous pointer value.
Therefore, it is not necessary to refer to the pointer value in advance for the slice element, so it is explicitly initialized.
