### PR TITLE
Fix decoding of slice with type implemented UnmarshalJSON

### DIFF
--- a/decode_slice.go
+++ b/decode_slice.go
@@ -67,9 +67,6 @@ func copySlice(elemType *rtype, dst, src sliceHeader) int
 //go:linkname newArray reflect.unsafe_NewArray
 func newArray(*rtype, int) unsafe.Pointer
 
-//go:linkname typedmemmovepartial reflect.typedmemmovepartial
-func typedmemmovepartial(typ *rtype, dst, src unsafe.Pointer, off, size uintptr)
-
 //go:linkname typedmemmove reflect.typedmemmove
 func typedmemmove(t *rtype, dst, src unsafe.Pointer)
 

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -121,6 +121,12 @@ func (d *sliceDecoder) decodeStream(s *stream, depth int64, p unsafe.Pointer) er
 				ep := unsafe.Pointer(uintptr(data) + uintptr(idx)*d.size)
 				if d.isElemPointerType {
 					*(*unsafe.Pointer)(ep) = nil // initialize elem pointer
+				} else if d.isElemSliceType {
+					*(*sliceHeader)(ep) = sliceHeader{
+						data: newArray(d.elemType, 0),
+						len:  0,
+						cap:  0,
+					}
 				}
 				if err := d.valueDecoder.decodeStream(s, depth, ep); err != nil {
 					return err

--- a/decode_test.go
+++ b/decode_test.go
@@ -2996,6 +2996,53 @@ func TestDecodeMultipleUnmarshal(t *testing.T) {
 	})
 }
 
+func TestMultipleDecodeWithRawMessage(t *testing.T) {
+	original := []byte(`{
+		"Body": {
+			"List": [
+				{
+					"Returns": [
+						{
+							"Value": "10",
+							"nodeType": "Literal"
+						}
+					],
+					"nodeKind": "Return",
+					"nodeType": "Statement"
+				}
+			],
+			"nodeKind": "Block",
+			"nodeType": "Statement"
+		},
+		"nodeType": "Function"
+	}`)
+
+	var a map[string]json.RawMessage
+	if err := json.Unmarshal(original, &a); err != nil {
+		t.Fatal(err)
+	}
+	var b map[string]json.RawMessage
+	if err := json.Unmarshal(a["Body"], &b); err != nil {
+		t.Fatal(err)
+	}
+	var c []json.RawMessage
+	if err := json.Unmarshal(b["List"], &c); err != nil {
+		t.Fatal(err)
+	}
+	var d map[string]json.RawMessage
+	if err := json.Unmarshal(c[0], &d); err != nil {
+		t.Fatal(err)
+	}
+	var e []json.RawMessage
+	if err := json.Unmarshal(d["Returns"], &e); err != nil {
+		t.Fatal(err)
+	}
+	var f map[string]json.RawMessage
+	if err := json.Unmarshal(e[0], &f); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type intUnmarshaler int
 
 func (u *intUnmarshaler) UnmarshalJSON(b []byte) error {

--- a/decode_test.go
+++ b/decode_test.go
@@ -2996,6 +2996,156 @@ func TestDecodeMultipleUnmarshal(t *testing.T) {
 	})
 }
 
