### PR TITLE
Make Valid more consistent with "encoding/json"

### DIFF
--- a/json.go
+++ b/json.go
@@ -333,8 +333,13 @@ func HTMLEscape(dst *bytes.Buffer, src []byte) {
 // Valid reports whether data is a valid JSON encoding.
 func Valid(data []byte) bool {
 	var v interface{}
-	if err := Unmarshal(data, &v); err != nil {
+	decoder := NewDecoder(bytes.NewReader(data))
+	err := decoder.Decode(&v)
+	if err != nil {
 		return false
 	}
-	return true
+	if !decoder.More() {
+		return true
+	}
+	return decoder.InputOffset() >= int64(len(data))
 }

--- a/json_test.go
+++ b/json_test.go
@@ -20,6 +20,7 @@ var validTests = []struct {
 	{`{}`, true},
 	{`{"foo":"bar"}`, true},
 	{`{"foo":"bar","bar":{"baz":["qux"]}}`, true},
+	{`[""],`, false},
 }
 
 func TestValid(t *testing.T) {


### PR DESCRIPTION
Valid is currently inconsistent with "encoding/json" because it returns true when there is additional non-whitespace after the initial value.  This changes it to use decoder and returns false when `decoder.More()` returns true after decoding a value.