### PR TITLE
Add valyala/fastjson to benchmark

### DIFF
--- a/benchmarks/decode_test.go
+++ b/benchmarks/decode_test.go
@@ -9,6 +9,7 @@ import (
 	gojson "github.com/goccy/go-json"
 	jsoniter "github.com/json-iterator/go"
 	segmentiojson "github.com/segmentio/encoding/json"
+	fastjson "github.com/valyala/fastjson"
 )
 
 func Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson(b *testing.B) {
@@ -16,6 +17,17 @@ func Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		result := SmallPayload{}
 		if err := json.Unmarshal(SmallFixture, &result); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Decode_SmallStruct_Unmarshal_FastJson(b *testing.B) {
+	smallFixture := string(SmallFixture)
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		var p fastjson.Parser
+		if _, err := p.Parse(smallFixture); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -151,6 +163,17 @@ func Benchmark_Decode_MediumStruct_Unmarshal_EncodingJson(b *testing.B) {
 	}
 }
 
+func Benchmark_Decode_MediumStruct_Unmarshal_FastJson(b *testing.B) {
+	mediumFixture := string(MediumFixture)
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		var p fastjson.Parser
+		if _, err := p.Parse(mediumFixture); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func Benchmark_Decode_MediumStruct_Unmarshal_JsonIter(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
@@ -276,6 +299,17 @@ func Benchmark_Decode_LargeStruct_Unmarshal_EncodingJson(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		result := LargePayload{}
 		if err := json.Unmarshal(LargeFixture, &result); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Decode_LargeStruct_Unmarshal_FastJson(b *testing.B) {
+	largeFixture := string(LargeFixture)
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		var p fastjson.Parser
+		if _, err := p.Parse(largeFixture); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/json-iterator/go v1.1.9
 	github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
 	github.com/segmentio/encoding v0.2.4
+	github.com/valyala/fastjson v1.6.3
 	github.com/wI2L/jettison v0.7.1
 )
 

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -113,6 +113,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/wI2L/jettison v0.7.1 h1:XNq/WvSOAiJhFww9F5JZZcBZtKFL2Y/9WHHEHLDq9TE=


### PR DESCRIPTION
I add https://github.com/valyala/fastjson to the benchmark of decoder .
Sure it was faster than `encoding/json`, but slower than any other library

### SMALL

```
goos: darwin
goarch: amd64
pkg: benchmark
Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson-16            511214              2286 ns/op             400 B/op         10 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_FastJson-16                705026              1633 ns/op            3376 B/op         11 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_JsonIter-16               1622686               745 ns/op             208 B/op         13 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJay-16                  2751475               455 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJayUnsafe-16            3126776               389 ns/op             112 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_SegmentioJson-16          1000000              1033 ns/op             192 B/op          5 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJson-16                 3379545               349 ns/op             257 B/op          3 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-16         4136845               279 ns/op             145 B/op          2 allocs/op
```

### MEDIUM

```
Benchmark_Decode_MediumStruct_Unmarshal_EncodingJson-16            81308             14343 ns/op             696 B/op         19 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_FastJson-16               122133              9422 ns/op           17304 B/op         54 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_JsonIter-16               226395              4972 ns/op             792 B/op         82 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJay-16                  378706              2904 ns/op            2448 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJayUnsafe-16            465039              2400 ns/op             144 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_SegmentioJson-16          235323              4828 ns/op             296 B/op          9 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJson-16                 470791              2397 ns/op            2448 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-16         497731              2387 ns/op            2416 B/op          7 allocs/op
```

### LARGE

```
goos: darwin
goarch: amd64
pkg: benchmark
Benchmark_Decode_LargeStruct_Unmarshal_EncodingJson-16              6289            183092 ns/op            6240 B/op        191 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_FastJson-16                 10000            123576 ns/op          283203 B/op        540 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_JsonIter-16                 13256             89737 ns/op           17170 B/op       1271 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJay-16                    34533             34322 ns/op           31235 B/op         77 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJayUnsafe-16              39668             29552 ns/op            2560 B/op         76 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_SegmentioJson-16            14196             84352 ns/op            4400 B/op        132 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJson-16                   37884             31719 ns/op           30731 B/op         67 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-16           37797             31745 ns/op           30699 B/op         66 allocs/op
```