+type intUnmarshaler int
+
+func (u *intUnmarshaler) UnmarshalJSON(b []byte) error {
+	if *u != 0 {
+		return fmt.Errorf("failed to decode of slice with int unmarshaler")
+	}
+	*u = 10
+	return nil
+}
+
+type arrayUnmarshaler [5]int
+
+func (u *arrayUnmarshaler) UnmarshalJSON(b []byte) error {
+	if (*u)[0] != 0 {
+		return fmt.Errorf("failed to decode of slice with array unmarshaler")
+	}
+	(*u)[0] = 10
+	return nil
+}
+
+type mapUnmarshaler map[string]int
+
+func (u *mapUnmarshaler) UnmarshalJSON(b []byte) error {
+	if len(*u) != 0 {
+		return fmt.Errorf("failed to decode of slice with map unmarshaler")
+	}
+	*u = map[string]int{"a": 10}
+	return nil
+}
+
+type structUnmarshaler struct {
+	A int
+}
+
+func (u *structUnmarshaler) UnmarshalJSON(b []byte) error {
+	if u.A != 0 {
+		return fmt.Errorf("failed to decode of slice with struct unmarshaler")
+	}
+	u.A = 10
+	return nil
+}
+
+func TestSliceElemUnmarshaler(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		var v []intUnmarshaler
+		if err := json.Unmarshal([]byte(`[1,2,3,4,5]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 5 {
+			t.Fatalf("failed to decode of slice with int unmarshaler: %v", v)
+		}
+		if v[0] != 10 {
+			t.Fatalf("failed to decode of slice with int unmarshaler: %v", v)
+		}
+		if err := json.Unmarshal([]byte(`[6]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("failed to decode of slice with int unmarshaler: %v", v)
+		}
+		if v[0] != 10 {
+			t.Fatalf("failed to decode of slice with int unmarshaler: %v", v)
+		}
+	})
+	t.Run("slice", func(t *testing.T) {
+		var v []json.RawMessage
+		if err := json.Unmarshal([]byte(`[1,2,3,4,5]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 5 {
+			t.Fatalf("failed to decode of slice with slice unmarshaler: %v", v)
+		}
+		if len(v[0]) != 1 {
+			t.Fatalf("failed to decode of slice with slice unmarshaler: %v", v)
+		}
+		if err := json.Unmarshal([]byte(`[6]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("failed to decode of slice with slice unmarshaler: %v", v)
+		}
+		if len(v[0]) != 1 {
+			t.Fatalf("failed to decode of slice with slice unmarshaler: %v", v)
+		}
+	})
+	t.Run("array", func(t *testing.T) {
+		var v []arrayUnmarshaler
+		if err := json.Unmarshal([]byte(`[1,2,3,4,5]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 5 {
+			t.Fatalf("failed to decode of slice with array unmarshaler: %v", v)
+		}
+		if v[0][0] != 10 {
+			t.Fatalf("failed to decode of slice with array unmarshaler: %v", v)
+		}
+		if err := json.Unmarshal([]byte(`[6]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("failed to decode of slice with array unmarshaler: %v", v)
+		}
+		if v[0][0] != 10 {
+			t.Fatalf("failed to decode of slice with array unmarshaler: %v", v)
+		}
+	})
+	t.Run("map", func(t *testing.T) {
+		var v []mapUnmarshaler
+		if err := json.Unmarshal([]byte(`[{"a":1},{"b":2},{"c":3},{"d":4},{"e":5}]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 5 {
+			t.Fatalf("failed to decode of slice with map unmarshaler: %v", v)
+		}
+		if v[0]["a"] != 10 {
+			t.Fatalf("failed to decode of slice with map unmarshaler: %v", v)
+		}
+		if err := json.Unmarshal([]byte(`[6]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("failed to decode of slice with map unmarshaler: %v", v)
+		}
+		if v[0]["a"] != 10 {
+			t.Fatalf("failed to decode of slice with map unmarshaler: %v", v)
+		}
+	})
+	t.Run("struct", func(t *testing.T) {
+		var v []structUnmarshaler
+		if err := json.Unmarshal([]byte(`[1,2,3,4,5]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 5 {
+			t.Fatalf("failed to decode of slice with struct unmarshaler: %v", v)
+		}
+		if v[0].A != 10 {
+			t.Fatalf("failed to decode of slice with struct unmarshaler: %v", v)
+		}
+		if err := json.Unmarshal([]byte(`[6]`), &v); err != nil {
+			t.Fatal(err)
+		}
+		if len(v) != 1 {
+			t.Fatalf("failed to decode of slice with struct unmarshaler: %v", v)
+		}
+		if v[0].A != 10 {
+			t.Fatalf("failed to decode of slice with struct unmarshaler: %v", v)
+		}
+	})
+}
+
 func TestInvalidTopLevelValue(t *testing.T) {
 	t.Run("invalid end of buffer", func(t *testing.T) {
 		var v struct{}


### PR DESCRIPTION
fix #195 

In decoding `UnmarshalJSON`, it is assumed that the passed pointer is used as it is as a receiver. If a type that implements UnmarshalJSON is specified as an element of slice, this should be taken into consideration so that the pointer of the reused slice element is not passed as it is.