### PR TITLE
Optimize json.Compact and json.Indent

### DIFF
--- a/internal/encoder/vm_escaped_indent/util.go
+++ b/internal/encoder/vm_escaped_indent/util.go
@@ -1,7 +1,6 @@
 package vm_escaped_indent
 
 import (
-	"bytes"
 	"encoding/json"
 	"unsafe"
 
@@ -75,16 +74,4 @@ func appendNull(b []byte) []byte {
 
 func appendComma(b []byte) []byte {
 	return append(b, ',', '\n')
-}
-
-func appendStructEnd(ctx *encoder.RuntimeContext, b []byte, indent int) []byte {
-	b = append(b, '\n')
-	b = append(b, ctx.Prefix...)
-	b = append(b, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+indent)...)
-	return append(b, '}', ',', '\n')
-}
-
-func appendIndent(ctx *encoder.RuntimeContext, b []byte, indent int) []byte {
-	b = append(b, ctx.Prefix...)
-	return append(b, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+indent)...)
 }

--- a/internal/encoder/vm_escaped_indent/vm.go
+++ b/internal/encoder/vm_escaped_indent/vm.go
@@ -1,7 +1,6 @@
 package vm_escaped_indent
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"sort"
@@ -29,6 +28,8 @@ var (
 	appendNumber        = encoder.AppendNumber
 	appendMarshalJSON   = encoder.AppendMarshalJSONIndent
 	appendMarshalText   = encoder.AppendMarshalTextIndent
+	appendStructEnd     = encoder.AppendStructEndIndent
+	appendIndent        = encoder.AppendIndent
 	errUnsupportedValue = encoder.ErrUnsupportedValue
 	errUnsupportedFloat = encoder.ErrUnsupportedFloat
 	mapiterinit         = encoder.MapIterInit
@@ -518,8 +519,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			sort.Sort(mapCtx.Slice)
 			buf := mapCtx.Buf
 			for _, item := range mapCtx.Slice.Items {
-				buf = append(buf, ctx.Prefix...)
-				buf = append(buf, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+code.Indent+1)...)
+				buf = appendIndent(ctx, buf, code.Indent+1)
 				buf = append(buf, item.Key...)
 				buf[len(buf)-2] = ':'
 				buf[len(buf)-1] = ' '
@@ -527,8 +527,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			buf = buf[:len(buf)-2]
 			buf = append(buf, '\n')
-			buf = append(buf, ctx.Prefix...)
-			buf = append(buf, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+code.Indent)...)
+			buf = appendIndent(ctx, buf, code.Indent)
 			buf = append(buf, '}', ',', '\n')
 
 			b = b[:pos[0]]

--- a/internal/encoder/vm_indent/util.go
+++ b/internal/encoder/vm_indent/util.go
@@ -1,7 +1,6 @@
 package vm_indent
 
 import (
-	"bytes"
 	"encoding/json"
 	"unsafe"
 
@@ -75,16 +74,4 @@ func appendNull(b []byte) []byte {
 
 func appendComma(b []byte) []byte {
 	return append(b, ',', '\n')
-}
-
-func appendStructEnd(ctx *encoder.RuntimeContext, b []byte, indent int) []byte {
-	b = append(b, '\n')
-	b = append(b, ctx.Prefix...)
-	b = append(b, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+indent)...)
-	return append(b, '}', ',', '\n')
-}
-
-func appendIndent(ctx *encoder.RuntimeContext, b []byte, indent int) []byte {
-	b = append(b, ctx.Prefix...)
-	return append(b, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+indent)...)
 }

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -1,7 +1,6 @@
 package vm_indent
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"sort"
@@ -29,6 +28,8 @@ var (
 	appendNumber        = encoder.AppendNumber
 	appendMarshalJSON   = encoder.AppendMarshalJSONIndent
 	appendMarshalText   = encoder.AppendMarshalTextIndent
+	appendStructEnd     = encoder.AppendStructEndIndent
+	appendIndent        = encoder.AppendIndent
 	errUnsupportedValue = encoder.ErrUnsupportedValue
 	errUnsupportedFloat = encoder.ErrUnsupportedFloat
 	mapiterinit         = encoder.MapIterInit
@@ -518,8 +519,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			sort.Sort(mapCtx.Slice)
 			buf := mapCtx.Buf
 			for _, item := range mapCtx.Slice.Items {
-				buf = append(buf, ctx.Prefix...)
-				buf = append(buf, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+code.Indent+1)...)
+				buf = appendIndent(ctx, buf, code.Indent+1)
 				buf = append(buf, item.Key...)
 				buf[len(buf)-2] = ':'
 				buf[len(buf)-1] = ' '
@@ -527,8 +527,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			buf = buf[:len(buf)-2]
 			buf = append(buf, '\n')
-			buf = append(buf, ctx.Prefix...)
-			buf = append(buf, bytes.Repeat(ctx.IndentStr, ctx.BaseIndent+code.Indent)...)
+			buf = appendIndent(ctx, buf, code.Indent)
 			buf = append(buf, '}', ',', '\n')
 
 			b = b[:pos[0]]


### PR DESCRIPTION
## Benchmark

around **2x** faster than encoding/json

```
$ go test -bench Indent
goos: darwin
goarch: amd64
pkg: benchmark
Benchmark_Indent_EncodingJson-16              38          30272302 ns/op        17069782 B/op         19 allocs/op
Benchmark_Indent_GoJson-16                    80          14656825 ns/op         5169307 B/op          2 allocs/op
PASS
ok      benchmark       3.615s

$ go test -bench Compact
goos: darwin
goarch: amd64
pkg: benchmark
Benchmark_Compact_EncodingJson-16            100          10036194 ns/op         1941742 B/op          1 allocs/op
Benchmark_Compact_GoJson-16                  190           6241213 ns/op         1941677 B/op          1 allocs/op
PASS
ok      benchmark       3.088s

```