### PR TITLE
use cow map intintmap to cache type information #194

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,9 @@ The fact that all type information can be acquired means that by constructing sl
 
 However, if there is too much type information, it will use a lot of memory, so by default we will only use this optimization if the slice size fits within **2Mib** .
 
-If this approach is not available, it will fall back to the `atomic` based process described above.
+If this approach is not available, it will fall back to a fast copy-on-write int map, which is slightly slower than the slice approach, but is much faster than the builtin map.
 
-If you want to know more, please refer to the implementation [here](https://github.com/goccy/go-json/blob/master/codec.go#L24-L76 )
+If you want to know more, please refer to the implementation [here](https://github.com/goccy/go-json/blob/master/codec.go#L19-L73 )
 
 ## Decoder
 

--- a/codec.go
+++ b/codec.go
@@ -3,7 +3,6 @@ package json
 import (
 	"fmt"
 	"reflect"
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -12,10 +11,9 @@ const (
 )
 
 var (
-	cachedDecoder    []decoder
-	cachedDecoderMap unsafe.Pointer // map[uintptr]decoder
-	baseTypeAddr     uintptr
-	maxTypeAddr      uintptr
+	cachedDecoder []decoder
+	baseTypeAddr  uintptr
+	maxTypeAddr   uintptr
 )
 
 //go:linkname typelinks reflect.typelinks
@@ -72,20 +70,4 @@ func setupCodec() error {
 
 func init() {
 	_ = setupCodec()
-}
-
-func loadDecoderMap() map[uintptr]decoder {
-	p := atomic.LoadPointer(&cachedDecoderMap)
-	return *(*map[uintptr]decoder)(unsafe.Pointer(&p))
-}
-
-func storeDecoder(typ uintptr, dec decoder, m map[uintptr]decoder) {
-	newDecoderMap := make(map[uintptr]decoder, len(m)+1)
-	newDecoderMap[typ] = dec
-
-	for k, v := range m {
-		newDecoderMap[k] = v
-	}
-
-	atomic.StorePointer(&cachedDecoderMap, *(*unsafe.Pointer)(unsafe.Pointer(&newDecoderMap)))
 }

--- a/decode_compile.go
+++ b/decode_compile.go
@@ -8,24 +8,25 @@ import (
 	"unicode"
 	"unsafe"
 
+	"github.com/goccy/go-json/internal/iimap"
 	"github.com/goccy/go-json/internal/runtime"
 )
 
 var (
 	jsonNumberType = reflect.TypeOf(json.Number(""))
+	decoderMap     = iimap.NewTypeMap()
 )
 
 func decodeCompileToGetDecoderSlowPath(typeptr uintptr, typ *rtype) (decoder, error) {
-	decoderMap := loadDecoderMap()
-	if dec, exists := decoderMap[typeptr]; exists {
-		return dec, nil
+	if dec := decoderMap.Get(typeptr); dec != nil {
+		return dec.(decoder), nil
 	}
 
 	dec, err := decodeCompileHead(typ, map[uintptr]decoder{})
 	if err != nil {
 		return nil, err
 	}
-	storeDecoder(typeptr, dec, decoderMap)
+	decoderMap.Set(typeptr, dec)
 	return dec, nil
 }
 

--- a/internal/iimap/intintmap.go
+++ b/internal/iimap/intintmap.go
@@ -1,0 +1,156 @@
+package iimap
+
+import (
+	"math"
+	"sync/atomic"
+	"unsafe"
+)
+
+// TypeMap is a lockless copy-on-write map to use for type information cache.
+// The fill factor used the TypeMap is 0.6.
+// A TypeMap will grow as needed.
+type TypeMap struct {
+	m unsafe.Pointer // *iiMap
+}
+
+// NewTypeMap returns a new TypeMap with 8 as initial capacity.
+func NewTypeMap() *TypeMap {
+	capacity := 8
+	iim := newIIMap(capacity)
+	return &TypeMap{m: unsafe.Pointer(iim)}
+}
+
+func (m *TypeMap) Size() int {
+	return (*iiMap)(atomic.LoadPointer(&m.m)).size
+}
+
+// Get returns the value if the key is found in the map.
+func (m *TypeMap) Get(key uintptr) interface{} {
+	return (*iiMap)(atomic.LoadPointer(&m.m)).Get(key)
+}
+
+// Set adds or updates key with value to the map, if the key value
+// is not present in the underlying map, it will copy the map and
+// add the key value to the copy, then swap to the new map using atomic
+// operation.
+func (m *TypeMap) Set(key uintptr, val interface{}) {
+	mm := (*iiMap)(atomic.LoadPointer(&m.m))
+	if v := mm.Get(key); v == val {
+		return
+	}
+
+	newMap := mm.Copy()
+	newMap.Set(key, val)
+	atomic.StorePointer(&m.m, unsafe.Pointer(newMap))
+}
+
+// -------- int interface map -------- //
+
+const (
+	intPhi     = 0x9E3779B9
+	freeKey    = 0
+	fillFactor = 0.6
+
+	ptrsize = unsafe.Sizeof(uintptr(0))
+)
+
+func phiMix(x uintptr) uint64 {
+	h := uint64(x * intPhi)
+	return h ^ (h >> 16)
+}
+
+func calcThreshold(capacity int) int {
+	return int(math.Floor(float64(capacity) * fillFactor))
+}
+
+type iiMap struct {
+	data    []iiEntry
+	dataptr unsafe.Pointer
+
+	threshold int
+	size      int
+	mask      uint64
+}
+
+type iiEntry struct {
+	K uintptr
+	V interface{}
+}
+
+func newIIMap(capacity int) *iiMap {
+	if capacity&(capacity-1) != 0 {
+		panic("capacity must be power of two")
+	}
+	threshold := calcThreshold(capacity)
+	mask := capacity - 1
+	data := make([]iiEntry, capacity)
+	return &iiMap{
+		data:      data,
+		dataptr:   unsafe.Pointer(&data[0]),
+		threshold: threshold,
+		size:      0,
+		mask:      uint64(mask),
+	}
+}
+
+// getK helps to eliminate slice bounds checking
+func (m *iiMap) getK(ptr uint64) *uintptr {
+	return (*uintptr)(unsafe.Pointer(uintptr(m.dataptr) + uintptr(ptr)*3*ptrsize))
+}
+
+// getV helps to eliminate slice bounds checking
+func (m *iiMap) getV(ptr uint64) *interface{} {
+	return (*interface{})(unsafe.Pointer(uintptr(m.dataptr) + uintptr(ptr)*3*ptrsize + ptrsize))
+}
+
+func (m *iiMap) Get(key uintptr) interface{} {
+	// manually inline phiMix to help inlining
+	h := uint64(key * intPhi)
+	ptr := h ^ (h >> 16)
+
+	for {
+		ptr &= m.mask
+		k := *m.getK(ptr)
+		if k == key {
+			return *m.getV(ptr)
+		}
+		if k == freeKey {
+			return nil
+		}
+		ptr += 1
+	}
+}
+
+func (m *iiMap) Set(key uintptr, val interface{}) {
+	ptr := phiMix(key)
+	for {
+		ptr &= m.mask
+		k := *m.getK(ptr)
+		if k == freeKey {
+			*m.getK(ptr) = key
+			*m.getV(ptr) = val
+			m.size++
+			return
+		}
+		if k == key {
+			*m.getV(ptr) = val
+			return
+		}
+		ptr += 1
+	}
+}
+
+func (m *iiMap) Copy() *iiMap {
+	capacity := cap(m.data)
+	if m.size >= m.threshold {
+		capacity *= 2
+	}
+	newMap := newIIMap(capacity)
+	for _, e := range m.data {
+		if e.K == freeKey {
+			continue
+		}
+		newMap.Set(e.K, e.V)
+	}
+	return newMap
+}

--- a/internal/iimap/intintmap_test.go
+++ b/internal/iimap/intintmap_test.go
@@ -1,0 +1,28 @@
+package iimap
+
+import "testing"
+
+func TestTypeMapSimple(t *testing.T) {
+	m := NewTypeMap()
+	var i uintptr
+	var v interface{}
+
+	const n = 20000
+
+	for i = 2; i < n; i += 2 {
+		m.Set(i, i)
+	}
+
+	for i = 2; i < n; i += 2 {
+		if v = m.Get(i); v != i {
+			t.Errorf("didn't get expected value, %v, %v", i, v)
+		}
+		if v = m.Get(i + 1); v != nil {
+			t.Errorf("didn't get expected 'not found' flag")
+		}
+	}
+
+	if m.Size() != (n-2)/2 {
+		t.Errorf("size (%d) is not right, should be %d", m.Size(), n-1)
+	}
+}


### PR DESCRIPTION
This PR adds a fast intintmap to use for type information cache when there are too many type information to use slice.
Benchmark shows it's slightly slower than the slice access, but is much faster than the builtin map.

This closes the issue #194.