### PR TITLE
 Supports using omitempty and string tags at the same time

### DIFF
--- a/cover_bool_test.go
+++ b/cover_bool_test.go
@@ -26,6 +26,9 @@ func TestCoverBool(t *testing.T) {
 	type structBoolString struct {
 		A bool `json:"a,string"`
 	}
+	type structBoolStringOmitEmpty struct {
+		A bool `json:"a,string,omitempty"`
+	}
 
 	type structBoolPtr struct {
 		A *bool `json:"a"`
@@ -35,6 +38,9 @@ func TestCoverBool(t *testing.T) {
 	}
 	type structBoolPtrString struct {
 		A *bool `json:"a,string"`
+	}
+	type structBoolPtrStringOmitEmpty struct {
+		A *bool `json:"a,string,omitempty"`
 	}
 
 	type structCustomBoolOmitEmpty struct {
@@ -99,6 +105,12 @@ func TestCoverBool(t *testing.T) {
 				A bool `json:"a,string"`
 			}{},
 		},
+		{
+			name: "HeadBoolZeroStringOmitEmpty",
+			data: struct {
+				A bool `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// HeadBool
 		{
@@ -117,6 +129,12 @@ func TestCoverBool(t *testing.T) {
 			name: "HeadBoolString",
 			data: struct {
 				A bool `json:"a,string"`
+			}{A: true},
+		},
+		{
+			name: "HeadBoolStringOmitEmpty",
+			data: struct {
+				A bool `json:"a,string,omitempty"`
 			}{A: true},
 		},
 
@@ -139,6 +157,12 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			}{A: boolptr(true)},
 		},
+		{
+			name: "HeadBoolPtrStringOmitEmpty",
+			data: struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: boolptr(true)},
+		},
 
 		// HeadBoolPtrNil
 		{
@@ -157,6 +181,12 @@ func TestCoverBool(t *testing.T) {
 			name: "HeadBoolPtrNilString",
 			data: struct {
 				A *bool `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "HeadBoolPtrNilStringOmitEmpty",
+			data: struct {
+				A *bool `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -179,6 +209,12 @@ func TestCoverBool(t *testing.T) {
 				A bool `json:"a,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadBoolZeroStringOmitEmpty",
+			data: &struct {
+				A bool `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadBool
 		{
@@ -197,6 +233,12 @@ func TestCoverBool(t *testing.T) {
 			name: "PtrHeadBoolString",
 			data: &struct {
 				A bool `json:"a,string"`
+			}{A: true},
+		},
+		{
+			name: "PtrHeadBoolStringOmitEmpty",
+			data: &struct {
+				A bool `json:"a,string,omitempty"`
 			}{A: true},
 		},
 
@@ -219,6 +261,12 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			}{A: boolptr(true)},
 		},
+		{
+			name: "PtrHeadBoolPtrStringOmitEmpty",
+			data: &struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: boolptr(true)},
+		},
 
 		// PtrHeadBoolPtrNil
 		{
@@ -237,6 +285,12 @@ func TestCoverBool(t *testing.T) {
 			name: "PtrHeadBoolPtrNilString",
 			data: &struct {
 				A *bool `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadBoolPtrNilStringOmitEmpty",
+			data: &struct {
+				A *bool `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -259,6 +313,12 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			})(nil),
 		},
+		{
+			name: "PtrHeadBoolNilStringOmitEmpty",
+			data: (*struct {
+				A *bool `json:"a,string,omitempty"`
+			})(nil),
+		},
 
 		// HeadBoolZeroMultiFields
 		{
@@ -278,11 +338,19 @@ func TestCoverBool(t *testing.T) {
 			}{},
 		},
 		{
-			name: "HeadBoolZeroMultiFields",
+			name: "HeadBoolZeroMultiFieldsString",
 			data: struct {
 				A bool `json:"a,string"`
 				B bool `json:"b,string"`
 				C bool `json:"c,string"`
+			}{},
+		},
+		{
+			name: "HeadBoolZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A bool `json:"a,string,omitempty"`
+				B bool `json:"b,string,omitempty"`
+				C bool `json:"c,string,omitempty"`
 			}{},
 		},
 
@@ -311,6 +379,14 @@ func TestCoverBool(t *testing.T) {
 				C bool `json:"c,string"`
 			}{A: true, B: false, C: true},
 		},
+		{
+			name: "HeadBoolMultiFieldsStringOmitEmpty",
+			data: struct {
+				A bool `json:"a,string,omitempty"`
+				B bool `json:"b,string,omitempty"`
+				C bool `json:"c,string,omitempty"`
+			}{A: true, B: false, C: true},
+		},
 
 		// HeadBoolPtrMultiFields
 		{
@@ -335,6 +411,14 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 				B *bool `json:"b,string"`
 				C *bool `json:"c,string"`
+			}{A: boolptr(true), B: boolptr(false), C: boolptr(true)},
+		},
+		{
+			name: "HeadBoolPtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
+				C *bool `json:"c,string,omitempty"`
 			}{A: boolptr(true), B: boolptr(false), C: boolptr(true)},
 		},
 
@@ -363,6 +447,14 @@ func TestCoverBool(t *testing.T) {
 				C *bool `json:"c,string"`
 			}{A: nil, B: nil, C: nil},
 		},
+		{
+			name: "HeadBoolPtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
+				C *bool `json:"c,string,omitempty"`
+			}{A: nil, B: nil, C: nil},
+		},
 
 		// PtrHeadBoolZeroMultiFields
 		{
@@ -384,6 +476,13 @@ func TestCoverBool(t *testing.T) {
 			data: &struct {
 				A bool `json:"a,string"`
 				B bool `json:"b,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadBoolZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A bool `json:"a,string,omitempty"`
+				B bool `json:"b,string,omitempty"`
 			}{},
 		},
 
@@ -409,6 +508,13 @@ func TestCoverBool(t *testing.T) {
 				B bool `json:"b,string"`
 			}{A: true, B: false},
 		},
+		{
+			name: "PtrHeadBoolMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A bool `json:"a,string,omitempty"`
+				B bool `json:"b,string,omitempty"`
+			}{A: true, B: false},
+		},
 
 		// PtrHeadBoolPtrMultiFields
 		{
@@ -430,6 +536,13 @@ func TestCoverBool(t *testing.T) {
 			data: &struct {
 				A *bool `json:"a,string"`
 				B *bool `json:"b,string"`
+			}{A: boolptr(true), B: boolptr(false)},
+		},
+		{
+			name: "PtrHeadBoolPtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
 			}{A: boolptr(true), B: boolptr(false)},
 		},
 
@@ -455,6 +568,13 @@ func TestCoverBool(t *testing.T) {
 				B *bool `json:"b,string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadBoolPtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadBoolNilMultiFields
 		{
@@ -476,6 +596,13 @@ func TestCoverBool(t *testing.T) {
 			data: (*struct {
 				A *bool `json:"a,string"`
 				B *bool `json:"b,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadBoolNilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
 			})(nil),
 		},
 
@@ -501,6 +628,14 @@ func TestCoverBool(t *testing.T) {
 			data: struct {
 				A struct {
 					A bool `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadBoolZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A bool `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -536,6 +671,16 @@ func TestCoverBool(t *testing.T) {
 				A bool `json:"a,string"`
 			}{A: true}},
 		},
+		{
+			name: "HeadBoolNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A bool `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A bool `json:"a,string,omitempty"`
+			}{A: true}},
+		},
 
 		// HeadBoolPtrNotRoot
 		{
@@ -568,6 +713,16 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			}{boolptr(true)}},
 		},
+		{
+			name: "HeadBoolPtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *bool `json:"a,string,omitempty"`
+			}{boolptr(true)}},
+		},
 
 		// HeadBoolPtrNilNotRoot
 		{
@@ -591,6 +746,14 @@ func TestCoverBool(t *testing.T) {
 			data: struct {
 				A struct {
 					A *bool `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadBoolPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *bool `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -626,6 +789,16 @@ func TestCoverBool(t *testing.T) {
 				A bool `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadBoolZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A bool `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A bool `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadBoolNotRoot
 		{
@@ -656,6 +829,16 @@ func TestCoverBool(t *testing.T) {
 				}
 			}{A: &(struct {
 				A bool `json:"a,string"`
+			}{A: true})},
+		},
+		{
+			name: "PtrHeadBoolNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A bool `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A bool `json:"a,string,omitempty"`
 			}{A: true})},
 		},
 
@@ -690,6 +873,16 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			}{A: boolptr(true)})},
 		},
+		{
+			name: "PtrHeadBoolPtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: boolptr(true)})},
+		},
 
 		// PtrHeadBoolPtrNilNotRoot
 		{
@@ -722,6 +915,16 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadBoolPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadBoolNilNotRoot
 		{
@@ -746,6 +949,14 @@ func TestCoverBool(t *testing.T) {
 				A *struct {
 					A *bool `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadBoolNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -780,6 +991,17 @@ func TestCoverBool(t *testing.T) {
 				}
 				B struct {
 					B bool `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadBoolZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A bool `json:"a,string,omitempty"`
+				}
+				B struct {
+					B bool `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -830,6 +1052,21 @@ func TestCoverBool(t *testing.T) {
 				B bool `json:"b,string"`
 			}{B: false}},
 		},
+		{
+			name: "HeadBoolMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A bool `json:"a,string,omitempty"`
+				}
+				B struct {
+					B bool `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A bool `json:"a,string,omitempty"`
+			}{A: true}, B: struct {
+				B bool `json:"b,string,omitempty"`
+			}{B: false}},
+		},
 
 		// HeadBoolPtrMultiFieldsNotRoot
 		{
@@ -875,6 +1112,21 @@ func TestCoverBool(t *testing.T) {
 				A *bool `json:"a,string"`
 			}{A: boolptr(true)}, B: struct {
 				B *bool `json:"b,string"`
+			}{B: boolptr(false)}},
+		},
+		{
+			name: "HeadBoolPtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *bool `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: boolptr(true)}, B: struct {
+				B *bool `json:"b,string,omitempty"`
 			}{B: boolptr(false)}},
 		},
 
@@ -924,6 +1176,21 @@ func TestCoverBool(t *testing.T) {
 				B *bool `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadBoolPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *bool `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *bool `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadBoolZeroMultiFieldsNotRoot
 		{
@@ -956,6 +1223,17 @@ func TestCoverBool(t *testing.T) {
 				}
 				B struct {
 					B bool `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadBoolZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A bool `json:"a,string,omitempty"`
+				}
+				B struct {
+					B bool `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -1006,6 +1284,21 @@ func TestCoverBool(t *testing.T) {
 				B bool `json:"b,string"`
 			}{B: false}},
 		},
+		{
+			name: "PtrHeadBoolMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A bool `json:"a,string,omitempty"`
+				}
+				B struct {
+					B bool `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A bool `json:"a,string,omitempty"`
+			}{A: true}, B: struct {
+				B bool `json:"b,string,omitempty"`
+			}{B: false}},
+		},
 
 		// PtrHeadBoolPtrMultiFieldsNotRoot
 		{
@@ -1053,6 +1346,21 @@ func TestCoverBool(t *testing.T) {
 				B *bool `json:"b,string"`
 			}{B: boolptr(false)})},
 		},
+		{
+			name: "PtrHeadBoolPtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *bool `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *bool `json:"a,string,omitempty"`
+			}{A: boolptr(true)}), B: &(struct {
+				B *bool `json:"b,string,omitempty"`
+			}{B: boolptr(false)})},
+		},
 
 		// PtrHeadBoolPtrNilMultiFieldsNotRoot
 		{
@@ -1088,6 +1396,17 @@ func TestCoverBool(t *testing.T) {
 				} `json:",string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadBoolPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+				} `json:",string"`
+				B *struct {
+					B *bool `json:"b,string,omitempty"`
+				} `json:",string"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadBoolNilMultiFieldsNotRoot
 		{
@@ -1120,6 +1439,17 @@ func TestCoverBool(t *testing.T) {
 				}
 				B *struct {
 					B *bool `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadBoolNilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *bool `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1182,6 +1512,25 @@ func TestCoverBool(t *testing.T) {
 				B bool `json:"b,string"`
 			}{A: true, B: false})},
 		},
+		{
+			name: "PtrHeadBoolDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A bool `json:"a,string,omitempty"`
+					B bool `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A bool `json:"a,string,omitempty"`
+					B bool `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A bool `json:"a,string,omitempty"`
+				B bool `json:"b,string,omitempty"`
+			}{A: true, B: false}), B: &(struct {
+				A bool `json:"a,string,omitempty"`
+				B bool `json:"b,string,omitempty"`
+			}{A: true, B: false})},
+		},
 
 		// PtrHeadBoolNilDoubleMultiFieldsNotRoot
 		{
@@ -1223,6 +1572,19 @@ func TestCoverBool(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadBoolNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A bool `json:"a,string,omitempty"`
+					B bool `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A bool `json:"a,string,omitempty"`
+					B bool `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadBoolNilDoubleMultiFieldsNotRoot
 		{
@@ -1261,6 +1623,19 @@ func TestCoverBool(t *testing.T) {
 				B *struct {
 					A bool `json:"a,string"`
 					B bool `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadBoolNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A bool `json:"a,string,omitempty"`
+					B bool `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A bool `json:"a,string,omitempty"`
+					B bool `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1323,6 +1698,25 @@ func TestCoverBool(t *testing.T) {
 				B *bool `json:"b,string"`
 			}{A: boolptr(true), B: boolptr(false)})},
 		},
+		{
+			name: "PtrHeadBoolPtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+					B *bool `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *bool `json:"a,string,omitempty"`
+					B *bool `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
+			}{A: boolptr(true), B: boolptr(false)}), B: &(struct {
+				A *bool `json:"a,string,omitempty"`
+				B *bool `json:"b,string,omitempty"`
+			}{A: boolptr(true), B: boolptr(false)})},
+		},
 
 		// PtrHeadBoolPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1364,6 +1758,19 @@ func TestCoverBool(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadBoolPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+					B *bool `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *bool `json:"a,string,omitempty"`
+					B *bool `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadBoolPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1402,6 +1809,19 @@ func TestCoverBool(t *testing.T) {
 				B *struct {
 					A *bool `json:"a,string"`
 					B *bool `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadBoolPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *bool `json:"a,string,omitempty"`
+					B *bool `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *bool `json:"a,string,omitempty"`
+					B *bool `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1517,6 +1937,16 @@ func TestCoverBool(t *testing.T) {
 				B:                false,
 			},
 		},
+		{
+			name: "AnonymousHeadBoolStringOmitEmpty",
+			data: struct {
+				structBoolStringOmitEmpty
+				B bool `json:"b,string,omitempty"`
+			}{
+				structBoolStringOmitEmpty: structBoolStringOmitEmpty{A: true},
+				B:                         false,
+			},
+		},
 
 		// PtrAnonymousHeadBool
 		{
@@ -1629,6 +2059,16 @@ func TestCoverBool(t *testing.T) {
 				B:                false,
 			},
 		},
+		{
+			name: "PtrAnonymousHeadBoolStringOmitEmpty",
+			data: struct {
+				*structBoolStringOmitEmpty
+				B bool `json:"b,string,omitempty"`
+			}{
+				structBoolStringOmitEmpty: &structBoolStringOmitEmpty{A: true},
+				B:                         false,
+			},
+		},
 
 		// NilPtrAnonymousHeadBool
 		{
@@ -1681,6 +2121,16 @@ func TestCoverBool(t *testing.T) {
 				B:                true,
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadBoolStringOmitEmpty",
+			data: struct {
+				*structBoolStringOmitEmpty
+				B bool `json:"b,string,omitempty"`
+			}{
+				structBoolStringOmitEmpty: nil,
+				B:                         true,
+			},
+		},
 
 		// AnonymousHeadBoolPtr
 		{
@@ -1711,6 +2161,16 @@ func TestCoverBool(t *testing.T) {
 			}{
 				structBoolPtrString: structBoolPtrString{A: boolptr(true)},
 				B:                   boolptr(false),
+			},
+		},
+		{
+			name: "AnonymousHeadBoolPtrStringOmitEmpty",
+			data: struct {
+				structBoolPtrStringOmitEmpty
+				B *bool `json:"b,string,omitempty"`
+			}{
+				structBoolPtrStringOmitEmpty: structBoolPtrStringOmitEmpty{A: boolptr(true)},
+				B:                            boolptr(false),
 			},
 		},
 
@@ -1745,6 +2205,16 @@ func TestCoverBool(t *testing.T) {
 				B:                   boolptr(true),
 			},
 		},
+		{
+			name: "AnonymousHeadBoolPtrNilStringOmitEmpty",
+			data: struct {
+				structBoolPtrStringOmitEmpty
+				B *bool `json:"b,string,omitempty"`
+			}{
+				structBoolPtrStringOmitEmpty: structBoolPtrStringOmitEmpty{A: nil},
+				B:                            boolptr(true),
+			},
+		},
 
 		// PtrAnonymousHeadBoolPtr
 		{
@@ -1777,6 +2247,16 @@ func TestCoverBool(t *testing.T) {
 				B:                   boolptr(false),
 			},
 		},
+		{
+			name: "PtrAnonymousHeadBoolPtrStringOmitEmpty",
+			data: struct {
+				*structBoolPtrStringOmitEmpty
+				B *bool `json:"b,string,omitempty"`
+			}{
+				structBoolPtrStringOmitEmpty: &structBoolPtrStringOmitEmpty{A: boolptr(true)},
+				B:                            boolptr(false),
+			},
+		},
 
 		// NilPtrAnonymousHeadBoolPtr
 		{
@@ -1807,6 +2287,16 @@ func TestCoverBool(t *testing.T) {
 			}{
 				structBoolPtrString: nil,
 				B:                   boolptr(true),
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadBoolPtrStringOmitEmpty",
+			data: struct {
+				*structBoolPtrStringOmitEmpty
+				B *bool `json:"b,string,omitempty"`
+			}{
+				structBoolPtrStringOmitEmpty: nil,
+				B:                            boolptr(true),
 			},
 		},
 
@@ -1883,6 +2373,14 @@ func TestCoverBool(t *testing.T) {
 				structBoolString: structBoolString{A: true},
 			},
 		},
+		{
+			name: "AnonymousHeadBoolOnlyStringOmitEmpty",
+			data: struct {
+				structBoolStringOmitEmpty
+			}{
+				structBoolStringOmitEmpty: structBoolStringOmitEmpty{A: true},
+			},
+		},
 
 		// PtrAnonymousHeadBoolOnly
 		{
@@ -1957,6 +2455,14 @@ func TestCoverBool(t *testing.T) {
 				structBoolString: &structBoolString{A: true},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadBoolOnlyStringOmitEmpty",
+			data: struct {
+				*structBoolStringOmitEmpty
+			}{
+				structBoolStringOmitEmpty: &structBoolStringOmitEmpty{A: true},
+			},
+		},
 
 		// NilPtrAnonymousHeadBoolOnly
 		{
@@ -1999,6 +2505,14 @@ func TestCoverBool(t *testing.T) {
 				structBoolString: nil,
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadBoolOnlyStringOmitEmpty",
+			data: struct {
+				*structBoolStringOmitEmpty
+			}{
+				structBoolStringOmitEmpty: nil,
+			},
+		},
 
 		// AnonymousHeadBoolPtrOnly
 		{
@@ -2023,6 +2537,14 @@ func TestCoverBool(t *testing.T) {
 				structBoolPtrString
 			}{
 				structBoolPtrString: structBoolPtrString{A: boolptr(true)},
+			},
+		},
+		{
+			name: "AnonymousHeadBoolPtrOnlyStringOmitEmpty",
+			data: struct {
+				structBoolPtrStringOmitEmpty
+			}{
+				structBoolPtrStringOmitEmpty: structBoolPtrStringOmitEmpty{A: boolptr(true)},
 			},
 		},
 
@@ -2051,6 +2573,14 @@ func TestCoverBool(t *testing.T) {
 				structBoolPtrString: structBoolPtrString{A: nil},
 			},
 		},
+		{
+			name: "AnonymousHeadBoolPtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structBoolPtrStringOmitEmpty
+			}{
+				structBoolPtrStringOmitEmpty: structBoolPtrStringOmitEmpty{A: nil},
+			},
+		},
 
 		// PtrAnonymousHeadBoolPtrOnly
 		{
@@ -2077,6 +2607,14 @@ func TestCoverBool(t *testing.T) {
 				structBoolPtrString: &structBoolPtrString{A: boolptr(true)},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadBoolPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structBoolPtrStringOmitEmpty
+			}{
+				structBoolPtrStringOmitEmpty: &structBoolPtrStringOmitEmpty{A: boolptr(true)},
+			},
+		},
 
 		// NilPtrAnonymousHeadBoolPtrOnly
 		{
@@ -2101,6 +2639,14 @@ func TestCoverBool(t *testing.T) {
 				*structBoolPtrString
 			}{
 				structBoolPtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadBoolPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structBoolPtrStringOmitEmpty
+			}{
+				structBoolPtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/cover_float32_test.go
+++ b/cover_float32_test.go
@@ -17,6 +17,9 @@ func TestCoverFloat32(t *testing.T) {
 	type structFloat32String struct {
 		A float32 `json:"a,string"`
 	}
+	type structFloat32StringOmitEmpty struct {
+		A float32 `json:"a,string,omitempty"`
+	}
 
 	type structFloat32Ptr struct {
 		A *float32 `json:"a"`
@@ -26,6 +29,9 @@ func TestCoverFloat32(t *testing.T) {
 	}
 	type structFloat32PtrString struct {
 		A *float32 `json:"a,string"`
+	}
+	type structFloat32PtrStringOmitEmpty struct {
+		A *float32 `json:"a,string,omitempty"`
 	}
 
 	tests := []struct {
@@ -72,6 +78,12 @@ func TestCoverFloat32(t *testing.T) {
 				A float32 `json:"a,string"`
 			}{},
 		},
+		{
+			name: "HeadFloat32ZeroStringOmitEmpty",
+			data: struct {
+				A float32 `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// HeadFloat32
 		{
@@ -90,6 +102,12 @@ func TestCoverFloat32(t *testing.T) {
 			name: "HeadFloat32String",
 			data: struct {
 				A float32 `json:"a,string"`
+			}{A: 1},
+		},
+		{
+			name: "HeadFloat32StringOmitEmpty",
+			data: struct {
+				A float32 `json:"a,string,omitempty"`
 			}{A: 1},
 		},
 
@@ -112,6 +130,12 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			}{A: float32ptr(1)},
 		},
+		{
+			name: "HeadFloat32PtrStringOmitEmpty",
+			data: struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: float32ptr(1)},
+		},
 
 		// HeadFloat32PtrNil
 		{
@@ -130,6 +154,12 @@ func TestCoverFloat32(t *testing.T) {
 			name: "HeadFloat32PtrNilString",
 			data: struct {
 				A *float32 `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "HeadFloat32PtrNilStringOmitEmpty",
+			data: struct {
+				A *float32 `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -152,6 +182,12 @@ func TestCoverFloat32(t *testing.T) {
 				A float32 `json:"a,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadFloat32ZeroStringOmitEmpty",
+			data: &struct {
+				A float32 `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadFloat32
 		{
@@ -170,6 +206,12 @@ func TestCoverFloat32(t *testing.T) {
 			name: "PtrHeadFloat32String",
 			data: &struct {
 				A float32 `json:"a,string"`
+			}{A: 1},
+		},
+		{
+			name: "PtrHeadFloat32StringOmitEmpty",
+			data: &struct {
+				A float32 `json:"a,string,omitempty"`
 			}{A: 1},
 		},
 
@@ -192,6 +234,12 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			}{A: float32ptr(1)},
 		},
+		{
+			name: "PtrHeadFloat32PtrStringOmitEmpty",
+			data: &struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: float32ptr(1)},
+		},
 
 		// PtrHeadFloat32PtrNil
 		{
@@ -210,6 +258,12 @@ func TestCoverFloat32(t *testing.T) {
 			name: "PtrHeadFloat32PtrNilString",
 			data: &struct {
 				A *float32 `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadFloat32PtrNilStringOmitEmpty",
+			data: &struct {
+				A *float32 `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -232,6 +286,12 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			})(nil),
 		},
+		{
+			name: "PtrHeadFloat32NilStringOmitEmpty",
+			data: (*struct {
+				A *float32 `json:"a,string,omitempty"`
+			})(nil),
+		},
 
 		// HeadFloat32ZeroMultiFields
 		{
@@ -251,11 +311,19 @@ func TestCoverFloat32(t *testing.T) {
 			}{},
 		},
 		{
-			name: "HeadFloat32ZeroMultiFields",
+			name: "HeadFloat32ZeroMultiFieldsString",
 			data: struct {
 				A float32 `json:"a,string"`
 				B float32 `json:"b,string"`
 				C float32 `json:"c,string"`
+			}{},
+		},
+		{
+			name: "HeadFloat32ZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A float32 `json:"a,string,omitempty"`
+				B float32 `json:"b,string,omitempty"`
+				C float32 `json:"c,string,omitempty"`
 			}{},
 		},
 
@@ -284,6 +352,14 @@ func TestCoverFloat32(t *testing.T) {
 				C float32 `json:"c,string"`
 			}{A: 1, B: 2, C: 3},
 		},
+		{
+			name: "HeadFloat32MultiFieldsStringOmitEmpty",
+			data: struct {
+				A float32 `json:"a,string,omitempty"`
+				B float32 `json:"b,string,omitempty"`
+				C float32 `json:"c,string,omitempty"`
+			}{A: 1, B: 2, C: 3},
+		},
 
 		// HeadFloat32PtrMultiFields
 		{
@@ -308,6 +384,14 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 				B *float32 `json:"b,string"`
 				C *float32 `json:"c,string"`
+			}{A: float32ptr(1), B: float32ptr(2), C: float32ptr(3)},
+		},
+		{
+			name: "HeadFloat32PtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
+				C *float32 `json:"c,string,omitempty"`
 			}{A: float32ptr(1), B: float32ptr(2), C: float32ptr(3)},
 		},
 
@@ -336,6 +420,14 @@ func TestCoverFloat32(t *testing.T) {
 				C *float32 `json:"c,string"`
 			}{A: nil, B: nil, C: nil},
 		},
+		{
+			name: "HeadFloat32PtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
+				C *float32 `json:"c,string,omitempty"`
+			}{A: nil, B: nil, C: nil},
+		},
 
 		// PtrHeadFloat32ZeroMultiFields
 		{
@@ -357,6 +449,13 @@ func TestCoverFloat32(t *testing.T) {
 			data: &struct {
 				A float32 `json:"a,string"`
 				B float32 `json:"b,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadFloat32ZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A float32 `json:"a,string,omitempty"`
+				B float32 `json:"b,string,omitempty"`
 			}{},
 		},
 
@@ -382,6 +481,13 @@ func TestCoverFloat32(t *testing.T) {
 				B float32 `json:"b,string"`
 			}{A: 1, B: 2},
 		},
+		{
+			name: "PtrHeadFloat32MultiFieldsStringOmitEmpty",
+			data: &struct {
+				A float32 `json:"a,string,omitempty"`
+				B float32 `json:"b,string,omitempty"`
+			}{A: 1, B: 2},
+		},
 
 		// PtrHeadFloat32PtrMultiFields
 		{
@@ -403,6 +509,13 @@ func TestCoverFloat32(t *testing.T) {
 			data: &struct {
 				A *float32 `json:"a,string"`
 				B *float32 `json:"b,string"`
+			}{A: float32ptr(1), B: float32ptr(2)},
+		},
+		{
+			name: "PtrHeadFloat32PtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
 			}{A: float32ptr(1), B: float32ptr(2)},
 		},
 
@@ -428,6 +541,13 @@ func TestCoverFloat32(t *testing.T) {
 				B *float32 `json:"b,string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat32PtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat32NilMultiFields
 		{
@@ -449,6 +569,13 @@ func TestCoverFloat32(t *testing.T) {
 			data: (*struct {
 				A *float32 `json:"a,string"`
 				B *float32 `json:"b,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat32NilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
 			})(nil),
 		},
 
@@ -474,6 +601,14 @@ func TestCoverFloat32(t *testing.T) {
 			data: struct {
 				A struct {
 					A float32 `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadFloat32ZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float32 `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -509,6 +644,16 @@ func TestCoverFloat32(t *testing.T) {
 				A float32 `json:"a,string"`
 			}{A: 1}},
 		},
+		{
+			name: "HeadFloat32NotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A float32 `json:"a,string,omitempty"`
+			}{A: 1}},
+		},
 
 		// HeadFloat32PtrNotRoot
 		{
@@ -541,6 +686,16 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			}{float32ptr(1)}},
 		},
+		{
+			name: "HeadFloat32PtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{float32ptr(1)}},
+		},
 
 		// HeadFloat32PtrNilNotRoot
 		{
@@ -564,6 +719,14 @@ func TestCoverFloat32(t *testing.T) {
 			data: struct {
 				A struct {
 					A *float32 `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadFloat32PtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float32 `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -599,6 +762,16 @@ func TestCoverFloat32(t *testing.T) {
 				A float32 `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadFloat32ZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A float32 `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadFloat32NotRoot
 		{
@@ -629,6 +802,16 @@ func TestCoverFloat32(t *testing.T) {
 				}
 			}{A: &(struct {
 				A float32 `json:"a,string"`
+			}{A: 1})},
+		},
+		{
+			name: "PtrHeadFloat32NotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A float32 `json:"a,string,omitempty"`
 			}{A: 1})},
 		},
 
@@ -663,6 +846,16 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			}{A: float32ptr(1)})},
 		},
+		{
+			name: "PtrHeadFloat32PtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: float32ptr(1)})},
+		},
 
 		// PtrHeadFloat32PtrNilNotRoot
 		{
@@ -695,6 +888,16 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadFloat32PtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadFloat32NilNotRoot
 		{
@@ -719,6 +922,14 @@ func TestCoverFloat32(t *testing.T) {
 				A *struct {
 					A *float32 `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadFloat32NilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -753,6 +964,17 @@ func TestCoverFloat32(t *testing.T) {
 				}
 				B struct {
 					B float32 `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadFloat32ZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float32 `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -803,6 +1025,21 @@ func TestCoverFloat32(t *testing.T) {
 				B float32 `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "HeadFloat32MultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float32 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A float32 `json:"a,string,omitempty"`
+			}{A: 1}, B: struct {
+				B float32 `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// HeadFloat32PtrMultiFieldsNotRoot
 		{
@@ -848,6 +1085,21 @@ func TestCoverFloat32(t *testing.T) {
 				A *float32 `json:"a,string"`
 			}{A: float32ptr(1)}, B: struct {
 				B *float32 `json:"b,string"`
+			}{B: float32ptr(2)}},
+		},
+		{
+			name: "HeadFloat32PtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *float32 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: float32ptr(1)}, B: struct {
+				B *float32 `json:"b,string,omitempty"`
 			}{B: float32ptr(2)}},
 		},
 
@@ -897,6 +1149,21 @@ func TestCoverFloat32(t *testing.T) {
 				B *float32 `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadFloat32PtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *float32 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *float32 `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadFloat32ZeroMultiFieldsNotRoot
 		{
@@ -929,6 +1196,17 @@ func TestCoverFloat32(t *testing.T) {
 				}
 				B struct {
 					B float32 `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadFloat32ZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float32 `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -979,6 +1257,21 @@ func TestCoverFloat32(t *testing.T) {
 				B float32 `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "PtrHeadFloat32MultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A float32 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float32 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A float32 `json:"a,string,omitempty"`
+			}{A: 1}, B: struct {
+				B float32 `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// PtrHeadFloat32PtrMultiFieldsNotRoot
 		{
@@ -1026,6 +1319,21 @@ func TestCoverFloat32(t *testing.T) {
 				B *float32 `json:"b,string"`
 			}{B: float32ptr(2)})},
 		},
+		{
+			name: "PtrHeadFloat32PtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *float32 `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float32 `json:"a,string,omitempty"`
+			}{A: float32ptr(1)}), B: &(struct {
+				B *float32 `json:"b,string,omitempty"`
+			}{B: float32ptr(2)})},
+		},
 
 		// PtrHeadFloat32PtrNilMultiFieldsNotRoot
 		{
@@ -1061,6 +1369,17 @@ func TestCoverFloat32(t *testing.T) {
 				} `json:",string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat32PtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
+				B *struct {
+					B *float32 `json:"b,string,omitempty"`
+				} `json:",string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat32NilMultiFieldsNotRoot
 		{
@@ -1093,6 +1412,17 @@ func TestCoverFloat32(t *testing.T) {
 				}
 				B *struct {
 					B *float32 `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat32NilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *float32 `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1155,6 +1485,25 @@ func TestCoverFloat32(t *testing.T) {
 				B float32 `json:"b,string"`
 			}{A: 3, B: 4})},
 		},
+		{
+			name: "PtrHeadFloat32DoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A float32 `json:"a,string,omitempty"`
+					B float32 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A float32 `json:"a,string,omitempty"`
+					B float32 `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A float32 `json:"a,string,omitempty"`
+				B float32 `json:"b,string,omitempty"`
+			}{A: 1, B: 2}), B: &(struct {
+				A float32 `json:"a,string,omitempty"`
+				B float32 `json:"b,string,omitempty"`
+			}{A: 3, B: 4})},
+		},
 
 		// PtrHeadFloat32NilDoubleMultiFieldsNotRoot
 		{
@@ -1196,6 +1545,19 @@ func TestCoverFloat32(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat32NilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A float32 `json:"a,string,omitempty"`
+					B float32 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A float32 `json:"a,string,omitempty"`
+					B float32 `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat32NilDoubleMultiFieldsNotRoot
 		{
@@ -1234,6 +1596,19 @@ func TestCoverFloat32(t *testing.T) {
 				B *struct {
 					A float32 `json:"a,string"`
 					B float32 `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat32NilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A float32 `json:"a,string,omitempty"`
+					B float32 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A float32 `json:"a,string,omitempty"`
+					B float32 `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1296,6 +1671,25 @@ func TestCoverFloat32(t *testing.T) {
 				B *float32 `json:"b,string"`
 			}{A: float32ptr(3), B: float32ptr(4)})},
 		},
+		{
+			name: "PtrHeadFloat32PtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+					B *float32 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *float32 `json:"a,string,omitempty"`
+					B *float32 `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
+			}{A: float32ptr(1), B: float32ptr(2)}), B: &(struct {
+				A *float32 `json:"a,string,omitempty"`
+				B *float32 `json:"b,string,omitempty"`
+			}{A: float32ptr(3), B: float32ptr(4)})},
+		},
 
 		// PtrHeadFloat32PtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1337,6 +1731,19 @@ func TestCoverFloat32(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat32PtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+					B *float32 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *float32 `json:"a,string,omitempty"`
+					B *float32 `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat32PtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1375,6 +1782,19 @@ func TestCoverFloat32(t *testing.T) {
 				B *struct {
 					A *float32 `json:"a,string"`
 					B *float32 `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat32PtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *float32 `json:"a,string,omitempty"`
+					B *float32 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *float32 `json:"a,string,omitempty"`
+					B *float32 `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1410,6 +1830,16 @@ func TestCoverFloat32(t *testing.T) {
 				B:                   2,
 			},
 		},
+		{
+			name: "AnonymousHeadFloat32StringOmitEmpty",
+			data: struct {
+				structFloat32StringOmitEmpty
+				B float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32StringOmitEmpty: structFloat32StringOmitEmpty{A: 1},
+				B:                            2,
+			},
+		},
 
 		// PtrAnonymousHeadFloat32
 		{
@@ -1440,6 +1870,16 @@ func TestCoverFloat32(t *testing.T) {
 			}{
 				structFloat32String: &structFloat32String{A: 1},
 				B:                   2,
+			},
+		},
+		{
+			name: "PtrAnonymousHeadFloat32StringOmitEmpty",
+			data: struct {
+				*structFloat32StringOmitEmpty
+				B float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32StringOmitEmpty: &structFloat32StringOmitEmpty{A: 1},
+				B:                            2,
 			},
 		},
 
@@ -1474,6 +1914,16 @@ func TestCoverFloat32(t *testing.T) {
 				B:                   2,
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadFloat32StringOmitEmpty",
+			data: struct {
+				*structFloat32StringOmitEmpty
+				B float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32StringOmitEmpty: nil,
+				B:                            2,
+			},
+		},
 
 		// AnonymousHeadFloat32Ptr
 		{
@@ -1504,6 +1954,16 @@ func TestCoverFloat32(t *testing.T) {
 			}{
 				structFloat32PtrString: structFloat32PtrString{A: float32ptr(1)},
 				B:                      float32ptr(2),
+			},
+		},
+		{
+			name: "AnonymousHeadFloat32PtrStringOmitEmpty",
+			data: struct {
+				structFloat32PtrStringOmitEmpty
+				B *float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32PtrStringOmitEmpty: structFloat32PtrStringOmitEmpty{A: float32ptr(1)},
+				B:                               float32ptr(2),
 			},
 		},
 
@@ -1538,6 +1998,16 @@ func TestCoverFloat32(t *testing.T) {
 				B:                      float32ptr(2),
 			},
 		},
+		{
+			name: "AnonymousHeadFloat32PtrNilStringOmitEmpty",
+			data: struct {
+				structFloat32PtrStringOmitEmpty
+				B *float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32PtrStringOmitEmpty: structFloat32PtrStringOmitEmpty{A: nil},
+				B:                               float32ptr(2),
+			},
+		},
 
 		// PtrAnonymousHeadFloat32Ptr
 		{
@@ -1568,6 +2038,16 @@ func TestCoverFloat32(t *testing.T) {
 			}{
 				structFloat32PtrString: &structFloat32PtrString{A: float32ptr(1)},
 				B:                      float32ptr(2),
+			},
+		},
+		{
+			name: "PtrAnonymousHeadFloat32PtrStringOmitEmpty",
+			data: struct {
+				*structFloat32PtrStringOmitEmpty
+				B *float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32PtrStringOmitEmpty: &structFloat32PtrStringOmitEmpty{A: float32ptr(1)},
+				B:                               float32ptr(2),
 			},
 		},
 
@@ -1602,6 +2082,16 @@ func TestCoverFloat32(t *testing.T) {
 				B:                      float32ptr(2),
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadFloat32PtrStringOmitEmpty",
+			data: struct {
+				*structFloat32PtrStringOmitEmpty
+				B *float32 `json:"b,string,omitempty"`
+			}{
+				structFloat32PtrStringOmitEmpty: nil,
+				B:                               float32ptr(2),
+			},
+		},
 
 		// AnonymousHeadFloat32Only
 		{
@@ -1626,6 +2116,14 @@ func TestCoverFloat32(t *testing.T) {
 				structFloat32String
 			}{
 				structFloat32String: structFloat32String{A: 1},
+			},
+		},
+		{
+			name: "AnonymousHeadFloat32OnlyStringOmitEmpty",
+			data: struct {
+				structFloat32StringOmitEmpty
+			}{
+				structFloat32StringOmitEmpty: structFloat32StringOmitEmpty{A: 1},
 			},
 		},
 
@@ -1654,6 +2152,14 @@ func TestCoverFloat32(t *testing.T) {
 				structFloat32String: &structFloat32String{A: 1},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadFloat32OnlyStringOmitEmpty",
+			data: struct {
+				*structFloat32StringOmitEmpty
+			}{
+				structFloat32StringOmitEmpty: &structFloat32StringOmitEmpty{A: 1},
+			},
+		},
 
 		// NilPtrAnonymousHeadFloat32Only
 		{
@@ -1678,6 +2184,14 @@ func TestCoverFloat32(t *testing.T) {
 				*structFloat32String
 			}{
 				structFloat32String: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadFloat32OnlyStringOmitEmpty",
+			data: struct {
+				*structFloat32StringOmitEmpty
+			}{
+				structFloat32StringOmitEmpty: nil,
 			},
 		},
 
@@ -1706,6 +2220,14 @@ func TestCoverFloat32(t *testing.T) {
 				structFloat32PtrString: structFloat32PtrString{A: float32ptr(1)},
 			},
 		},
+		{
+			name: "AnonymousHeadFloat32PtrOnlyStringOmitEmpty",
+			data: struct {
+				structFloat32PtrStringOmitEmpty
+			}{
+				structFloat32PtrStringOmitEmpty: structFloat32PtrStringOmitEmpty{A: float32ptr(1)},
+			},
+		},
 
 		// AnonymousHeadFloat32PtrNilOnly
 		{
@@ -1730,6 +2252,14 @@ func TestCoverFloat32(t *testing.T) {
 				structFloat32PtrString
 			}{
 				structFloat32PtrString: structFloat32PtrString{A: nil},
+			},
+		},
+		{
+			name: "AnonymousHeadFloat32PtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structFloat32PtrStringOmitEmpty
+			}{
+				structFloat32PtrStringOmitEmpty: structFloat32PtrStringOmitEmpty{A: nil},
 			},
 		},
 
@@ -1758,6 +2288,14 @@ func TestCoverFloat32(t *testing.T) {
 				structFloat32PtrString: &structFloat32PtrString{A: float32ptr(1)},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadFloat32PtrOnlyStringOmitEmpty",
+			data: struct {
+				*structFloat32PtrStringOmitEmpty
+			}{
+				structFloat32PtrStringOmitEmpty: &structFloat32PtrStringOmitEmpty{A: float32ptr(1)},
+			},
+		},
 
 		// NilPtrAnonymousHeadFloat32PtrOnly
 		{
@@ -1782,6 +2320,14 @@ func TestCoverFloat32(t *testing.T) {
 				*structFloat32PtrString
 			}{
 				structFloat32PtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadFloat32PtrOnlyStringOmitEmpty",
+			data: struct {
+				*structFloat32PtrStringOmitEmpty
+			}{
+				structFloat32PtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/cover_float64_test.go
+++ b/cover_float64_test.go
@@ -17,6 +17,9 @@ func TestCoverFloat64(t *testing.T) {
 	type structFloat64String struct {
 		A float64 `json:"a,string"`
 	}
+	type structFloat64StringOmitEmpty struct {
+		A float64 `json:"a,string,omitempty"`
+	}
 
 	type structFloat64Ptr struct {
 		A *float64 `json:"a"`
@@ -26,6 +29,9 @@ func TestCoverFloat64(t *testing.T) {
 	}
 	type structFloat64PtrString struct {
 		A *float64 `json:"a,string"`
+	}
+	type structFloat64PtrStringOmitEmpty struct {
+		A *float64 `json:"a,string,omitempty"`
 	}
 
 	tests := []struct {
@@ -72,6 +78,12 @@ func TestCoverFloat64(t *testing.T) {
 				A float64 `json:"a,string"`
 			}{},
 		},
+		{
+			name: "HeadFloat64ZeroStringOmitEmpty",
+			data: struct {
+				A float64 `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// HeadFloat64
 		{
@@ -90,6 +102,12 @@ func TestCoverFloat64(t *testing.T) {
 			name: "HeadFloat64String",
 			data: struct {
 				A float64 `json:"a,string"`
+			}{A: 1},
+		},
+		{
+			name: "HeadFloat64StringOmitEmpty",
+			data: struct {
+				A float64 `json:"a,string,omitempty"`
 			}{A: 1},
 		},
 
@@ -112,6 +130,12 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			}{A: float64ptr(1)},
 		},
+		{
+			name: "HeadFloat64PtrStringOmitEmpty",
+			data: struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: float64ptr(1)},
+		},
 
 		// HeadFloat64PtrNil
 		{
@@ -130,6 +154,12 @@ func TestCoverFloat64(t *testing.T) {
 			name: "HeadFloat64PtrNilString",
 			data: struct {
 				A *float64 `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "HeadFloat64PtrNilStringOmitEmpty",
+			data: struct {
+				A *float64 `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -152,6 +182,12 @@ func TestCoverFloat64(t *testing.T) {
 				A float64 `json:"a,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadFloat64ZeroStringOmitEmpty",
+			data: &struct {
+				A float64 `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadFloat64
 		{
@@ -170,6 +206,12 @@ func TestCoverFloat64(t *testing.T) {
 			name: "PtrHeadFloat64String",
 			data: &struct {
 				A float64 `json:"a,string"`
+			}{A: 1},
+		},
+		{
+			name: "PtrHeadFloat64StringOmitEmpty",
+			data: &struct {
+				A float64 `json:"a,string,omitempty"`
 			}{A: 1},
 		},
 
@@ -192,6 +234,12 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			}{A: float64ptr(1)},
 		},
+		{
+			name: "PtrHeadFloat64PtrStringOmitEmpty",
+			data: &struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: float64ptr(1)},
+		},
 
 		// PtrHeadFloat64PtrNil
 		{
@@ -210,6 +258,12 @@ func TestCoverFloat64(t *testing.T) {
 			name: "PtrHeadFloat64PtrNilString",
 			data: &struct {
 				A *float64 `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadFloat64PtrNilStringOmitEmpty",
+			data: &struct {
+				A *float64 `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -232,6 +286,12 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			})(nil),
 		},
+		{
+			name: "PtrHeadFloat64NilStringOmitEmpty",
+			data: (*struct {
+				A *float64 `json:"a,string,omitempty"`
+			})(nil),
+		},
 
 		// HeadFloat64ZeroMultiFields
 		{
@@ -251,11 +311,19 @@ func TestCoverFloat64(t *testing.T) {
 			}{},
 		},
 		{
-			name: "HeadFloat64ZeroMultiFields",
+			name: "HeadFloat64ZeroMultiFieldsString",
 			data: struct {
 				A float64 `json:"a,string"`
 				B float64 `json:"b,string"`
 				C float64 `json:"c,string"`
+			}{},
+		},
+		{
+			name: "HeadFloat64ZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A float64 `json:"a,string,omitempty"`
+				B float64 `json:"b,string,omitempty"`
+				C float64 `json:"c,string,omitempty"`
 			}{},
 		},
 
@@ -284,6 +352,14 @@ func TestCoverFloat64(t *testing.T) {
 				C float64 `json:"c,string"`
 			}{A: 1, B: 2, C: 3},
 		},
+		{
+			name: "HeadFloat64MultiFieldsStringOmitEmpty",
+			data: struct {
+				A float64 `json:"a,string,omitempty"`
+				B float64 `json:"b,string,omitempty"`
+				C float64 `json:"c,string,omitempty"`
+			}{A: 1, B: 2, C: 3},
+		},
 
 		// HeadFloat64PtrMultiFields
 		{
@@ -308,6 +384,14 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 				B *float64 `json:"b,string"`
 				C *float64 `json:"c,string"`
+			}{A: float64ptr(1), B: float64ptr(2), C: float64ptr(3)},
+		},
+		{
+			name: "HeadFloat64PtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
+				C *float64 `json:"c,string,omitempty"`
 			}{A: float64ptr(1), B: float64ptr(2), C: float64ptr(3)},
 		},
 
@@ -336,6 +420,14 @@ func TestCoverFloat64(t *testing.T) {
 				C *float64 `json:"c,string"`
 			}{A: nil, B: nil, C: nil},
 		},
+		{
+			name: "HeadFloat64PtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
+				C *float64 `json:"c,string,omitempty"`
+			}{A: nil, B: nil, C: nil},
+		},
 
 		// PtrHeadFloat64ZeroMultiFields
 		{
@@ -357,6 +449,13 @@ func TestCoverFloat64(t *testing.T) {
 			data: &struct {
 				A float64 `json:"a,string"`
 				B float64 `json:"b,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadFloat64ZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A float64 `json:"a,string,omitempty"`
+				B float64 `json:"b,string,omitempty"`
 			}{},
 		},
 
@@ -382,6 +481,13 @@ func TestCoverFloat64(t *testing.T) {
 				B float64 `json:"b,string"`
 			}{A: 1, B: 2},
 		},
+		{
+			name: "PtrHeadFloat64MultiFieldsStringOmitEmpty",
+			data: &struct {
+				A float64 `json:"a,string,omitempty"`
+				B float64 `json:"b,string,omitempty"`
+			}{A: 1, B: 2},
+		},
 
 		// PtrHeadFloat64PtrMultiFields
 		{
@@ -403,6 +509,13 @@ func TestCoverFloat64(t *testing.T) {
 			data: &struct {
 				A *float64 `json:"a,string"`
 				B *float64 `json:"b,string"`
+			}{A: float64ptr(1), B: float64ptr(2)},
+		},
+		{
+			name: "PtrHeadFloat64PtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
 			}{A: float64ptr(1), B: float64ptr(2)},
 		},
 
@@ -428,6 +541,13 @@ func TestCoverFloat64(t *testing.T) {
 				B *float64 `json:"b,string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat64PtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat64NilMultiFields
 		{
@@ -449,6 +569,13 @@ func TestCoverFloat64(t *testing.T) {
 			data: (*struct {
 				A *float64 `json:"a,string"`
 				B *float64 `json:"b,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat64NilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
 			})(nil),
 		},
 
@@ -474,6 +601,14 @@ func TestCoverFloat64(t *testing.T) {
 			data: struct {
 				A struct {
 					A float64 `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadFloat64ZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float64 `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -509,6 +644,16 @@ func TestCoverFloat64(t *testing.T) {
 				A float64 `json:"a,string"`
 			}{A: 1}},
 		},
+		{
+			name: "HeadFloat64NotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A float64 `json:"a,string,omitempty"`
+			}{A: 1}},
+		},
 
 		// HeadFloat64PtrNotRoot
 		{
@@ -541,6 +686,16 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			}{float64ptr(1)}},
 		},
+		{
+			name: "HeadFloat64PtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{float64ptr(1)}},
+		},
 
 		// HeadFloat64PtrNilNotRoot
 		{
@@ -564,6 +719,14 @@ func TestCoverFloat64(t *testing.T) {
 			data: struct {
 				A struct {
 					A *float64 `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadFloat64PtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float64 `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -599,6 +762,16 @@ func TestCoverFloat64(t *testing.T) {
 				A float64 `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadFloat64ZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A float64 `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadFloat64NotRoot
 		{
@@ -629,6 +802,16 @@ func TestCoverFloat64(t *testing.T) {
 				}
 			}{A: &(struct {
 				A float64 `json:"a,string"`
+			}{A: 1})},
+		},
+		{
+			name: "PtrHeadFloat64NotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A float64 `json:"a,string,omitempty"`
 			}{A: 1})},
 		},
 
@@ -663,6 +846,16 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			}{A: float64ptr(1)})},
 		},
+		{
+			name: "PtrHeadFloat64PtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: float64ptr(1)})},
+		},
 
 		// PtrHeadFloat64PtrNilNotRoot
 		{
@@ -695,6 +888,16 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadFloat64PtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadFloat64NilNotRoot
 		{
@@ -719,6 +922,14 @@ func TestCoverFloat64(t *testing.T) {
 				A *struct {
 					A *float64 `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadFloat64NilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -753,6 +964,17 @@ func TestCoverFloat64(t *testing.T) {
 				}
 				B struct {
 					B float64 `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadFloat64ZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float64 `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -803,6 +1025,21 @@ func TestCoverFloat64(t *testing.T) {
 				B float64 `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "HeadFloat64MultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float64 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A float64 `json:"a,string,omitempty"`
+			}{A: 1}, B: struct {
+				B float64 `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// HeadFloat64PtrMultiFieldsNotRoot
 		{
@@ -848,6 +1085,21 @@ func TestCoverFloat64(t *testing.T) {
 				A *float64 `json:"a,string"`
 			}{A: float64ptr(1)}, B: struct {
 				B *float64 `json:"b,string"`
+			}{B: float64ptr(2)}},
+		},
+		{
+			name: "HeadFloat64PtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *float64 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: float64ptr(1)}, B: struct {
+				B *float64 `json:"b,string,omitempty"`
 			}{B: float64ptr(2)}},
 		},
 
@@ -897,6 +1149,21 @@ func TestCoverFloat64(t *testing.T) {
 				B *float64 `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadFloat64PtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *float64 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *float64 `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadFloat64ZeroMultiFieldsNotRoot
 		{
@@ -929,6 +1196,17 @@ func TestCoverFloat64(t *testing.T) {
 				}
 				B struct {
 					B float64 `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadFloat64ZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float64 `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -979,6 +1257,21 @@ func TestCoverFloat64(t *testing.T) {
 				B float64 `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "PtrHeadFloat64MultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A float64 `json:"a,string,omitempty"`
+				}
+				B struct {
+					B float64 `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A float64 `json:"a,string,omitempty"`
+			}{A: 1}, B: struct {
+				B float64 `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// PtrHeadFloat64PtrMultiFieldsNotRoot
 		{
@@ -1026,6 +1319,21 @@ func TestCoverFloat64(t *testing.T) {
 				B *float64 `json:"b,string"`
 			}{B: float64ptr(2)})},
 		},
+		{
+			name: "PtrHeadFloat64PtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *float64 `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float64 `json:"a,string,omitempty"`
+			}{A: float64ptr(1)}), B: &(struct {
+				B *float64 `json:"b,string,omitempty"`
+			}{B: float64ptr(2)})},
+		},
 
 		// PtrHeadFloat64PtrNilMultiFieldsNotRoot
 		{
@@ -1061,6 +1369,17 @@ func TestCoverFloat64(t *testing.T) {
 				} `json:",string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat64PtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
+				B *struct {
+					B *float64 `json:"b,string,omitempty"`
+				} `json:",string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat64NilMultiFieldsNotRoot
 		{
@@ -1093,6 +1412,17 @@ func TestCoverFloat64(t *testing.T) {
 				}
 				B *struct {
 					B *float64 `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat64NilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *float64 `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1155,6 +1485,25 @@ func TestCoverFloat64(t *testing.T) {
 				B float64 `json:"b,string"`
 			}{A: 3, B: 4})},
 		},
+		{
+			name: "PtrHeadFloat64DoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A float64 `json:"a,string,omitempty"`
+					B float64 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A float64 `json:"a,string,omitempty"`
+					B float64 `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A float64 `json:"a,string,omitempty"`
+				B float64 `json:"b,string,omitempty"`
+			}{A: 1, B: 2}), B: &(struct {
+				A float64 `json:"a,string,omitempty"`
+				B float64 `json:"b,string,omitempty"`
+			}{A: 3, B: 4})},
+		},
 
 		// PtrHeadFloat64NilDoubleMultiFieldsNotRoot
 		{
@@ -1196,6 +1545,19 @@ func TestCoverFloat64(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat64NilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A float64 `json:"a,string,omitempty"`
+					B float64 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A float64 `json:"a,string,omitempty"`
+					B float64 `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat64NilDoubleMultiFieldsNotRoot
 		{
@@ -1234,6 +1596,19 @@ func TestCoverFloat64(t *testing.T) {
 				B *struct {
 					A float64 `json:"a,string"`
 					B float64 `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat64NilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A float64 `json:"a,string,omitempty"`
+					B float64 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A float64 `json:"a,string,omitempty"`
+					B float64 `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1296,6 +1671,25 @@ func TestCoverFloat64(t *testing.T) {
 				B *float64 `json:"b,string"`
 			}{A: float64ptr(3), B: float64ptr(4)})},
 		},
+		{
+			name: "PtrHeadFloat64PtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+					B *float64 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *float64 `json:"a,string,omitempty"`
+					B *float64 `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
+			}{A: float64ptr(1), B: float64ptr(2)}), B: &(struct {
+				A *float64 `json:"a,string,omitempty"`
+				B *float64 `json:"b,string,omitempty"`
+			}{A: float64ptr(3), B: float64ptr(4)})},
+		},
 
 		// PtrHeadFloat64PtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1337,6 +1731,19 @@ func TestCoverFloat64(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadFloat64PtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+					B *float64 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *float64 `json:"a,string,omitempty"`
+					B *float64 `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadFloat64PtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1375,6 +1782,19 @@ func TestCoverFloat64(t *testing.T) {
 				B *struct {
 					A *float64 `json:"a,string"`
 					B *float64 `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadFloat64PtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *float64 `json:"a,string,omitempty"`
+					B *float64 `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *float64 `json:"a,string,omitempty"`
+					B *float64 `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1410,6 +1830,16 @@ func TestCoverFloat64(t *testing.T) {
 				B:                   2,
 			},
 		},
+		{
+			name: "AnonymousHeadFloat64StringOmitEmpty",
+			data: struct {
+				structFloat64StringOmitEmpty
+				B float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64StringOmitEmpty: structFloat64StringOmitEmpty{A: 1},
+				B:                            2,
+			},
+		},
 
 		// PtrAnonymousHeadFloat64
 		{
@@ -1440,6 +1870,16 @@ func TestCoverFloat64(t *testing.T) {
 			}{
 				structFloat64String: &structFloat64String{A: 1},
 				B:                   2,
+			},
+		},
+		{
+			name: "PtrAnonymousHeadFloat64StringOmitEmpty",
+			data: struct {
+				*structFloat64StringOmitEmpty
+				B float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64StringOmitEmpty: &structFloat64StringOmitEmpty{A: 1},
+				B:                            2,
 			},
 		},
 
@@ -1474,6 +1914,16 @@ func TestCoverFloat64(t *testing.T) {
 				B:                   2,
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadFloat64StringOmitEmpty",
+			data: struct {
+				*structFloat64StringOmitEmpty
+				B float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64StringOmitEmpty: nil,
+				B:                            2,
+			},
+		},
 
 		// AnonymousHeadFloat64Ptr
 		{
@@ -1504,6 +1954,16 @@ func TestCoverFloat64(t *testing.T) {
 			}{
 				structFloat64PtrString: structFloat64PtrString{A: float64ptr(1)},
 				B:                      float64ptr(2),
+			},
+		},
+		{
+			name: "AnonymousHeadFloat64PtrStringOmitEmpty",
+			data: struct {
+				structFloat64PtrStringOmitEmpty
+				B *float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64PtrStringOmitEmpty: structFloat64PtrStringOmitEmpty{A: float64ptr(1)},
+				B:                               float64ptr(2),
 			},
 		},
 
@@ -1538,6 +1998,16 @@ func TestCoverFloat64(t *testing.T) {
 				B:                      float64ptr(2),
 			},
 		},
+		{
+			name: "AnonymousHeadFloat64PtrNilStringOmitEmpty",
+			data: struct {
+				structFloat64PtrStringOmitEmpty
+				B *float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64PtrStringOmitEmpty: structFloat64PtrStringOmitEmpty{A: nil},
+				B:                               float64ptr(2),
+			},
+		},
 
 		// PtrAnonymousHeadFloat64Ptr
 		{
@@ -1568,6 +2038,16 @@ func TestCoverFloat64(t *testing.T) {
 			}{
 				structFloat64PtrString: &structFloat64PtrString{A: float64ptr(1)},
 				B:                      float64ptr(2),
+			},
+		},
+		{
+			name: "PtrAnonymousHeadFloat64PtrStringOmitEmpty",
+			data: struct {
+				*structFloat64PtrStringOmitEmpty
+				B *float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64PtrStringOmitEmpty: &structFloat64PtrStringOmitEmpty{A: float64ptr(1)},
+				B:                               float64ptr(2),
 			},
 		},
 
@@ -1602,6 +2082,16 @@ func TestCoverFloat64(t *testing.T) {
 				B:                      float64ptr(2),
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadFloat64PtrStringOmitEmpty",
+			data: struct {
+				*structFloat64PtrStringOmitEmpty
+				B *float64 `json:"b,string,omitempty"`
+			}{
+				structFloat64PtrStringOmitEmpty: nil,
+				B:                               float64ptr(2),
+			},
+		},
 
 		// AnonymousHeadFloat64Only
 		{
@@ -1626,6 +2116,14 @@ func TestCoverFloat64(t *testing.T) {
 				structFloat64String
 			}{
 				structFloat64String: structFloat64String{A: 1},
+			},
+		},
+		{
+			name: "AnonymousHeadFloat64OnlyStringOmitEmpty",
+			data: struct {
+				structFloat64StringOmitEmpty
+			}{
+				structFloat64StringOmitEmpty: structFloat64StringOmitEmpty{A: 1},
 			},
 		},
 
@@ -1654,6 +2152,14 @@ func TestCoverFloat64(t *testing.T) {
 				structFloat64String: &structFloat64String{A: 1},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadFloat64OnlyStringOmitEmpty",
+			data: struct {
+				*structFloat64StringOmitEmpty
+			}{
+				structFloat64StringOmitEmpty: &structFloat64StringOmitEmpty{A: 1},
+			},
+		},
 
 		// NilPtrAnonymousHeadFloat64Only
 		{
@@ -1678,6 +2184,14 @@ func TestCoverFloat64(t *testing.T) {
 				*structFloat64String
 			}{
 				structFloat64String: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadFloat64OnlyStringOmitEmpty",
+			data: struct {
+				*structFloat64StringOmitEmpty
+			}{
+				structFloat64StringOmitEmpty: nil,
 			},
 		},
 
@@ -1706,6 +2220,14 @@ func TestCoverFloat64(t *testing.T) {
 				structFloat64PtrString: structFloat64PtrString{A: float64ptr(1)},
 			},
 		},
+		{
+			name: "AnonymousHeadFloat64PtrOnlyStringOmitEmpty",
+			data: struct {
+				structFloat64PtrStringOmitEmpty
+			}{
+				structFloat64PtrStringOmitEmpty: structFloat64PtrStringOmitEmpty{A: float64ptr(1)},
+			},
+		},
 
 		// AnonymousHeadFloat64PtrNilOnly
 		{
@@ -1730,6 +2252,14 @@ func TestCoverFloat64(t *testing.T) {
 				structFloat64PtrString
 			}{
 				structFloat64PtrString: structFloat64PtrString{A: nil},
+			},
+		},
+		{
+			name: "AnonymousHeadFloat64PtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structFloat64PtrStringOmitEmpty
+			}{
+				structFloat64PtrStringOmitEmpty: structFloat64PtrStringOmitEmpty{A: nil},
 			},
 		},
 
@@ -1758,6 +2288,14 @@ func TestCoverFloat64(t *testing.T) {
 				structFloat64PtrString: &structFloat64PtrString{A: float64ptr(1)},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadFloat64PtrOnlyStringOmitEmpty",
+			data: struct {
+				*structFloat64PtrStringOmitEmpty
+			}{
+				structFloat64PtrStringOmitEmpty: &structFloat64PtrStringOmitEmpty{A: float64ptr(1)},
+			},
+		},
 
 		// NilPtrAnonymousHeadFloat64PtrOnly
 		{
@@ -1782,6 +2320,14 @@ func TestCoverFloat64(t *testing.T) {
 				*structFloat64PtrString
 			}{
 				structFloat64PtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadFloat64PtrOnlyStringOmitEmpty",
+			data: struct {
+				*structFloat64PtrStringOmitEmpty
+			}{
+				structFloat64PtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/cover_int_test.go
+++ b/cover_int_test.go
@@ -184,6 +184,12 @@ func TestCoverInt(t *testing.T) {
 				A int `json:"a,string"`
 			}{A: -1},
 		},
+		{
+			name: "PtrHeadIntStringOmitEmpty",
+			data: &struct {
+				A int `json:"a,string,omitempty"`
+			}{A: -1},
+		},
 
 		// PtrHeadIntPtr
 		{
@@ -202,6 +208,12 @@ func TestCoverInt(t *testing.T) {
 			name: "PtrHeadIntPtrString",
 			data: &struct {
 				A *int `json:"a,string"`
+			}{A: intptr(-1)},
+		},
+		{
+			name: "PtrHeadIntPtrStringOmitEmpty",
+			data: &struct {
+				A *int `json:"a,string,omitempty"`
 			}{A: intptr(-1)},
 		},
 
@@ -224,6 +236,12 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 			}{A: nil},
 		},
+		{
+			name: "PtrHeadIntPtrNilStringOmitEmpty",
+			data: &struct {
+				A *int `json:"a,string,omitempty"`
+			}{A: nil},
+		},
 
 		// PtrHeadIntNil
 		{
@@ -242,6 +260,12 @@ func TestCoverInt(t *testing.T) {
 			name: "PtrHeadIntNilString",
 			data: (*struct {
 				A *int `json:"a,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadIntNilStringOmitEmpty",
+			data: (*struct {
+				A *int `json:"a,string,omitempty"`
 			})(nil),
 		},
 
@@ -263,11 +287,19 @@ func TestCoverInt(t *testing.T) {
 			}{},
 		},
 		{
-			name: "HeadIntZeroMultiFields",
+			name: "HeadIntZeroMultiFieldsString",
 			data: struct {
 				A int `json:"a,string"`
 				B int `json:"b,string"`
 				C int `json:"c,string"`
+			}{},
+		},
+		{
+			name: "HeadIntZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A int `json:"a,string,omitempty"`
+				B int `json:"b,string,omitempty"`
+				C int `json:"c,string,omitempty"`
 			}{},
 		},
 
@@ -296,6 +328,14 @@ func TestCoverInt(t *testing.T) {
 				C int `json:"c,string"`
 			}{A: -1, B: 2, C: 3},
 		},
+		{
+			name: "HeadIntMultiFieldsStringOmitEmpty",
+			data: struct {
+				A int `json:"a,string,omitempty"`
+				B int `json:"b,string,omitempty"`
+				C int `json:"c,string,omitempty"`
+			}{A: -1, B: 2, C: 3},
+		},
 
 		// HeadIntPtrMultiFields
 		{
@@ -320,6 +360,14 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
 				C *int `json:"c,string"`
+			}{A: intptr(-1), B: intptr(2), C: intptr(3)},
+		},
+		{
+			name: "HeadIntPtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
+				C *int `json:"c,string,omitempty"`
 			}{A: intptr(-1), B: intptr(2), C: intptr(3)},
 		},
 
@@ -348,6 +396,14 @@ func TestCoverInt(t *testing.T) {
 				C *int `json:"c,string"`
 			}{A: nil, B: nil, C: nil},
 		},
+		{
+			name: "HeadIntPtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
+				C *int `json:"c,string,omitempty"`
+			}{A: nil, B: nil, C: nil},
+		},
 
 		// PtrHeadIntZeroMultiFields
 		{
@@ -369,6 +425,13 @@ func TestCoverInt(t *testing.T) {
 			data: &struct {
 				A int `json:"a,string"`
 				B int `json:"b,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadIntZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A int `json:"a,string,omitempty"`
+				B int `json:"b,string,omitempty"`
 			}{},
 		},
 
@@ -394,6 +457,13 @@ func TestCoverInt(t *testing.T) {
 				B int `json:"b,string"`
 			}{A: -1, B: 2},
 		},
+		{
+			name: "PtrHeadIntMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A int `json:"a,string,omitempty"`
+				B int `json:"b,string,omitempty"`
+			}{A: -1, B: 2},
+		},
 
 		// PtrHeadIntPtrMultiFields
 		{
@@ -415,6 +485,13 @@ func TestCoverInt(t *testing.T) {
 			data: &struct {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
+			}{A: intptr(-1), B: intptr(2)},
+		},
+		{
+			name: "PtrHeadIntPtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
 			}{A: intptr(-1), B: intptr(2)},
 		},
 
@@ -440,6 +517,13 @@ func TestCoverInt(t *testing.T) {
 				B *int `json:"b,string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadIntPtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadIntNilMultiFields
 		{
@@ -461,6 +545,13 @@ func TestCoverInt(t *testing.T) {
 			data: (*struct {
 				A *int `json:"a,string"`
 				B *int `json:"b,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadIntNilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
 			})(nil),
 		},
 
@@ -486,6 +577,14 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				A struct {
 					A int `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadIntZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A int `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -521,6 +620,16 @@ func TestCoverInt(t *testing.T) {
 				A int `json:"a,string"`
 			}{A: -1}},
 		},
+		{
+			name: "HeadIntNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A int `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A int `json:"a,string,omitempty"`
+			}{A: -1}},
+		},
 
 		// HeadIntPtrNotRoot
 		{
@@ -553,6 +662,16 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 			}{intptr(-1)}},
 		},
+		{
+			name: "HeadIntPtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *int `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *int `json:"a,string,omitempty"`
+			}{intptr(-1)}},
+		},
 
 		// HeadIntPtrNilNotRoot
 		{
@@ -576,6 +695,14 @@ func TestCoverInt(t *testing.T) {
 			data: struct {
 				A struct {
 					A *int `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadIntPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *int `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -611,6 +738,16 @@ func TestCoverInt(t *testing.T) {
 				A int `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadIntZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A int `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A int `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadIntNotRoot
 		{
@@ -641,6 +778,16 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: &(struct {
 				A int `json:"a,string"`
+			}{A: -1})},
+		},
+		{
+			name: "PtrHeadIntNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A int `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A int `json:"a,string,omitempty"`
 			}{A: -1})},
 		},
 
@@ -675,6 +822,16 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 			}{A: intptr(-1)})},
 		},
+		{
+			name: "PtrHeadIntPtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *int `json:"a,string,omitempty"`
+			}{A: intptr(-1)})},
+		},
 
 		// PtrHeadIntPtrNilNotRoot
 		{
@@ -707,6 +864,16 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadIntPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *int `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadIntNilNotRoot
 		{
@@ -731,6 +898,14 @@ func TestCoverInt(t *testing.T) {
 				A *struct {
 					A *int `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadIntNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -765,6 +940,17 @@ func TestCoverInt(t *testing.T) {
 				}
 				B struct {
 					B int `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadIntZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A int `json:"a,string,omitempty"`
+				}
+				B struct {
+					B int `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -815,6 +1001,21 @@ func TestCoverInt(t *testing.T) {
 				B int `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "HeadIntMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A int `json:"a,string,omitempty"`
+				}
+				B struct {
+					B int `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A int `json:"a,string,omitempty"`
+			}{A: -1}, B: struct {
+				B int `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// HeadIntPtrMultiFieldsNotRoot
 		{
@@ -860,6 +1061,21 @@ func TestCoverInt(t *testing.T) {
 				A *int `json:"a,string"`
 			}{A: intptr(-1)}, B: struct {
 				B *int `json:"b,string"`
+			}{B: intptr(2)}},
+		},
+		{
+			name: "HeadIntPtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *int `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *int `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *int `json:"a,string,omitempty"`
+			}{A: intptr(-1)}, B: struct {
+				B *int `json:"b,string,omitempty"`
 			}{B: intptr(2)}},
 		},
 
@@ -909,6 +1125,21 @@ func TestCoverInt(t *testing.T) {
 				B *int `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadIntPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *int `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *int `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *int `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *int `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadIntZeroMultiFieldsNotRoot
 		{
@@ -941,6 +1172,17 @@ func TestCoverInt(t *testing.T) {
 				}
 				B struct {
 					B int `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadIntZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A int `json:"a,string,omitempty"`
+				}
+				B struct {
+					B int `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -991,6 +1233,21 @@ func TestCoverInt(t *testing.T) {
 				B int `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "PtrHeadIntMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A int `json:"a,string,omitempty"`
+				}
+				B struct {
+					B int `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A int `json:"a,string,omitempty"`
+			}{A: -1}, B: struct {
+				B int `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// PtrHeadIntPtrMultiFieldsNotRoot
 		{
@@ -1038,6 +1295,21 @@ func TestCoverInt(t *testing.T) {
 				B *int `json:"b,string"`
 			}{B: intptr(2)})},
 		},
+		{
+			name: "PtrHeadIntPtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *int `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *int `json:"a,string,omitempty"`
+			}{A: intptr(-1)}), B: &(struct {
+				B *int `json:"b,string,omitempty"`
+			}{B: intptr(2)})},
+		},
 
 		// PtrHeadIntPtrNilMultiFieldsNotRoot
 		{
@@ -1073,6 +1345,17 @@ func TestCoverInt(t *testing.T) {
 				} `json:",string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadIntPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
+				B *struct {
+					B *int `json:"b,string,omitempty"`
+				} `json:",string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadIntNilMultiFieldsNotRoot
 		{
@@ -1105,6 +1388,17 @@ func TestCoverInt(t *testing.T) {
 				}
 				B *struct {
 					B *int `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadIntNilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *int `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1167,6 +1461,25 @@ func TestCoverInt(t *testing.T) {
 				B int `json:"b,string"`
 			}{A: 3, B: 4})},
 		},
+		{
+			name: "PtrHeadIntDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A int `json:"a,string,omitempty"`
+					B int `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A int `json:"a,string,omitempty"`
+					B int `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A int `json:"a,string,omitempty"`
+				B int `json:"b,string,omitempty"`
+			}{A: -1, B: 2}), B: &(struct {
+				A int `json:"a,string,omitempty"`
+				B int `json:"b,string,omitempty"`
+			}{A: 3, B: 4})},
+		},
 
 		// PtrHeadIntNilDoubleMultiFieldsNotRoot
 		{
@@ -1208,6 +1521,19 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadIntNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A int `json:"a,string,omitempty"`
+					B int `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A int `json:"a,string,omitempty"`
+					B int `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadIntNilDoubleMultiFieldsNotRoot
 		{
@@ -1246,6 +1572,19 @@ func TestCoverInt(t *testing.T) {
 				B *struct {
 					A int `json:"a,string"`
 					B int `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadIntNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A int `json:"a,string,omitempty"`
+					B int `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A int `json:"a,string,omitempty"`
+					B int `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1308,6 +1647,25 @@ func TestCoverInt(t *testing.T) {
 				B *int `json:"b,string"`
 			}{A: intptr(3), B: intptr(4)})},
 		},
+		{
+			name: "PtrHeadIntPtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+					B *int `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *int `json:"a,string,omitempty"`
+					B *int `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
+			}{A: intptr(-1), B: intptr(2)}), B: &(struct {
+				A *int `json:"a,string,omitempty"`
+				B *int `json:"b,string,omitempty"`
+			}{A: intptr(3), B: intptr(4)})},
+		},
 
 		// PtrHeadIntPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1349,6 +1707,19 @@ func TestCoverInt(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadIntPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+					B *int `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *int `json:"a,string,omitempty"`
+					B *int `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadIntPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1387,6 +1758,19 @@ func TestCoverInt(t *testing.T) {
 				B *struct {
 					A *int `json:"a,string"`
 					B *int `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadIntPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *int `json:"a,string,omitempty"`
+					B *int `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *int `json:"a,string,omitempty"`
+					B *int `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1422,6 +1806,16 @@ func TestCoverInt(t *testing.T) {
 				B:               2,
 			},
 		},
+		{
+			name: "AnonymousHeadIntStringOmitEmpty",
+			data: struct {
+				structIntStringOmitEmpty
+				B int `json:"b,string,omitempty"`
+			}{
+				structIntStringOmitEmpty: structIntStringOmitEmpty{A: -1},
+				B:                        2,
+			},
+		},
 
 		// PtrAnonymousHeadInt
 		{
@@ -1452,6 +1846,16 @@ func TestCoverInt(t *testing.T) {
 			}{
 				structIntString: &structIntString{A: -1},
 				B:               2,
+			},
+		},
+		{
+			name: "PtrAnonymousHeadIntStringOmitEmpty",
+			data: struct {
+				*structIntStringOmitEmpty
+				B int `json:"b,string,omitempty"`
+			}{
+				structIntStringOmitEmpty: &structIntStringOmitEmpty{A: -1},
+				B:                        2,
 			},
 		},
 
@@ -1486,6 +1890,16 @@ func TestCoverInt(t *testing.T) {
 				B:               2,
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadIntStringOmitEmpty",
+			data: struct {
+				*structIntStringOmitEmpty
+				B int `json:"b,string,omitempty"`
+			}{
+				structIntStringOmitEmpty: nil,
+				B:                        2,
+			},
+		},
 
 		// AnonymousHeadIntPtr
 		{
@@ -1516,6 +1930,16 @@ func TestCoverInt(t *testing.T) {
 			}{
 				structIntPtrString: structIntPtrString{A: intptr(-1)},
 				B:                  intptr(2),
+			},
+		},
+		{
+			name: "AnonymousHeadIntPtrStringOmitEmpty",
+			data: struct {
+				structIntPtrStringOmitEmpty
+				B *int `json:"b,string,omitempty"`
+			}{
+				structIntPtrStringOmitEmpty: structIntPtrStringOmitEmpty{A: intptr(-1)},
+				B:                           intptr(2),
 			},
 		},
 
@@ -1550,6 +1974,16 @@ func TestCoverInt(t *testing.T) {
 				B:                  intptr(2),
 			},
 		},
+		{
+			name: "AnonymousHeadIntPtrNilStringOmitEmpty",
+			data: struct {
+				structIntPtrStringOmitEmpty
+				B *int `json:"b,string,omitempty"`
+			}{
+				structIntPtrStringOmitEmpty: structIntPtrStringOmitEmpty{A: nil},
+				B:                           intptr(2),
+			},
+		},
 
 		// PtrAnonymousHeadIntPtr
 		{
@@ -1580,6 +2014,16 @@ func TestCoverInt(t *testing.T) {
 			}{
 				structIntPtrString: &structIntPtrString{A: intptr(-1)},
 				B:                  intptr(2),
+			},
+		},
+		{
+			name: "PtrAnonymousHeadIntPtrStringOmitEmpty",
+			data: struct {
+				*structIntPtrStringOmitEmpty
+				B *int `json:"b,string,omitempty"`
+			}{
+				structIntPtrStringOmitEmpty: &structIntPtrStringOmitEmpty{A: intptr(-1)},
+				B:                           intptr(2),
 			},
 		},
 
@@ -1614,6 +2058,16 @@ func TestCoverInt(t *testing.T) {
 				B:                  intptr(2),
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadIntPtrStringOmitEmpty",
+			data: struct {
+				*structIntPtrStringOmitEmpty
+				B *int `json:"b,string,omitempty"`
+			}{
+				structIntPtrStringOmitEmpty: nil,
+				B:                           intptr(2),
+			},
+		},
 
 		// AnonymousHeadIntOnly
 		{
@@ -1638,6 +2092,14 @@ func TestCoverInt(t *testing.T) {
 				structIntString
 			}{
 				structIntString: structIntString{A: -1},
+			},
+		},
+		{
+			name: "AnonymousHeadIntOnlyStringOmitEmpty",
+			data: struct {
+				structIntStringOmitEmpty
+			}{
+				structIntStringOmitEmpty: structIntStringOmitEmpty{A: -1},
 			},
 		},
 
@@ -1666,6 +2128,14 @@ func TestCoverInt(t *testing.T) {
 				structIntString: &structIntString{A: -1},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadIntOnlyStringOmitEmpty",
+			data: struct {
+				*structIntStringOmitEmpty
+			}{
+				structIntStringOmitEmpty: &structIntStringOmitEmpty{A: -1},
+			},
+		},
 
 		// NilPtrAnonymousHeadIntOnly
 		{
@@ -1690,6 +2160,14 @@ func TestCoverInt(t *testing.T) {
 				*structIntString
 			}{
 				structIntString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadIntOnlyStringOmitEmpty",
+			data: struct {
+				*structIntStringOmitEmpty
+			}{
+				structIntStringOmitEmpty: nil,
 			},
 		},
 
@@ -1718,6 +2196,14 @@ func TestCoverInt(t *testing.T) {
 				structIntPtrString: structIntPtrString{A: intptr(-1)},
 			},
 		},
+		{
+			name: "AnonymousHeadIntPtrOnlyStringOmitEmpty",
+			data: struct {
+				structIntPtrStringOmitEmpty
+			}{
+				structIntPtrStringOmitEmpty: structIntPtrStringOmitEmpty{A: intptr(-1)},
+			},
+		},
 
 		// AnonymousHeadIntPtrNilOnly
 		{
@@ -1742,6 +2228,14 @@ func TestCoverInt(t *testing.T) {
 				structIntPtrString
 			}{
 				structIntPtrString: structIntPtrString{A: nil},
+			},
+		},
+		{
+			name: "AnonymousHeadIntPtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structIntPtrStringOmitEmpty
+			}{
+				structIntPtrStringOmitEmpty: structIntPtrStringOmitEmpty{A: nil},
 			},
 		},
 
@@ -1770,6 +2264,14 @@ func TestCoverInt(t *testing.T) {
 				structIntPtrString: &structIntPtrString{A: intptr(-1)},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadIntPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structIntPtrStringOmitEmpty
+			}{
+				structIntPtrStringOmitEmpty: &structIntPtrStringOmitEmpty{A: intptr(-1)},
+			},
+		},
 
 		// NilPtrAnonymousHeadIntPtrOnly
 		{
@@ -1794,6 +2296,14 @@ func TestCoverInt(t *testing.T) {
 				*structIntPtrString
 			}{
 				structIntPtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadIntPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structIntPtrStringOmitEmpty
+			}{
+				structIntPtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/cover_int_test.go
+++ b/cover_int_test.go
@@ -17,6 +17,9 @@ func TestCoverInt(t *testing.T) {
 	type structIntString struct {
 		A int `json:"a,string"`
 	}
+	type structIntStringOmitEmpty struct {
+		A int `json:"a,omitempty,string"`
+	}
 
 	type structIntPtr struct {
 		A *int `json:"a"`
@@ -26,6 +29,9 @@ func TestCoverInt(t *testing.T) {
 	}
 	type structIntPtrString struct {
 		A *int `json:"a,string"`
+	}
+	type structIntPtrStringOmitEmpty struct {
+		A *int `json:"a,omitempty,string"`
 	}
 
 	tests := []struct {
@@ -150,6 +156,12 @@ func TestCoverInt(t *testing.T) {
 			name: "PtrHeadIntZeroString",
 			data: &struct {
 				A int `json:"a,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadIntZeroStringOmitEmpty",
+			data: &struct {
+				A int `json:"a,string,omitempty"`
 			}{},
 		},
 

--- a/cover_number_test.go
+++ b/cover_number_test.go
@@ -17,6 +17,9 @@ func TestCoverNumber(t *testing.T) {
 	type structNumberString struct {
 		A json.Number `json:"a,string"`
 	}
+	type structNumberStringOmitEmpty struct {
+		A json.Number `json:"a,string,omitempty"`
+	}
 
 	type structNumberPtr struct {
 		A *json.Number `json:"a"`
@@ -26,6 +29,9 @@ func TestCoverNumber(t *testing.T) {
 	}
 	type structNumberPtrString struct {
 		A *json.Number `json:"a,string"`
+	}
+	type structNumberPtrStringOmitEmpty struct {
+		A *json.Number `json:"a,string,omitempty"`
 	}
 
 	tests := []struct {
@@ -72,6 +78,12 @@ func TestCoverNumber(t *testing.T) {
 				A json.Number `json:"a,string"`
 			}{},
 		},
+		{
+			name: "HeadNumberZeroStringOmitEmpty",
+			data: struct {
+				A json.Number `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// HeadNumber
 		{
@@ -90,6 +102,12 @@ func TestCoverNumber(t *testing.T) {
 			name: "HeadNumberString",
 			data: struct {
 				A json.Number `json:"a,string"`
+			}{A: "1"},
+		},
+		{
+			name: "HeadNumberStringOmitEmpty",
+			data: struct {
+				A json.Number `json:"a,string,omitempty"`
 			}{A: "1"},
 		},
 
@@ -112,6 +130,12 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			}{A: numberptr("1")},
 		},
+		{
+			name: "HeadNumberPtrStringOmitEmpty",
+			data: struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: numberptr("1")},
+		},
 
 		// HeadNumberPtrNil
 		{
@@ -130,6 +154,12 @@ func TestCoverNumber(t *testing.T) {
 			name: "HeadNumberPtrNilString",
 			data: struct {
 				A *json.Number `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "HeadNumberPtrNilStringOmitEmpty",
+			data: struct {
+				A *json.Number `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -152,6 +182,12 @@ func TestCoverNumber(t *testing.T) {
 				A json.Number `json:"a,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadNumberZeroStringOmitEmpty",
+			data: &struct {
+				A json.Number `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadNumber
 		{
@@ -170,6 +206,12 @@ func TestCoverNumber(t *testing.T) {
 			name: "PtrHeadNumberString",
 			data: &struct {
 				A json.Number `json:"a,string"`
+			}{A: "1"},
+		},
+		{
+			name: "PtrHeadNumberStringOmitEmpty",
+			data: &struct {
+				A json.Number `json:"a,string,omitempty"`
 			}{A: "1"},
 		},
 
@@ -192,6 +234,12 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			}{A: numberptr("1")},
 		},
+		{
+			name: "PtrHeadNumberPtrStringOmitEmpty",
+			data: &struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: numberptr("1")},
+		},
 
 		// PtrHeadNumberPtrNil
 		{
@@ -210,6 +258,12 @@ func TestCoverNumber(t *testing.T) {
 			name: "PtrHeadNumberPtrNilString",
 			data: &struct {
 				A *json.Number `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadNumberPtrNilStringOmitEmpty",
+			data: &struct {
+				A *json.Number `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -232,6 +286,12 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			})(nil),
 		},
+		{
+			name: "PtrHeadNumberNilStringOmitEmpty",
+			data: (*struct {
+				A *json.Number `json:"a,string,omitempty"`
+			})(nil),
+		},
 
 		// HeadNumberZeroMultiFields
 		{
@@ -251,11 +311,19 @@ func TestCoverNumber(t *testing.T) {
 			}{},
 		},
 		{
-			name: "HeadNumberZeroMultiFields",
+			name: "HeadNumberZeroMultiFieldsString",
 			data: struct {
 				A json.Number `json:"a,string"`
 				B json.Number `json:"b,string"`
 				C json.Number `json:"c,string"`
+			}{},
+		},
+		{
+			name: "HeadNumberZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A json.Number `json:"a,string,omitempty"`
+				B json.Number `json:"b,string,omitempty"`
+				C json.Number `json:"c,string,omitempty"`
 			}{},
 		},
 
@@ -284,6 +352,14 @@ func TestCoverNumber(t *testing.T) {
 				C json.Number `json:"c,string"`
 			}{A: "1", B: "2", C: "3"},
 		},
+		{
+			name: "HeadNumberMultiFieldsStringOmitEmpty",
+			data: struct {
+				A json.Number `json:"a,string,omitempty"`
+				B json.Number `json:"b,string,omitempty"`
+				C json.Number `json:"c,string,omitempty"`
+			}{A: "1", B: "2", C: "3"},
+		},
 
 		// HeadNumberPtrMultiFields
 		{
@@ -308,6 +384,14 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 				B *json.Number `json:"b,string"`
 				C *json.Number `json:"c,string"`
+			}{A: numberptr("1"), B: numberptr("2"), C: numberptr("3")},
+		},
+		{
+			name: "HeadNumberPtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
+				C *json.Number `json:"c,string,omitempty"`
 			}{A: numberptr("1"), B: numberptr("2"), C: numberptr("3")},
 		},
 
@@ -336,6 +420,14 @@ func TestCoverNumber(t *testing.T) {
 				C *json.Number `json:"c,string"`
 			}{A: nil, B: nil, C: nil},
 		},
+		{
+			name: "HeadNumberPtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
+				C *json.Number `json:"c,string,omitempty"`
+			}{A: nil, B: nil, C: nil},
+		},
 
 		// PtrHeadNumberZeroMultiFields
 		{
@@ -357,6 +449,13 @@ func TestCoverNumber(t *testing.T) {
 			data: &struct {
 				A json.Number `json:"a,string"`
 				B json.Number `json:"b,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadNumberZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A json.Number `json:"a,string,omitempty"`
+				B json.Number `json:"b,string,omitempty"`
 			}{},
 		},
 
@@ -382,6 +481,13 @@ func TestCoverNumber(t *testing.T) {
 				B json.Number `json:"b,string"`
 			}{A: "1", B: "2"},
 		},
+		{
+			name: "PtrHeadNumberMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A json.Number `json:"a,string,omitempty"`
+				B json.Number `json:"b,string,omitempty"`
+			}{A: "1", B: "2"},
+		},
 
 		// PtrHeadNumberPtrMultiFields
 		{
@@ -403,6 +509,13 @@ func TestCoverNumber(t *testing.T) {
 			data: &struct {
 				A *json.Number `json:"a,string"`
 				B *json.Number `json:"b,string"`
+			}{A: numberptr("1"), B: numberptr("2")},
+		},
+		{
+			name: "PtrHeadNumberPtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
 			}{A: numberptr("1"), B: numberptr("2")},
 		},
 
@@ -428,6 +541,13 @@ func TestCoverNumber(t *testing.T) {
 				B *json.Number `json:"b,string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadNumberPtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadNumberNilMultiFields
 		{
@@ -449,6 +569,13 @@ func TestCoverNumber(t *testing.T) {
 			data: (*struct {
 				A *json.Number `json:"a,string"`
 				B *json.Number `json:"b,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadNumberNilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
 			})(nil),
 		},
 
@@ -474,6 +601,14 @@ func TestCoverNumber(t *testing.T) {
 			data: struct {
 				A struct {
 					A json.Number `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadNumberZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A json.Number `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -509,6 +644,16 @@ func TestCoverNumber(t *testing.T) {
 				A json.Number `json:"a,string"`
 			}{A: "1"}},
 		},
+		{
+			name: "HeadNumberNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A json.Number `json:"a,string,omitempty"`
+			}{A: "1"}},
+		},
 
 		// HeadNumberPtrNotRoot
 		{
@@ -541,6 +686,16 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			}{numberptr("1")}},
 		},
+		{
+			name: "HeadNumberPtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{numberptr("1")}},
+		},
 
 		// HeadNumberPtrNilNotRoot
 		{
@@ -564,6 +719,14 @@ func TestCoverNumber(t *testing.T) {
 			data: struct {
 				A struct {
 					A *json.Number `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadNumberPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *json.Number `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -599,6 +762,16 @@ func TestCoverNumber(t *testing.T) {
 				A json.Number `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadNumberZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A json.Number `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadNumberNotRoot
 		{
@@ -629,6 +802,16 @@ func TestCoverNumber(t *testing.T) {
 				}
 			}{A: &(struct {
 				A json.Number `json:"a,string"`
+			}{A: "1"})},
+		},
+		{
+			name: "PtrHeadNumberNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A json.Number `json:"a,string,omitempty"`
 			}{A: "1"})},
 		},
 
@@ -663,6 +846,16 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			}{A: numberptr("1")})},
 		},
+		{
+			name: "PtrHeadNumberPtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: numberptr("1")})},
+		},
 
 		// PtrHeadNumberPtrNilNotRoot
 		{
@@ -695,6 +888,16 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadNumberPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadNumberNilNotRoot
 		{
@@ -719,6 +922,14 @@ func TestCoverNumber(t *testing.T) {
 				A *struct {
 					A *json.Number `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadNumberNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -753,6 +964,17 @@ func TestCoverNumber(t *testing.T) {
 				}
 				B struct {
 					B json.Number `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadNumberZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+				B struct {
+					B json.Number `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -803,6 +1025,21 @@ func TestCoverNumber(t *testing.T) {
 				B json.Number `json:"b,string"`
 			}{B: "2"}},
 		},
+		{
+			name: "HeadNumberMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+				B struct {
+					B json.Number `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A json.Number `json:"a,string,omitempty"`
+			}{A: "1"}, B: struct {
+				B json.Number `json:"b,string,omitempty"`
+			}{B: "2"}},
+		},
 
 		// HeadNumberPtrMultiFieldsNotRoot
 		{
@@ -848,6 +1085,21 @@ func TestCoverNumber(t *testing.T) {
 				A *json.Number `json:"a,string"`
 			}{A: numberptr("1")}, B: struct {
 				B *json.Number `json:"b,string"`
+			}{B: numberptr("2")}},
+		},
+		{
+			name: "HeadNumberPtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *json.Number `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: numberptr("1")}, B: struct {
+				B *json.Number `json:"b,string,omitempty"`
 			}{B: numberptr("2")}},
 		},
 
@@ -897,6 +1149,21 @@ func TestCoverNumber(t *testing.T) {
 				B *json.Number `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadNumberPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *json.Number `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *json.Number `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadNumberZeroMultiFieldsNotRoot
 		{
@@ -929,6 +1196,17 @@ func TestCoverNumber(t *testing.T) {
 				}
 				B struct {
 					B json.Number `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadNumberZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+				B struct {
+					B json.Number `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -979,6 +1257,21 @@ func TestCoverNumber(t *testing.T) {
 				B json.Number `json:"b,string"`
 			}{B: "2"}},
 		},
+		{
+			name: "PtrHeadNumberMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A json.Number `json:"a,string,omitempty"`
+				}
+				B struct {
+					B json.Number `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A json.Number `json:"a,string,omitempty"`
+			}{A: "1"}, B: struct {
+				B json.Number `json:"b,string,omitempty"`
+			}{B: "2"}},
+		},
 
 		// PtrHeadNumberPtrMultiFieldsNotRoot
 		{
@@ -1026,6 +1319,21 @@ func TestCoverNumber(t *testing.T) {
 				B *json.Number `json:"b,string"`
 			}{B: numberptr("2")})},
 		},
+		{
+			name: "PtrHeadNumberPtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *json.Number `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *json.Number `json:"a,string,omitempty"`
+			}{A: numberptr("1")}), B: &(struct {
+				B *json.Number `json:"b,string,omitempty"`
+			}{B: numberptr("2")})},
+		},
 
 		// PtrHeadNumberPtrNilMultiFieldsNotRoot
 		{
@@ -1061,6 +1369,17 @@ func TestCoverNumber(t *testing.T) {
 				} `json:",string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadNumberPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
+				B *struct {
+					B *json.Number `json:"b,string,omitempty"`
+				} `json:",string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadNumberNilMultiFieldsNotRoot
 		{
@@ -1093,6 +1412,17 @@ func TestCoverNumber(t *testing.T) {
 				}
 				B *struct {
 					B *json.Number `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadNumberNilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *json.Number `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1155,6 +1485,25 @@ func TestCoverNumber(t *testing.T) {
 				B json.Number `json:"b,string"`
 			}{A: "3", B: "4"})},
 		},
+		{
+			name: "PtrHeadNumberDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A json.Number `json:"a,string,omitempty"`
+					B json.Number `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A json.Number `json:"a,string,omitempty"`
+					B json.Number `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A json.Number `json:"a,string,omitempty"`
+				B json.Number `json:"b,string,omitempty"`
+			}{A: "1", B: "2"}), B: &(struct {
+				A json.Number `json:"a,string,omitempty"`
+				B json.Number `json:"b,string,omitempty"`
+			}{A: "3", B: "4"})},
+		},
 
 		// PtrHeadNumberNilDoubleMultiFieldsNotRoot
 		{
@@ -1196,6 +1545,19 @@ func TestCoverNumber(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadNumberNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A json.Number `json:"a,string,omitempty"`
+					B json.Number `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A json.Number `json:"a,string,omitempty"`
+					B json.Number `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadNumberNilDoubleMultiFieldsNotRoot
 		{
@@ -1234,6 +1596,19 @@ func TestCoverNumber(t *testing.T) {
 				B *struct {
 					A json.Number `json:"a,string"`
 					B json.Number `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadNumberNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A json.Number `json:"a,string,omitempty"`
+					B json.Number `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A json.Number `json:"a,string,omitempty"`
+					B json.Number `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1296,6 +1671,25 @@ func TestCoverNumber(t *testing.T) {
 				B *json.Number `json:"b,string"`
 			}{A: numberptr("3"), B: numberptr("4")})},
 		},
+		{
+			name: "PtrHeadNumberPtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+					B *json.Number `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *json.Number `json:"a,string,omitempty"`
+					B *json.Number `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
+			}{A: numberptr("1"), B: numberptr("2")}), B: &(struct {
+				A *json.Number `json:"a,string,omitempty"`
+				B *json.Number `json:"b,string,omitempty"`
+			}{A: numberptr("3"), B: numberptr("4")})},
+		},
 
 		// PtrHeadNumberPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1337,6 +1731,19 @@ func TestCoverNumber(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadNumberPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+					B *json.Number `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *json.Number `json:"a,string,omitempty"`
+					B *json.Number `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadNumberPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1375,6 +1782,19 @@ func TestCoverNumber(t *testing.T) {
 				B *struct {
 					A *json.Number `json:"a,string"`
 					B *json.Number `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadNumberPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *json.Number `json:"a,string,omitempty"`
+					B *json.Number `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *json.Number `json:"a,string,omitempty"`
+					B *json.Number `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1410,6 +1830,16 @@ func TestCoverNumber(t *testing.T) {
 				B:                  "2",
 			},
 		},
+		{
+			name: "AnonymousHeadNumberStringOmitEmpty",
+			data: struct {
+				structNumberStringOmitEmpty
+				B json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberStringOmitEmpty: structNumberStringOmitEmpty{A: "1"},
+				B:                           "2",
+			},
+		},
 
 		// PtrAnonymousHeadNumber
 		{
@@ -1440,6 +1870,16 @@ func TestCoverNumber(t *testing.T) {
 			}{
 				structNumberString: &structNumberString{A: "1"},
 				B:                  "2",
+			},
+		},
+		{
+			name: "PtrAnonymousHeadNumberStringOmitEmpty",
+			data: struct {
+				*structNumberStringOmitEmpty
+				B json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberStringOmitEmpty: &structNumberStringOmitEmpty{A: "1"},
+				B:                           "2",
 			},
 		},
 
@@ -1474,6 +1914,16 @@ func TestCoverNumber(t *testing.T) {
 				B:                  "2",
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadNumberStringOmitEmpty",
+			data: struct {
+				*structNumberStringOmitEmpty
+				B json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberStringOmitEmpty: nil,
+				B:                           "2",
+			},
+		},
 
 		// AnonymousHeadNumberPtr
 		{
@@ -1504,6 +1954,16 @@ func TestCoverNumber(t *testing.T) {
 			}{
 				structNumberPtrString: structNumberPtrString{A: numberptr("1")},
 				B:                     numberptr("2"),
+			},
+		},
+		{
+			name: "AnonymousHeadNumberPtrStringOmitEmpty",
+			data: struct {
+				structNumberPtrStringOmitEmpty
+				B *json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberPtrStringOmitEmpty: structNumberPtrStringOmitEmpty{A: numberptr("1")},
+				B:                              numberptr("2"),
 			},
 		},
 
@@ -1538,6 +1998,16 @@ func TestCoverNumber(t *testing.T) {
 				B:                     numberptr("2"),
 			},
 		},
+		{
+			name: "AnonymousHeadNumberPtrNilStringOmitEmpty",
+			data: struct {
+				structNumberPtrStringOmitEmpty
+				B *json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberPtrStringOmitEmpty: structNumberPtrStringOmitEmpty{A: nil},
+				B:                              numberptr("2"),
+			},
+		},
 
 		// PtrAnonymousHeadNumberPtr
 		{
@@ -1568,6 +2038,16 @@ func TestCoverNumber(t *testing.T) {
 			}{
 				structNumberPtrString: &structNumberPtrString{A: numberptr("1")},
 				B:                     numberptr("2"),
+			},
+		},
+		{
+			name: "PtrAnonymousHeadNumberPtrStringOmitEmpty",
+			data: struct {
+				*structNumberPtrStringOmitEmpty
+				B *json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberPtrStringOmitEmpty: &structNumberPtrStringOmitEmpty{A: numberptr("1")},
+				B:                              numberptr("2"),
 			},
 		},
 
@@ -1602,6 +2082,16 @@ func TestCoverNumber(t *testing.T) {
 				B:                     numberptr("2"),
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadNumberPtrStringOmitEmpty",
+			data: struct {
+				*structNumberPtrStringOmitEmpty
+				B *json.Number `json:"b,string,omitempty"`
+			}{
+				structNumberPtrStringOmitEmpty: nil,
+				B:                              numberptr("2"),
+			},
+		},
 
 		// AnonymousHeadNumberOnly
 		{
@@ -1626,6 +2116,14 @@ func TestCoverNumber(t *testing.T) {
 				structNumberString
 			}{
 				structNumberString: structNumberString{A: "1"},
+			},
+		},
+		{
+			name: "AnonymousHeadNumberOnlyStringOmitEmpty",
+			data: struct {
+				structNumberStringOmitEmpty
+			}{
+				structNumberStringOmitEmpty: structNumberStringOmitEmpty{A: "1"},
 			},
 		},
 
@@ -1654,6 +2152,14 @@ func TestCoverNumber(t *testing.T) {
 				structNumberString: &structNumberString{A: "1"},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadNumberOnlyStringOmitEmpty",
+			data: struct {
+				*structNumberStringOmitEmpty
+			}{
+				structNumberStringOmitEmpty: &structNumberStringOmitEmpty{A: "1"},
+			},
+		},
 
 		// NilPtrAnonymousHeadNumberOnly
 		{
@@ -1678,6 +2184,14 @@ func TestCoverNumber(t *testing.T) {
 				*structNumberString
 			}{
 				structNumberString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadNumberOnlyStringOmitEmpty",
+			data: struct {
+				*structNumberStringOmitEmpty
+			}{
+				structNumberStringOmitEmpty: nil,
 			},
 		},
 
@@ -1706,6 +2220,14 @@ func TestCoverNumber(t *testing.T) {
 				structNumberPtrString: structNumberPtrString{A: numberptr("1")},
 			},
 		},
+		{
+			name: "AnonymousHeadNumberPtrOnlyStringOmitEmpty",
+			data: struct {
+				structNumberPtrStringOmitEmpty
+			}{
+				structNumberPtrStringOmitEmpty: structNumberPtrStringOmitEmpty{A: numberptr("1")},
+			},
+		},
 
 		// AnonymousHeadNumberPtrNilOnly
 		{
@@ -1730,6 +2252,14 @@ func TestCoverNumber(t *testing.T) {
 				structNumberPtrString
 			}{
 				structNumberPtrString: structNumberPtrString{A: nil},
+			},
+		},
+		{
+			name: "AnonymousHeadNumberPtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structNumberPtrStringOmitEmpty
+			}{
+				structNumberPtrStringOmitEmpty: structNumberPtrStringOmitEmpty{A: nil},
 			},
 		},
 
@@ -1758,6 +2288,14 @@ func TestCoverNumber(t *testing.T) {
 				structNumberPtrString: &structNumberPtrString{A: numberptr("1")},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadNumberPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structNumberPtrStringOmitEmpty
+			}{
+				structNumberPtrStringOmitEmpty: &structNumberPtrStringOmitEmpty{A: numberptr("1")},
+			},
+		},
 
 		// NilPtrAnonymousHeadNumberPtrOnly
 		{
@@ -1782,6 +2320,14 @@ func TestCoverNumber(t *testing.T) {
 				*structNumberPtrString
 			}{
 				structNumberPtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadNumberPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structNumberPtrStringOmitEmpty
+			}{
+				structNumberPtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/cover_string_test.go
+++ b/cover_string_test.go
@@ -17,6 +17,9 @@ func TestCoverString(t *testing.T) {
 	type structStringString struct {
 		A string `json:"a,string"`
 	}
+	type structStringStringOmitEmpty struct {
+		A string `json:"a,string,omitempty"`
+	}
 
 	type structStringPtr struct {
 		A *string `json:"a"`
@@ -26,6 +29,9 @@ func TestCoverString(t *testing.T) {
 	}
 	type structStringPtrString struct {
 		A *string `json:"a,string"`
+	}
+	type structStringPtrStringOmitEmpty struct {
+		A *string `json:"a,string,omitempty"`
 	}
 
 	tests := []struct {
@@ -84,6 +90,12 @@ func TestCoverString(t *testing.T) {
 				A string `json:"a,string"`
 			}{},
 		},
+		{
+			name: "HeadStringZeroStringOmitEmpty",
+			data: struct {
+				A string `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// HeadString
 		{
@@ -102,6 +114,12 @@ func TestCoverString(t *testing.T) {
 			name: "HeadStringString",
 			data: struct {
 				A string `json:"a,string"`
+			}{A: "foo"},
+		},
+		{
+			name: "HeadStringStringOmitEmpty",
+			data: struct {
+				A string `json:"a,string,omitempty"`
 			}{A: "foo"},
 		},
 
@@ -124,6 +142,12 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{A: stringptr("foo")},
 		},
+		{
+			name: "HeadStringPtrStringOmitEmpty",
+			data: struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: stringptr("foo")},
+		},
 
 		// HeadStringPtrNil
 		{
@@ -142,6 +166,12 @@ func TestCoverString(t *testing.T) {
 			name: "HeadStringPtrNilString",
 			data: struct {
 				A *string `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "HeadStringPtrNilStringOmitEmpty",
+			data: struct {
+				A *string `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -164,6 +194,12 @@ func TestCoverString(t *testing.T) {
 				A string `json:"a,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadStringZeroStringOmitEmpty",
+			data: &struct {
+				A string `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadString
 		{
@@ -182,6 +218,12 @@ func TestCoverString(t *testing.T) {
 			name: "PtrHeadStringString",
 			data: &struct {
 				A string `json:"a,string"`
+			}{A: "foo"},
+		},
+		{
+			name: "PtrHeadStringStringOmitEmpty",
+			data: &struct {
+				A string `json:"a,string,omitempty"`
 			}{A: "foo"},
 		},
 
@@ -204,6 +246,12 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{A: stringptr("foo")},
 		},
+		{
+			name: "PtrHeadStringPtrStringOmitEmpty",
+			data: &struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: stringptr("foo")},
+		},
 
 		// PtrHeadStringPtrNil
 		{
@@ -224,6 +272,12 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{A: nil},
 		},
+		{
+			name: "PtrHeadStringPtrNilStringOmitEmpty",
+			data: &struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: nil},
+		},
 
 		// PtrHeadStringNil
 		{
@@ -242,6 +296,12 @@ func TestCoverString(t *testing.T) {
 			name: "PtrHeadStringNilString",
 			data: (*struct {
 				A *string `json:"a,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadStringNilStringOmitEmpty",
+			data: (*struct {
+				A *string `json:"a,string,omitempty"`
 			})(nil),
 		},
 
@@ -270,6 +330,14 @@ func TestCoverString(t *testing.T) {
 				C string `json:"c,string"`
 			}{},
 		},
+		{
+			name: "HeadStringZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A string `json:"a,string,omitempty"`
+				B string `json:"b,string,omitempty"`
+				C string `json:"c,string,omitempty"`
+			}{},
+		},
 
 		// HeadStringMultiFields
 		{
@@ -294,6 +362,14 @@ func TestCoverString(t *testing.T) {
 				A string `json:"a,string"`
 				B string `json:"b,string"`
 				C string `json:"c,string"`
+			}{A: "foo", B: "bar", C: "baz"},
+		},
+		{
+			name: "HeadStringMultiFieldsStringOmitEmpty",
+			data: struct {
+				A string `json:"a,string,omitempty"`
+				B string `json:"b,string,omitempty"`
+				C string `json:"c,string,omitempty"`
 			}{A: "foo", B: "bar", C: "baz"},
 		},
 
@@ -322,6 +398,14 @@ func TestCoverString(t *testing.T) {
 				C *string `json:"c,string"`
 			}{A: stringptr("foo"), B: stringptr("bar"), C: stringptr("baz")},
 		},
+		{
+			name: "HeadStringPtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+				C *string `json:"c,string,omitempty"`
+			}{A: stringptr("foo"), B: stringptr("bar"), C: stringptr("baz")},
+		},
 
 		// HeadStringPtrNilMultiFields
 		{
@@ -346,6 +430,14 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 				B *string `json:"b,string"`
 				C *string `json:"c,string"`
+			}{A: nil, B: nil, C: nil},
+		},
+		{
+			name: "HeadStringPtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+				C *string `json:"c,string,omitempty"`
 			}{A: nil, B: nil, C: nil},
 		},
 
@@ -374,6 +466,14 @@ func TestCoverString(t *testing.T) {
 				C string `json:"c,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadStringZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A string `json:"a,string,omitempty"`
+				B string `json:"b,string,omitempty"`
+				C string `json:"c,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadStringMultiFields
 		{
@@ -398,6 +498,14 @@ func TestCoverString(t *testing.T) {
 				A string `json:"a,string"`
 				B string `json:"b,string"`
 				C string `json:"c,string"`
+			}{A: "foo", B: "bar", C: "baz"},
+		},
+		{
+			name: "PtrHeadStringMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A string `json:"a,string,omitempty"`
+				B string `json:"b,string,omitempty"`
+				C string `json:"c,string,omitempty"`
 			}{A: "foo", B: "bar", C: "baz"},
 		},
 
@@ -426,6 +534,14 @@ func TestCoverString(t *testing.T) {
 				C *string `json:"c,string"`
 			}{A: stringptr("foo"), B: stringptr("bar"), C: stringptr("baz")},
 		},
+		{
+			name: "PtrHeadStringPtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+				C *string `json:"c,string,omitempty"`
+			}{A: stringptr("foo"), B: stringptr("bar"), C: stringptr("baz")},
+		},
 
 		// PtrHeadStringPtrNilMultiFields
 		{
@@ -450,6 +566,14 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 				B *string `json:"b,string"`
 				C *string `json:"c,string"`
+			}{A: nil, B: nil, C: nil},
+		},
+		{
+			name: "PtrHeadStringPtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+				C *string `json:"c,string,omitempty"`
 			}{A: nil, B: nil, C: nil},
 		},
 
@@ -478,6 +602,14 @@ func TestCoverString(t *testing.T) {
 				C *string `json:"c,string"`
 			})(nil),
 		},
+		{
+			name: "PtrHeadStringNilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+				C *string `json:"c,string,omitempty"`
+			})(nil),
+		},
 
 		// HeadStringZeroNotRoot
 		{
@@ -501,6 +633,14 @@ func TestCoverString(t *testing.T) {
 			data: struct {
 				A struct {
 					A string `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadStringZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A string `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -536,6 +676,16 @@ func TestCoverString(t *testing.T) {
 				A string `json:"a,string"`
 			}{A: "foo"}},
 		},
+		{
+			name: "HeadStringNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A string `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A string `json:"a,string,omitempty"`
+			}{A: "foo"}},
+		},
 
 		// HeadStringPtrNotRoot
 		{
@@ -568,6 +718,16 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{stringptr("foo")}},
 		},
+		{
+			name: "HeadStringPtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *string `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *string `json:"a,string,omitempty"`
+			}{stringptr("foo")}},
+		},
 
 		// HeadStringPtrNilNotRoot
 		{
@@ -591,6 +751,14 @@ func TestCoverString(t *testing.T) {
 			data: struct {
 				A struct {
 					A *string `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadStringPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *string `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -626,6 +794,16 @@ func TestCoverString(t *testing.T) {
 				A string `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadStringZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A string `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A string `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadStringNotRoot
 		{
@@ -656,6 +834,16 @@ func TestCoverString(t *testing.T) {
 				}
 			}{A: &(struct {
 				A string `json:"a,string"`
+			}{A: "foo"})},
+		},
+		{
+			name: "PtrHeadStringNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A string `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A string `json:"a,string,omitempty"`
 			}{A: "foo"})},
 		},
 
@@ -690,6 +878,16 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{A: stringptr("foo")})},
 		},
+		{
+			name: "PtrHeadStringPtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: stringptr("foo")})},
+		},
 
 		// PtrHeadStringPtrNilNotRoot
 		{
@@ -722,6 +920,16 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadStringPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadStringNilNotRoot
 		{
@@ -746,6 +954,14 @@ func TestCoverString(t *testing.T) {
 				A *struct {
 					A *string `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadStringNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -780,6 +996,17 @@ func TestCoverString(t *testing.T) {
 				}
 				B struct {
 					B string `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadStringZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A string `json:"a,string,omitempty"`
+				}
+				B struct {
+					B string `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -830,6 +1057,21 @@ func TestCoverString(t *testing.T) {
 				B string `json:"b,string"`
 			}{B: "bar"}},
 		},
+		{
+			name: "HeadStringMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A string `json:"a,string,omitempty"`
+				}
+				B struct {
+					B string `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A string `json:"a,string,omitempty"`
+			}{A: "foo"}, B: struct {
+				B string `json:"b,string,omitempty"`
+			}{B: "bar"}},
+		},
 
 		// HeadStringPtrMultiFieldsNotRoot
 		{
@@ -875,6 +1117,21 @@ func TestCoverString(t *testing.T) {
 				A *string `json:"a,string"`
 			}{A: stringptr("foo")}, B: struct {
 				B *string `json:"b,string"`
+			}{B: stringptr("bar")}},
+		},
+		{
+			name: "HeadStringPtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *string `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *string `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: stringptr("foo")}, B: struct {
+				B *string `json:"b,string,omitempty"`
 			}{B: stringptr("bar")}},
 		},
 
@@ -924,6 +1181,21 @@ func TestCoverString(t *testing.T) {
 				B *string `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadStringPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *string `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *string `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *string `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadStringZeroMultiFieldsNotRoot
 		{
@@ -956,6 +1228,17 @@ func TestCoverString(t *testing.T) {
 				}
 				B struct {
 					B string `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadStringZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A string `json:"a,string,omitempty"`
+				}
+				B struct {
+					B string `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -1006,6 +1289,21 @@ func TestCoverString(t *testing.T) {
 				B string `json:"b,string"`
 			}{B: "bar"}},
 		},
+		{
+			name: "PtrHeadStringMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A string `json:"a,string,omitempty"`
+				}
+				B struct {
+					B string `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A string `json:"a,string,omitempty"`
+			}{A: "foo"}, B: struct {
+				B string `json:"b,string,omitempty"`
+			}{B: "bar"}},
+		},
 
 		// PtrHeadStringPtrMultiFieldsNotRoot
 		{
@@ -1053,6 +1351,21 @@ func TestCoverString(t *testing.T) {
 				B *string `json:"b,string"`
 			}{B: stringptr("bar")})},
 		},
+		{
+			name: "PtrHeadStringPtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *string `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *string `json:"a,string,omitempty"`
+			}{A: stringptr("foo")}), B: &(struct {
+				B *string `json:"b,string,omitempty"`
+			}{B: stringptr("bar")})},
+		},
 
 		// PtrHeadStringPtrNilMultiFieldsNotRoot
 		{
@@ -1088,6 +1401,17 @@ func TestCoverString(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadStringPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *string `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadStringNilMultiFieldsNotRoot
 		{
@@ -1120,6 +1444,17 @@ func TestCoverString(t *testing.T) {
 				}
 				B *struct {
 					B *string `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadStringNilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *string `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1186,6 +1521,25 @@ func TestCoverString(t *testing.T) {
 				B string `json:"b,string"`
 			}{A: "foo", B: "bar"})},
 		},
+		{
+			name: "PtrHeadStringDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A string `json:"a,string,omitempty"`
+					B string `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A string `json:"a,string,omitempty"`
+					B string `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A string `json:"a,string,omitempty"`
+				B string `json:"b,string,omitempty"`
+			}{A: "foo", B: "bar"}), B: &(struct {
+				A string `json:"a,string,omitempty"`
+				B string `json:"b,string,omitempty"`
+			}{A: "foo", B: "bar"})},
+		},
 
 		// PtrHeadStringNilDoubleMultiFieldsNotRoot
 		{
@@ -1227,6 +1581,19 @@ func TestCoverString(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadStringNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A string `json:"a,string,omitempty"`
+					B string `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A string `json:"a,string,omitempty"`
+					B string `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadStringNilDoubleMultiFieldsNotRoot
 		{
@@ -1265,6 +1632,19 @@ func TestCoverString(t *testing.T) {
 				B *struct {
 					A string `json:"a,string"`
 					B string `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadStringNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A string `json:"a,string,omitempty"`
+					B string `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A string `json:"a,string,omitempty"`
+					B string `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1327,6 +1707,25 @@ func TestCoverString(t *testing.T) {
 				B *string `json:"b,string"`
 			}{A: stringptr("foo"), B: stringptr("bar")})},
 		},
+		{
+			name: "PtrHeadStringPtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+					B *string `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *string `json:"a,string,omitempty"`
+					B *string `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+			}{A: stringptr("foo"), B: stringptr("bar")}), B: &(struct {
+				A *string `json:"a,string,omitempty"`
+				B *string `json:"b,string,omitempty"`
+			}{A: stringptr("foo"), B: stringptr("bar")})},
+		},
 
 		// PtrHeadStringPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1368,6 +1767,19 @@ func TestCoverString(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadStringPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+					B *string `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *string `json:"a,string,omitempty"`
+					B *string `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadStringPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1406,6 +1818,19 @@ func TestCoverString(t *testing.T) {
 				B *struct {
 					A *string `json:"a,string"`
 					B *string `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadStringPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *string `json:"a,string,omitempty"`
+					B *string `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *string `json:"a,string,omitempty"`
+					B *string `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1441,6 +1866,16 @@ func TestCoverString(t *testing.T) {
 				B:                  "bar",
 			},
 		},
+		{
+			name: "AnonymousHeadStringStringOmitEmpty",
+			data: struct {
+				structStringStringOmitEmpty
+				B string `json:"b,string,omitempty"`
+			}{
+				structStringStringOmitEmpty: structStringStringOmitEmpty{A: "foo"},
+				B:                           "bar",
+			},
+		},
 
 		// PtrAnonymousHeadString
 		{
@@ -1471,6 +1906,16 @@ func TestCoverString(t *testing.T) {
 			}{
 				structStringString: &structStringString{A: "foo"},
 				B:                  "bar",
+			},
+		},
+		{
+			name: "PtrAnonymousHeadStringStringOmitEmpty",
+			data: struct {
+				*structStringStringOmitEmpty
+				B string `json:"b,string,omitempty"`
+			}{
+				structStringStringOmitEmpty: &structStringStringOmitEmpty{A: "foo"},
+				B:                           "bar",
 			},
 		},
 
@@ -1505,6 +1950,16 @@ func TestCoverString(t *testing.T) {
 				B:                  "baz",
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadStringStringOmitEmpty",
+			data: struct {
+				*structStringStringOmitEmpty
+				B string `json:"b,string,omitempty"`
+			}{
+				structStringStringOmitEmpty: nil,
+				B:                           "baz",
+			},
+		},
 
 		// AnonymousHeadStringPtr
 		{
@@ -1535,6 +1990,16 @@ func TestCoverString(t *testing.T) {
 			}{
 				structStringPtrString: structStringPtrString{A: stringptr("foo")},
 				B:                     stringptr("bar"),
+			},
+		},
+		{
+			name: "AnonymousHeadStringPtrStringOmitEmpty",
+			data: struct {
+				structStringPtrStringOmitEmpty
+				B *string `json:"b,string,omitempty"`
+			}{
+				structStringPtrStringOmitEmpty: structStringPtrStringOmitEmpty{A: stringptr("foo")},
+				B:                              stringptr("bar"),
 			},
 		},
 
@@ -1569,6 +2034,16 @@ func TestCoverString(t *testing.T) {
 				B:                     stringptr("foo"),
 			},
 		},
+		{
+			name: "AnonymousHeadStringPtrNilStringOmitEmpty",
+			data: struct {
+				structStringPtrStringOmitEmpty
+				B *string `json:"b,string,omitempty"`
+			}{
+				structStringPtrStringOmitEmpty: structStringPtrStringOmitEmpty{A: nil},
+				B:                              stringptr("foo"),
+			},
+		},
 
 		// PtrAnonymousHeadStringPtr
 		{
@@ -1599,6 +2074,16 @@ func TestCoverString(t *testing.T) {
 			}{
 				structStringPtrString: &structStringPtrString{A: stringptr("foo")},
 				B:                     stringptr("bar"),
+			},
+		},
+		{
+			name: "PtrAnonymousHeadStringPtrStringOmitEmpty",
+			data: struct {
+				*structStringPtrStringOmitEmpty
+				B *string `json:"b,string,omitempty"`
+			}{
+				structStringPtrStringOmitEmpty: &structStringPtrStringOmitEmpty{A: stringptr("foo")},
+				B:                              stringptr("bar"),
 			},
 		},
 
@@ -1633,6 +2118,16 @@ func TestCoverString(t *testing.T) {
 				B:                     stringptr("foo"),
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadStringPtrStringOmitEmpty",
+			data: struct {
+				*structStringPtrStringOmitEmpty
+				B *string `json:"b,string,omitempty"`
+			}{
+				structStringPtrStringOmitEmpty: nil,
+				B:                              stringptr("foo"),
+			},
+		},
 
 		// AnonymousHeadStringOnly
 		{
@@ -1657,6 +2152,14 @@ func TestCoverString(t *testing.T) {
 				structStringString
 			}{
 				structStringString: structStringString{A: "foo"},
+			},
+		},
+		{
+			name: "AnonymousHeadStringOnlyStringOmitEmpty",
+			data: struct {
+				structStringStringOmitEmpty
+			}{
+				structStringStringOmitEmpty: structStringStringOmitEmpty{A: "foo"},
 			},
 		},
 
@@ -1685,6 +2188,14 @@ func TestCoverString(t *testing.T) {
 				structStringString: &structStringString{A: "foo"},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadStringOnlyStringOmitEmpty",
+			data: struct {
+				*structStringStringOmitEmpty
+			}{
+				structStringStringOmitEmpty: &structStringStringOmitEmpty{A: "foo"},
+			},
+		},
 
 		// NilPtrAnonymousHeadStringOnly
 		{
@@ -1709,6 +2220,14 @@ func TestCoverString(t *testing.T) {
 				*structStringString
 			}{
 				structStringString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadStringOnlyStringOmitEmpty",
+			data: struct {
+				*structStringStringOmitEmpty
+			}{
+				structStringStringOmitEmpty: nil,
 			},
 		},
 
@@ -1737,6 +2256,14 @@ func TestCoverString(t *testing.T) {
 				structStringPtrString: structStringPtrString{A: stringptr("foo")},
 			},
 		},
+		{
+			name: "AnonymousHeadStringPtrOnlyStringOmitEmpty",
+			data: struct {
+				structStringPtrStringOmitEmpty
+			}{
+				structStringPtrStringOmitEmpty: structStringPtrStringOmitEmpty{A: stringptr("foo")},
+			},
+		},
 
 		// AnonymousHeadStringPtrNilOnly
 		{
@@ -1761,6 +2288,14 @@ func TestCoverString(t *testing.T) {
 				structStringPtrString
 			}{
 				structStringPtrString: structStringPtrString{A: nil},
+			},
+		},
+		{
+			name: "AnonymousHeadStringPtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structStringPtrStringOmitEmpty
+			}{
+				structStringPtrStringOmitEmpty: structStringPtrStringOmitEmpty{A: nil},
 			},
 		},
 
@@ -1789,6 +2324,14 @@ func TestCoverString(t *testing.T) {
 				structStringPtrString: &structStringPtrString{A: stringptr("foo")},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadStringPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structStringPtrStringOmitEmpty
+			}{
+				structStringPtrStringOmitEmpty: &structStringPtrStringOmitEmpty{A: stringptr("foo")},
+			},
+		},
 
 		// NilPtrAnonymousHeadStringPtrOnly
 		{
@@ -1813,6 +2356,14 @@ func TestCoverString(t *testing.T) {
 				*structStringPtrString
 			}{
 				structStringPtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadStringPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structStringPtrStringOmitEmpty
+			}{
+				structStringPtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/cover_uint_test.go
+++ b/cover_uint_test.go
@@ -17,6 +17,9 @@ func TestCoverUint(t *testing.T) {
 	type structUintString struct {
 		A uint `json:"a,string"`
 	}
+	type structUintStringOmitEmpty struct {
+		A uint `json:"a,string,omitempty"`
+	}
 
 	type structUintPtr struct {
 		A *uint `json:"a"`
@@ -26,6 +29,9 @@ func TestCoverUint(t *testing.T) {
 	}
 	type structUintPtrString struct {
 		A *uint `json:"a,string"`
+	}
+	type structUintPtrStringOmitEmpty struct {
+		A *uint `json:"a,string,omitempty"`
 	}
 
 	tests := []struct {
@@ -72,6 +78,12 @@ func TestCoverUint(t *testing.T) {
 				A uint `json:"a,string"`
 			}{},
 		},
+		{
+			name: "HeadUintZeroStringOmitEmpty",
+			data: struct {
+				A uint `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// HeadUint
 		{
@@ -90,6 +102,12 @@ func TestCoverUint(t *testing.T) {
 			name: "HeadUintString",
 			data: struct {
 				A uint `json:"a,string"`
+			}{A: 1},
+		},
+		{
+			name: "HeadUintStringOmitEmpty",
+			data: struct {
+				A uint `json:"a,string,omitempty"`
 			}{A: 1},
 		},
 
@@ -112,6 +130,12 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			}{A: uptr(1)},
 		},
+		{
+			name: "HeadUintPtrStringOmitEmpty",
+			data: struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: uptr(1)},
+		},
 
 		// HeadUintPtrNil
 		{
@@ -130,6 +154,12 @@ func TestCoverUint(t *testing.T) {
 			name: "HeadUintPtrNilString",
 			data: struct {
 				A *uint `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "HeadUintPtrNilStringOmitEmpty",
+			data: struct {
+				A *uint `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -152,6 +182,12 @@ func TestCoverUint(t *testing.T) {
 				A uint `json:"a,string"`
 			}{},
 		},
+		{
+			name: "PtrHeadUintZeroStringOmitEmpty",
+			data: &struct {
+				A uint `json:"a,string,omitempty"`
+			}{},
+		},
 
 		// PtrHeadUint
 		{
@@ -170,6 +206,12 @@ func TestCoverUint(t *testing.T) {
 			name: "PtrHeadUintString",
 			data: &struct {
 				A uint `json:"a,string"`
+			}{A: 1},
+		},
+		{
+			name: "PtrHeadUintStringOmitEmpty",
+			data: &struct {
+				A uint `json:"a,string,omitempty"`
 			}{A: 1},
 		},
 
@@ -192,6 +234,12 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			}{A: uptr(1)},
 		},
+		{
+			name: "PtrHeadUintPtrStringOmitEmpty",
+			data: &struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: uptr(1)},
+		},
 
 		// PtrHeadUintPtrNil
 		{
@@ -210,6 +258,12 @@ func TestCoverUint(t *testing.T) {
 			name: "PtrHeadUintPtrNilString",
 			data: &struct {
 				A *uint `json:"a,string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadUintPtrNilStringOmitEmpty",
+			data: &struct {
+				A *uint `json:"a,string,omitempty"`
 			}{A: nil},
 		},
 
@@ -232,6 +286,12 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			})(nil),
 		},
+		{
+			name: "PtrHeadUintNilStringOmitEmpty",
+			data: (*struct {
+				A *uint `json:"a,string,omitempty"`
+			})(nil),
+		},
 
 		// HeadUintZeroMultiFields
 		{
@@ -251,11 +311,19 @@ func TestCoverUint(t *testing.T) {
 			}{},
 		},
 		{
-			name: "HeadUintZeroMultiFields",
+			name: "HeadUintZeroMultiFieldsString",
 			data: struct {
 				A uint `json:"a,string"`
 				B uint `json:"b,string"`
 				C uint `json:"c,string"`
+			}{},
+		},
+		{
+			name: "HeadUintZeroMultiFieldsStringOmitEmpty",
+			data: struct {
+				A uint `json:"a,string,omitempty"`
+				B uint `json:"b,string,omitempty"`
+				C uint `json:"c,string,omitempty"`
 			}{},
 		},
 
@@ -284,6 +352,14 @@ func TestCoverUint(t *testing.T) {
 				C uint `json:"c,string"`
 			}{A: 1, B: 2, C: 3},
 		},
+		{
+			name: "HeadUintMultiFieldsStringOmitEmpty",
+			data: struct {
+				A uint `json:"a,string,omitempty"`
+				B uint `json:"b,string,omitempty"`
+				C uint `json:"c,string,omitempty"`
+			}{A: 1, B: 2, C: 3},
+		},
 
 		// HeadUintPtrMultiFields
 		{
@@ -308,6 +384,14 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 				B *uint `json:"b,string"`
 				C *uint `json:"c,string"`
+			}{A: uptr(1), B: uptr(2), C: uptr(3)},
+		},
+		{
+			name: "HeadUintPtrMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
+				C *uint `json:"c,string,omitempty"`
 			}{A: uptr(1), B: uptr(2), C: uptr(3)},
 		},
 
@@ -336,6 +420,14 @@ func TestCoverUint(t *testing.T) {
 				C *uint `json:"c,string"`
 			}{A: nil, B: nil, C: nil},
 		},
+		{
+			name: "HeadUintPtrNilMultiFieldsStringOmitEmpty",
+			data: struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
+				C *uint `json:"c,string,omitempty"`
+			}{A: nil, B: nil, C: nil},
+		},
 
 		// PtrHeadUintZeroMultiFields
 		{
@@ -357,6 +449,13 @@ func TestCoverUint(t *testing.T) {
 			data: &struct {
 				A uint `json:"a,string"`
 				B uint `json:"b,string"`
+			}{},
+		},
+		{
+			name: "PtrHeadUintZeroMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A uint `json:"a,string,omitempty"`
+				B uint `json:"b,string,omitempty"`
 			}{},
 		},
 
@@ -382,6 +481,13 @@ func TestCoverUint(t *testing.T) {
 				B uint `json:"b,string"`
 			}{A: 1, B: 2},
 		},
+		{
+			name: "PtrHeadUintMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A uint `json:"a,string,omitempty"`
+				B uint `json:"b,string,omitempty"`
+			}{A: 1, B: 2},
+		},
 
 		// PtrHeadUintPtrMultiFields
 		{
@@ -403,6 +509,13 @@ func TestCoverUint(t *testing.T) {
 			data: &struct {
 				A *uint `json:"a,string"`
 				B *uint `json:"b,string"`
+			}{A: uptr(1), B: uptr(2)},
+		},
+		{
+			name: "PtrHeadUintPtrMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
 			}{A: uptr(1), B: uptr(2)},
 		},
 
@@ -428,6 +541,13 @@ func TestCoverUint(t *testing.T) {
 				B *uint `json:"b,string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadUintPtrNilMultiFieldsStringOmitEmpty",
+			data: &struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadUintNilMultiFields
 		{
@@ -449,6 +569,13 @@ func TestCoverUint(t *testing.T) {
 			data: (*struct {
 				A *uint `json:"a,string"`
 				B *uint `json:"b,string"`
+			})(nil),
+		},
+		{
+			name: "PtrHeadUintNilMultiFieldsStringOmitEmpty",
+			data: (*struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
 			})(nil),
 		},
 
@@ -474,6 +601,14 @@ func TestCoverUint(t *testing.T) {
 			data: struct {
 				A struct {
 					A uint `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadUintZeroNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A uint `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -509,6 +644,16 @@ func TestCoverUint(t *testing.T) {
 				A uint `json:"a,string"`
 			}{A: 1}},
 		},
+		{
+			name: "HeadUintNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A uint `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A uint `json:"a,string,omitempty"`
+			}{A: 1}},
+		},
 
 		// HeadUintPtrNotRoot
 		{
@@ -541,6 +686,16 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			}{uptr(1)}},
 		},
+		{
+			name: "HeadUintPtrNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+			}{A: struct {
+				A *uint `json:"a,string,omitempty"`
+			}{uptr(1)}},
+		},
 
 		// HeadUintPtrNilNotRoot
 		{
@@ -564,6 +719,14 @@ func TestCoverUint(t *testing.T) {
 			data: struct {
 				A struct {
 					A *uint `json:"a,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadUintPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *uint `json:"a,string,omitempty"`
 				}
 			}{},
 		},
@@ -599,6 +762,16 @@ func TestCoverUint(t *testing.T) {
 				A uint `json:"a,string"`
 			})},
 		},
+		{
+			name: "PtrHeadUintZeroNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A uint `json:"a,string,omitempty"`
+				}
+			}{A: new(struct {
+				A uint `json:"a,string,omitempty"`
+			})},
+		},
 
 		// PtrHeadUintNotRoot
 		{
@@ -629,6 +802,16 @@ func TestCoverUint(t *testing.T) {
 				}
 			}{A: &(struct {
 				A uint `json:"a,string"`
+			}{A: 1})},
+		},
+		{
+			name: "PtrHeadUintNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A uint `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A uint `json:"a,string,omitempty"`
 			}{A: 1})},
 		},
 
@@ -663,6 +846,16 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			}{A: uptr(1)})},
 		},
+		{
+			name: "PtrHeadUintPtrNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: uptr(1)})},
+		},
 
 		// PtrHeadUintPtrNilNotRoot
 		{
@@ -695,6 +888,16 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			}{A: nil})},
 		},
+		{
+			name: "PtrHeadUintPtrNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: nil})},
+		},
 
 		// PtrHeadUintNilNotRoot
 		{
@@ -719,6 +922,14 @@ func TestCoverUint(t *testing.T) {
 				A *struct {
 					A *uint `json:"a,string"`
 				} `json:",string"`
+			}{A: nil},
+		},
+		{
+			name: "PtrHeadUintNilNotRootStringOmitEmpty",
+			data: struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
 			}{A: nil},
 		},
 
@@ -753,6 +964,17 @@ func TestCoverUint(t *testing.T) {
 				}
 				B struct {
 					B uint `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "HeadUintZeroMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A uint `json:"a,string,omitempty"`
+				}
+				B struct {
+					B uint `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -803,6 +1025,21 @@ func TestCoverUint(t *testing.T) {
 				B uint `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "HeadUintMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A uint `json:"a,string,omitempty"`
+				}
+				B struct {
+					B uint `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A uint `json:"a,string,omitempty"`
+			}{A: 1}, B: struct {
+				B uint `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// HeadUintPtrMultiFieldsNotRoot
 		{
@@ -848,6 +1085,21 @@ func TestCoverUint(t *testing.T) {
 				A *uint `json:"a,string"`
 			}{A: uptr(1)}, B: struct {
 				B *uint `json:"b,string"`
+			}{B: uptr(2)}},
+		},
+		{
+			name: "HeadUintPtrMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *uint `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: uptr(1)}, B: struct {
+				B *uint `json:"b,string,omitempty"`
 			}{B: uptr(2)}},
 		},
 
@@ -897,6 +1149,21 @@ func TestCoverUint(t *testing.T) {
 				B *uint `json:"b,string"`
 			}{B: nil}},
 		},
+		{
+			name: "HeadUintPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: struct {
+				A struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+				B struct {
+					B *uint `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: nil}, B: struct {
+				B *uint `json:"b,string,omitempty"`
+			}{B: nil}},
+		},
 
 		// PtrHeadUintZeroMultiFieldsNotRoot
 		{
@@ -929,6 +1196,17 @@ func TestCoverUint(t *testing.T) {
 				}
 				B struct {
 					B uint `json:"b,string"`
+				}
+			}{},
+		},
+		{
+			name: "PtrHeadUintZeroMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A uint `json:"a,string,omitempty"`
+				}
+				B struct {
+					B uint `json:"b,string,omitempty"`
 				}
 			}{},
 		},
@@ -979,6 +1257,21 @@ func TestCoverUint(t *testing.T) {
 				B uint `json:"b,string"`
 			}{B: 2}},
 		},
+		{
+			name: "PtrHeadUintMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A struct {
+					A uint `json:"a,string,omitempty"`
+				}
+				B struct {
+					B uint `json:"b,string,omitempty"`
+				}
+			}{A: struct {
+				A uint `json:"a,string,omitempty"`
+			}{A: 1}, B: struct {
+				B uint `json:"b,string,omitempty"`
+			}{B: 2}},
+		},
 
 		// PtrHeadUintPtrMultiFieldsNotRoot
 		{
@@ -1026,6 +1319,21 @@ func TestCoverUint(t *testing.T) {
 				B *uint `json:"b,string"`
 			}{B: uptr(2)})},
 		},
+		{
+			name: "PtrHeadUintPtrMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *uint `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *uint `json:"a,string,omitempty"`
+			}{A: uptr(1)}), B: &(struct {
+				B *uint `json:"b,string,omitempty"`
+			}{B: uptr(2)})},
+		},
 
 		// PtrHeadUintPtrNilMultiFieldsNotRoot
 		{
@@ -1061,6 +1369,17 @@ func TestCoverUint(t *testing.T) {
 				} `json:",string"`
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadUintPtrNilMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+				} `json:",string,omitempty"`
+				B *struct {
+					B *uint `json:"b,string,omitempty"`
+				} `json:",string,omitempty"`
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadUintNilMultiFieldsNotRoot
 		{
@@ -1093,6 +1412,17 @@ func TestCoverUint(t *testing.T) {
 				}
 				B *struct {
 					B *uint `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadUintNilMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+				}
+				B *struct {
+					B *uint `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1155,6 +1485,25 @@ func TestCoverUint(t *testing.T) {
 				B uint `json:"b,string"`
 			}{A: 3, B: 4})},
 		},
+		{
+			name: "PtrHeadUintDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A uint `json:"a,string,omitempty"`
+					B uint `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A uint `json:"a,string,omitempty"`
+					B uint `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A uint `json:"a,string,omitempty"`
+				B uint `json:"b,string,omitempty"`
+			}{A: 1, B: 2}), B: &(struct {
+				A uint `json:"a,string,omitempty"`
+				B uint `json:"b,string,omitempty"`
+			}{A: 3, B: 4})},
+		},
 
 		// PtrHeadUintNilDoubleMultiFieldsNotRoot
 		{
@@ -1196,6 +1545,19 @@ func TestCoverUint(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadUintNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A uint `json:"a,string,omitempty"`
+					B uint `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A uint `json:"a,string,omitempty"`
+					B uint `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadUintNilDoubleMultiFieldsNotRoot
 		{
@@ -1234,6 +1596,19 @@ func TestCoverUint(t *testing.T) {
 				B *struct {
 					A uint `json:"a,string"`
 					B uint `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadUintNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A uint `json:"a,string,omitempty"`
+					B uint `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A uint `json:"a,string,omitempty"`
+					B uint `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1296,6 +1671,25 @@ func TestCoverUint(t *testing.T) {
 				B *uint `json:"b,string"`
 			}{A: uptr(3), B: uptr(4)})},
 		},
+		{
+			name: "PtrHeadUintPtrDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+					B *uint `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *uint `json:"a,string,omitempty"`
+					B *uint `json:"b,string,omitempty"`
+				}
+			}{A: &(struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
+			}{A: uptr(1), B: uptr(2)}), B: &(struct {
+				A *uint `json:"a,string,omitempty"`
+				B *uint `json:"b,string,omitempty"`
+			}{A: uptr(3), B: uptr(4)})},
+		},
 
 		// PtrHeadUintPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1337,6 +1731,19 @@ func TestCoverUint(t *testing.T) {
 				}
 			}{A: nil, B: nil},
 		},
+		{
+			name: "PtrHeadUintPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: &struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+					B *uint `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *uint `json:"a,string,omitempty"`
+					B *uint `json:"b,string,omitempty"`
+				}
+			}{A: nil, B: nil},
+		},
 
 		// PtrHeadUintPtrNilDoubleMultiFieldsNotRoot
 		{
@@ -1375,6 +1782,19 @@ func TestCoverUint(t *testing.T) {
 				B *struct {
 					A *uint `json:"a,string"`
 					B *uint `json:"b,string"`
+				}
+			})(nil),
+		},
+		{
+			name: "PtrHeadUintPtrNilDoubleMultiFieldsNotRootStringOmitEmpty",
+			data: (*struct {
+				A *struct {
+					A *uint `json:"a,string,omitempty"`
+					B *uint `json:"b,string,omitempty"`
+				}
+				B *struct {
+					A *uint `json:"a,string,omitempty"`
+					B *uint `json:"b,string,omitempty"`
 				}
 			})(nil),
 		},
@@ -1410,6 +1830,16 @@ func TestCoverUint(t *testing.T) {
 				B:                2,
 			},
 		},
+		{
+			name: "AnonymousHeadUintStringOmitEmpty",
+			data: struct {
+				structUintStringOmitEmpty
+				B uint `json:"b,string,omitempty"`
+			}{
+				structUintStringOmitEmpty: structUintStringOmitEmpty{A: 1},
+				B:                         2,
+			},
+		},
 
 		// PtrAnonymousHeadUint
 		{
@@ -1440,6 +1870,16 @@ func TestCoverUint(t *testing.T) {
 			}{
 				structUintString: &structUintString{A: 1},
 				B:                2,
+			},
+		},
+		{
+			name: "PtrAnonymousHeadUintStringOmitEmpty",
+			data: struct {
+				*structUintStringOmitEmpty
+				B uint `json:"b,string,omitempty"`
+			}{
+				structUintStringOmitEmpty: &structUintStringOmitEmpty{A: 1},
+				B:                         2,
 			},
 		},
 
@@ -1474,6 +1914,16 @@ func TestCoverUint(t *testing.T) {
 				B:                2,
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadUintStringOmitEmpty",
+			data: struct {
+				*structUintStringOmitEmpty
+				B uint `json:"b,string,omitempty"`
+			}{
+				structUintStringOmitEmpty: nil,
+				B:                         2,
+			},
+		},
 
 		// AnonymousHeadUintPtr
 		{
@@ -1504,6 +1954,16 @@ func TestCoverUint(t *testing.T) {
 			}{
 				structUintPtrString: structUintPtrString{A: uptr(1)},
 				B:                   uptr(2),
+			},
+		},
+		{
+			name: "AnonymousHeadUintPtrStringOmitEmpty",
+			data: struct {
+				structUintPtrStringOmitEmpty
+				B *uint `json:"b,string,omitempty"`
+			}{
+				structUintPtrStringOmitEmpty: structUintPtrStringOmitEmpty{A: uptr(1)},
+				B:                            uptr(2),
 			},
 		},
 
@@ -1538,6 +1998,16 @@ func TestCoverUint(t *testing.T) {
 				B:                   uptr(2),
 			},
 		},
+		{
+			name: "AnonymousHeadUintPtrNilStringOmitEmpty",
+			data: struct {
+				structUintPtrStringOmitEmpty
+				B *uint `json:"b,string,omitempty"`
+			}{
+				structUintPtrStringOmitEmpty: structUintPtrStringOmitEmpty{A: nil},
+				B:                            uptr(2),
+			},
+		},
 
 		// PtrAnonymousHeadUintPtr
 		{
@@ -1568,6 +2038,16 @@ func TestCoverUint(t *testing.T) {
 			}{
 				structUintPtrString: &structUintPtrString{A: uptr(1)},
 				B:                   uptr(2),
+			},
+		},
+		{
+			name: "PtrAnonymousHeadUintPtrStringOmitEmpty",
+			data: struct {
+				*structUintPtrStringOmitEmpty
+				B *uint `json:"b,string,omitempty"`
+			}{
+				structUintPtrStringOmitEmpty: &structUintPtrStringOmitEmpty{A: uptr(1)},
+				B:                            uptr(2),
 			},
 		},
 
@@ -1602,6 +2082,16 @@ func TestCoverUint(t *testing.T) {
 				B:                   uptr(2),
 			},
 		},
+		{
+			name: "NilPtrAnonymousHeadUintPtrStringOmitEmpty",
+			data: struct {
+				*structUintPtrStringOmitEmpty
+				B *uint `json:"b,string,omitempty"`
+			}{
+				structUintPtrStringOmitEmpty: nil,
+				B:                            uptr(2),
+			},
+		},
 
 		// AnonymousHeadUintOnly
 		{
@@ -1626,6 +2116,14 @@ func TestCoverUint(t *testing.T) {
 				structUintString
 			}{
 				structUintString: structUintString{A: 1},
+			},
+		},
+		{
+			name: "AnonymousHeadUintOnlyStringOmitEmpty",
+			data: struct {
+				structUintStringOmitEmpty
+			}{
+				structUintStringOmitEmpty: structUintStringOmitEmpty{A: 1},
 			},
 		},
 
@@ -1654,6 +2152,14 @@ func TestCoverUint(t *testing.T) {
 				structUintString: &structUintString{A: 1},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadUintOnlyStringOmitEmpty",
+			data: struct {
+				*structUintStringOmitEmpty
+			}{
+				structUintStringOmitEmpty: &structUintStringOmitEmpty{A: 1},
+			},
+		},
 
 		// NilPtrAnonymousHeadUintOnly
 		{
@@ -1678,6 +2184,14 @@ func TestCoverUint(t *testing.T) {
 				*structUintString
 			}{
 				structUintString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadUintOnlyStringOmitEmpty",
+			data: struct {
+				*structUintStringOmitEmpty
+			}{
+				structUintStringOmitEmpty: nil,
 			},
 		},
 
@@ -1706,6 +2220,14 @@ func TestCoverUint(t *testing.T) {
 				structUintPtrString: structUintPtrString{A: uptr(1)},
 			},
 		},
+		{
+			name: "AnonymousHeadUintPtrOnlyStringOmitEmpty",
+			data: struct {
+				structUintPtrStringOmitEmpty
+			}{
+				structUintPtrStringOmitEmpty: structUintPtrStringOmitEmpty{A: uptr(1)},
+			},
+		},
 
 		// AnonymousHeadUintPtrNilOnly
 		{
@@ -1730,6 +2252,14 @@ func TestCoverUint(t *testing.T) {
 				structUintPtrString
 			}{
 				structUintPtrString: structUintPtrString{A: nil},
+			},
+		},
+		{
+			name: "AnonymousHeadUintPtrNilOnlyStringOmitEmpty",
+			data: struct {
+				structUintPtrStringOmitEmpty
+			}{
+				structUintPtrStringOmitEmpty: structUintPtrStringOmitEmpty{A: nil},
 			},
 		},
 
@@ -1758,6 +2288,14 @@ func TestCoverUint(t *testing.T) {
 				structUintPtrString: &structUintPtrString{A: uptr(1)},
 			},
 		},
+		{
+			name: "PtrAnonymousHeadUintPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structUintPtrStringOmitEmpty
+			}{
+				structUintPtrStringOmitEmpty: &structUintPtrStringOmitEmpty{A: uptr(1)},
+			},
+		},
 
 		// NilPtrAnonymousHeadUintPtrOnly
 		{
@@ -1782,6 +2320,14 @@ func TestCoverUint(t *testing.T) {
 				*structUintPtrString
 			}{
 				structUintPtrString: nil,
+			},
+		},
+		{
+			name: "NilPtrAnonymousHeadUintPtrOnlyStringOmitEmpty",
+			data: struct {
+				*structUintPtrStringOmitEmpty
+			}{
+				structUintPtrStringOmitEmpty: nil,
 			},
 		},
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 600M
+          memory: 700M
     working_dir: /go/src/go-json
     command: |
       sh -c "go test -c . && ls go-json.test"

--- a/internal/cmd/generator/main.go
+++ b/internal/cmd/generator/main.go
@@ -100,7 +100,7 @@ func (t OpType) HeadToPtrHead() OpType {
   }
   suffix := "PtrHead"+t.String()[idx+len("Head"):]
 
-  const toPtrOffset = 3
+  const toPtrOffset = 2
   if strings.Contains(OpType(int(t) + toPtrOffset).String(), suffix) {
     return OpType(int(t) + toPtrOffset)
   }
@@ -116,14 +116,6 @@ func (t OpType) HeadToOmitEmptyHead() OpType {
   return t
 }
 
-func (t OpType) HeadToStringTagHead() OpType {
-  const toStringTagOffset = 2
-  if strings.Contains(OpType(int(t) + toStringTagOffset).String(), "StringTag") {
-    return OpType(int(t) + toStringTagOffset)
-  }
-  return t
-}
-
 func (t OpType) PtrHeadToHead() OpType {
   idx := strings.Index(t.String(), "Ptr")
   if idx == -1 {
@@ -131,7 +123,7 @@ func (t OpType) PtrHeadToHead() OpType {
   }
   suffix := t.String()[idx+len("Ptr"):]
 
-  const toPtrOffset = 3
+  const toPtrOffset = 2
   if strings.Contains(OpType(int(t) - toPtrOffset).String(), suffix) {
     return OpType(int(t) - toPtrOffset)
   }
@@ -144,10 +136,10 @@ func (t OpType) FieldToEnd() OpType {
     return t
   }
   suffix := t.String()[idx+len("Field"):]
-  if suffix == "" || suffix == "OmitEmpty" || suffix == "StringTag" {
+  if suffix == "" || suffix == "OmitEmpty" {
     return t
   }
-  const toEndOffset = 3
+  const toEndOffset = 2
   if strings.Contains(OpType(int(t) + toEndOffset).String(), "End"+suffix) {
     return OpType(int(t) + toEndOffset)
   }
@@ -161,15 +153,6 @@ func (t OpType) FieldToOmitEmptyField() OpType {
   }
   return t
 }
-
-func (t OpType) FieldToStringTagField() OpType {
-  const toStringTagOffset = 2
-  if strings.Contains(OpType(int(t) + toStringTagOffset).String(), "StringTag") {
-    return OpType(int(t) + toStringTagOffset)
-  }
-  return t
-}
-
 `)
 	if err != nil {
 		return err
@@ -191,9 +174,10 @@ func (t OpType) FieldToStringTagField() OpType {
 	primitiveTypes := []string{
 		"int", "uint", "float32", "float64", "bool", "string", "bytes", "number",
 		"array", "map", "slice", "struct", "MarshalJSON", "MarshalText",
-		"intString", "uintString",
+		"intString", "uintString", "float32String", "float64String", "boolString", "stringString", "numberString",
 		"intPtr", "uintPtr", "float32Ptr", "float64Ptr", "boolPtr", "stringPtr", "bytesPtr", "numberPtr",
 		"arrayPtr", "mapPtr", "slicePtr", "marshalJSONPtr", "marshalTextPtr", "interfacePtr",
+		"intPtrString", "uintPtrString", "float32PtrString", "float64PtrString", "boolPtrString", "stringPtrString", "numberPtrString",
 	}
 	primitiveTypesUpper := []string{}
 	for _, typ := range primitiveTypes {
@@ -221,7 +205,7 @@ func (t OpType) FieldToStringTagField() OpType {
 	}
 	for _, typ := range append(primitiveTypesUpper, "") {
 		for _, ptrOrNot := range []string{"", "Ptr"} {
-			for _, opt := range []string{"", "OmitEmpty", "StringTag"} {
+			for _, opt := range []string{"", "OmitEmpty"} {
 				ptrOrNot := ptrOrNot
 				opt := opt
 				typ := typ
@@ -240,7 +224,7 @@ func (t OpType) FieldToStringTagField() OpType {
 		}
 	}
 	for _, typ := range append(primitiveTypesUpper, "") {
-		for _, opt := range []string{"", "OmitEmpty", "StringTag"} {
+		for _, opt := range []string{"", "OmitEmpty"} {
 			opt := opt
 			typ := typ
 
@@ -254,7 +238,7 @@ func (t OpType) FieldToStringTagField() OpType {
 				Code: "StructField",
 			})
 		}
-		for _, opt := range []string{"", "OmitEmpty", "StringTag"} {
+		for _, opt := range []string{"", "OmitEmpty"} {
 			opt := opt
 			typ := typ
 

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -1019,23 +1019,17 @@ func compileMapValue(ctx *compileContext) (*Opcode, error) {
 }
 
 func optimizeStructHeader(code *Opcode, tag *runtime.StructTag) OpType {
-	headType := code.ToHeaderType()
-	switch {
-	case tag.IsOmitEmpty:
+	headType := code.ToHeaderType(tag.IsString)
+	if tag.IsOmitEmpty {
 		headType = headType.HeadToOmitEmptyHead()
-	case tag.IsString:
-		headType = headType.HeadToStringTagHead()
 	}
 	return headType
 }
 
 func optimizeStructField(code *Opcode, tag *runtime.StructTag) OpType {
-	fieldType := code.ToFieldType()
-	switch {
-	case tag.IsOmitEmpty:
+	fieldType := code.ToFieldType(tag.IsString)
+	if tag.IsOmitEmpty {
 		fieldType = fieldType.FieldToOmitEmptyField()
-	case tag.IsString:
-		fieldType = fieldType.FieldToStringTagField()
 	}
 	return fieldType
 }

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -41,37 +41,23 @@ func (t OpType) IsMultipleOpHead() bool {
 		return true
 	case OpStructHeadOmitEmptySlice:
 		return true
-	case OpStructHeadStringTagSlice:
-		return true
 	case OpStructHeadOmitEmptyArray:
-		return true
-	case OpStructHeadStringTagArray:
 		return true
 	case OpStructHeadOmitEmptyMap:
 		return true
-	case OpStructHeadStringTagMap:
-		return true
 	case OpStructHeadOmitEmptyStruct:
-		return true
-	case OpStructHeadStringTag:
 		return true
 	case OpStructHeadSlicePtr:
 		return true
 	case OpStructHeadOmitEmptySlicePtr:
 		return true
-	case OpStructHeadStringTagSlicePtr:
-		return true
 	case OpStructHeadArrayPtr:
 		return true
 	case OpStructHeadOmitEmptyArrayPtr:
 		return true
-	case OpStructHeadStringTagArrayPtr:
-		return true
 	case OpStructHeadMapPtr:
 		return true
 	case OpStructHeadOmitEmptyMapPtr:
-		return true
-	case OpStructHeadStringTagMapPtr:
 		return true
 	}
 	return false
@@ -93,37 +79,23 @@ func (t OpType) IsMultipleOpField() bool {
 		return true
 	case OpStructFieldOmitEmptySlice:
 		return true
-	case OpStructFieldStringTagSlice:
-		return true
 	case OpStructFieldOmitEmptyArray:
-		return true
-	case OpStructFieldStringTagArray:
 		return true
 	case OpStructFieldOmitEmptyMap:
 		return true
-	case OpStructFieldStringTagMap:
-		return true
 	case OpStructFieldOmitEmptyStruct:
-		return true
-	case OpStructFieldStringTag:
 		return true
 	case OpStructFieldSlicePtr:
 		return true
 	case OpStructFieldOmitEmptySlicePtr:
 		return true
-	case OpStructFieldStringTagSlicePtr:
-		return true
 	case OpStructFieldArrayPtr:
 		return true
 	case OpStructFieldOmitEmptyArrayPtr:
 		return true
-	case OpStructFieldStringTagArrayPtr:
-		return true
 	case OpStructFieldMapPtr:
 		return true
 	case OpStructFieldOmitEmptyMapPtr:
-		return true
-	case OpStructFieldStringTagMapPtr:
 		return true
 	}
 	return false

--- a/internal/encoder/opcode.go
+++ b/internal/encoder/opcode.go
@@ -68,35 +68,77 @@ func (c *Opcode) setMaskAndRshiftNum(bitSize uint8) {
 	c.RshiftNum = rshitNum(bitSize)
 }
 
-func (c *Opcode) ToHeaderType() OpType {
+func (c *Opcode) ToHeaderType(isString bool) OpType {
 	switch c.Op {
 	case OpInt:
+		if isString {
+			return OpStructHeadIntString
+		}
 		return OpStructHeadInt
 	case OpIntPtr:
+		if isString {
+			return OpStructHeadIntPtrString
+		}
 		return OpStructHeadIntPtr
 	case OpUint:
+		if isString {
+			return OpStructHeadUintString
+		}
 		return OpStructHeadUint
 	case OpUintPtr:
+		if isString {
+			return OpStructHeadUintPtrString
+		}
 		return OpStructHeadUintPtr
 	case OpFloat32:
+		if isString {
+			return OpStructHeadFloat32String
+		}
 		return OpStructHeadFloat32
 	case OpFloat32Ptr:
+		if isString {
+			return OpStructHeadFloat32PtrString
+		}
 		return OpStructHeadFloat32Ptr
 	case OpFloat64:
+		if isString {
+			return OpStructHeadFloat64String
+		}
 		return OpStructHeadFloat64
 	case OpFloat64Ptr:
+		if isString {
+			return OpStructHeadFloat64PtrString
+		}
 		return OpStructHeadFloat64Ptr
 	case OpString:
+		if isString {
+			return OpStructHeadStringString
+		}
 		return OpStructHeadString
 	case OpStringPtr:
+		if isString {
+			return OpStructHeadStringPtrString
+		}
 		return OpStructHeadStringPtr
 	case OpNumber:
+		if isString {
+			return OpStructHeadNumberString
+		}
 		return OpStructHeadNumber
 	case OpNumberPtr:
+		if isString {
+			return OpStructHeadNumberPtrString
+		}
 		return OpStructHeadNumberPtr
 	case OpBool:
+		if isString {
+			return OpStructHeadBoolString
+		}
 		return OpStructHeadBool
 	case OpBoolPtr:
+		if isString {
+			return OpStructHeadBoolPtrString
+		}
 		return OpStructHeadBoolPtr
 	case OpBytes:
 		return OpStructHeadBytes
@@ -129,35 +171,77 @@ func (c *Opcode) ToHeaderType() OpType {
 	return OpStructHead
 }
 
-func (c *Opcode) ToFieldType() OpType {
+func (c *Opcode) ToFieldType(isString bool) OpType {
 	switch c.Op {
 	case OpInt:
+		if isString {
+			return OpStructFieldIntString
+		}
 		return OpStructFieldInt
 	case OpIntPtr:
+		if isString {
+			return OpStructFieldIntPtrString
+		}
 		return OpStructFieldIntPtr
 	case OpUint:
+		if isString {
+			return OpStructFieldUintString
+		}
 		return OpStructFieldUint
 	case OpUintPtr:
+		if isString {
+			return OpStructFieldUintPtrString
+		}
 		return OpStructFieldUintPtr
 	case OpFloat32:
+		if isString {
+			return OpStructFieldFloat32String
+		}
 		return OpStructFieldFloat32
 	case OpFloat32Ptr:
+		if isString {
+			return OpStructFieldFloat32PtrString
+		}
 		return OpStructFieldFloat32Ptr
 	case OpFloat64:
+		if isString {
+			return OpStructFieldFloat64String
+		}
 		return OpStructFieldFloat64
 	case OpFloat64Ptr:
+		if isString {
+			return OpStructFieldFloat64PtrString
+		}
 		return OpStructFieldFloat64Ptr
 	case OpString:
+		if isString {
+			return OpStructFieldStringString
+		}
 		return OpStructFieldString
 	case OpStringPtr:
+		if isString {
+			return OpStructFieldStringPtrString
+		}
 		return OpStructFieldStringPtr
 	case OpNumber:
+		if isString {
+			return OpStructFieldNumberString
+		}
 		return OpStructFieldNumber
 	case OpNumberPtr:
+		if isString {
+			return OpStructFieldNumberPtrString
+		}
 		return OpStructFieldNumberPtr
 	case OpBool:
+		if isString {
+			return OpStructFieldBoolString
+		}
 		return OpStructFieldBool
 	case OpBoolPtr:
+		if isString {
+			return OpStructFieldBoolPtrString
+		}
 		return OpStructFieldBoolPtr
 	case OpBytes:
 		return OpStructFieldBytes

--- a/internal/encoder/optype.go
+++ b/internal/encoder/optype.go
@@ -22,7 +22,7 @@ const (
 	CodeStructEnd   CodeType = 11
 )
 
-var opTypeStrings = [416]string{
+var opTypeStrings = [400]string{
 	"End",
 	"Interface",
 	"Ptr",
@@ -53,6 +53,11 @@ var opTypeStrings = [416]string{
 	"MarshalText",
 	"IntString",
 	"UintString",
+	"Float32String",
+	"Float64String",
+	"BoolString",
+	"StringString",
+	"NumberString",
 	"IntPtr",
 	"UintPtr",
 	"Float32Ptr",
@@ -67,803 +72,766 @@ var opTypeStrings = [416]string{
 	"MarshalJSONPtr",
 	"MarshalTextPtr",
 	"InterfacePtr",
+	"IntPtrString",
+	"UintPtrString",
+	"Float32PtrString",
+	"Float64PtrString",
+	"BoolPtrString",
+	"StringPtrString",
+	"NumberPtrString",
 	"StructHeadInt",
 	"StructHeadOmitEmptyInt",
-	"StructHeadStringTagInt",
 	"StructPtrHeadInt",
 	"StructPtrHeadOmitEmptyInt",
-	"StructPtrHeadStringTagInt",
 	"StructHeadUint",
 	"StructHeadOmitEmptyUint",
-	"StructHeadStringTagUint",
 	"StructPtrHeadUint",
 	"StructPtrHeadOmitEmptyUint",
-	"StructPtrHeadStringTagUint",
 	"StructHeadFloat32",
 	"StructHeadOmitEmptyFloat32",
-	"StructHeadStringTagFloat32",
 	"StructPtrHeadFloat32",
 	"StructPtrHeadOmitEmptyFloat32",
-	"StructPtrHeadStringTagFloat32",
 	"StructHeadFloat64",
 	"StructHeadOmitEmptyFloat64",
-	"StructHeadStringTagFloat64",
 	"StructPtrHeadFloat64",
 	"StructPtrHeadOmitEmptyFloat64",
-	"StructPtrHeadStringTagFloat64",
 	"StructHeadBool",
 	"StructHeadOmitEmptyBool",
-	"StructHeadStringTagBool",
 	"StructPtrHeadBool",
 	"StructPtrHeadOmitEmptyBool",
-	"StructPtrHeadStringTagBool",
 	"StructHeadString",
 	"StructHeadOmitEmptyString",
-	"StructHeadStringTagString",
 	"StructPtrHeadString",
 	"StructPtrHeadOmitEmptyString",
-	"StructPtrHeadStringTagString",
 	"StructHeadBytes",
 	"StructHeadOmitEmptyBytes",
-	"StructHeadStringTagBytes",
 	"StructPtrHeadBytes",
 	"StructPtrHeadOmitEmptyBytes",
-	"StructPtrHeadStringTagBytes",
 	"StructHeadNumber",
 	"StructHeadOmitEmptyNumber",
-	"StructHeadStringTagNumber",
 	"StructPtrHeadNumber",
 	"StructPtrHeadOmitEmptyNumber",
-	"StructPtrHeadStringTagNumber",
 	"StructHeadArray",
 	"StructHeadOmitEmptyArray",
-	"StructHeadStringTagArray",
 	"StructPtrHeadArray",
 	"StructPtrHeadOmitEmptyArray",
-	"StructPtrHeadStringTagArray",
 	"StructHeadMap",
 	"StructHeadOmitEmptyMap",
-	"StructHeadStringTagMap",
 	"StructPtrHeadMap",
 	"StructPtrHeadOmitEmptyMap",
-	"StructPtrHeadStringTagMap",
 	"StructHeadSlice",
 	"StructHeadOmitEmptySlice",
-	"StructHeadStringTagSlice",
 	"StructPtrHeadSlice",
 	"StructPtrHeadOmitEmptySlice",
-	"StructPtrHeadStringTagSlice",
 	"StructHeadStruct",
 	"StructHeadOmitEmptyStruct",
-	"StructHeadStringTagStruct",
 	"StructPtrHeadStruct",
 	"StructPtrHeadOmitEmptyStruct",
-	"StructPtrHeadStringTagStruct",
 	"StructHeadMarshalJSON",
 	"StructHeadOmitEmptyMarshalJSON",
-	"StructHeadStringTagMarshalJSON",
 	"StructPtrHeadMarshalJSON",
 	"StructPtrHeadOmitEmptyMarshalJSON",
-	"StructPtrHeadStringTagMarshalJSON",
 	"StructHeadMarshalText",
 	"StructHeadOmitEmptyMarshalText",
-	"StructHeadStringTagMarshalText",
 	"StructPtrHeadMarshalText",
 	"StructPtrHeadOmitEmptyMarshalText",
-	"StructPtrHeadStringTagMarshalText",
 	"StructHeadIntString",
 	"StructHeadOmitEmptyIntString",
-	"StructHeadStringTagIntString",
 	"StructPtrHeadIntString",
 	"StructPtrHeadOmitEmptyIntString",
-	"StructPtrHeadStringTagIntString",
 	"StructHeadUintString",
 	"StructHeadOmitEmptyUintString",
-	"StructHeadStringTagUintString",
 	"StructPtrHeadUintString",
 	"StructPtrHeadOmitEmptyUintString",
-	"StructPtrHeadStringTagUintString",
+	"StructHeadFloat32String",
+	"StructHeadOmitEmptyFloat32String",
+	"StructPtrHeadFloat32String",
+	"StructPtrHeadOmitEmptyFloat32String",
+	"StructHeadFloat64String",
+	"StructHeadOmitEmptyFloat64String",
+	"StructPtrHeadFloat64String",
+	"StructPtrHeadOmitEmptyFloat64String",
+	"StructHeadBoolString",
+	"StructHeadOmitEmptyBoolString",
+	"StructPtrHeadBoolString",
+	"StructPtrHeadOmitEmptyBoolString",
+	"StructHeadStringString",
+	"StructHeadOmitEmptyStringString",
+	"StructPtrHeadStringString",
+	"StructPtrHeadOmitEmptyStringString",
+	"StructHeadNumberString",
+	"StructHeadOmitEmptyNumberString",
+	"StructPtrHeadNumberString",
+	"StructPtrHeadOmitEmptyNumberString",
 	"StructHeadIntPtr",
 	"StructHeadOmitEmptyIntPtr",
-	"StructHeadStringTagIntPtr",
 	"StructPtrHeadIntPtr",
 	"StructPtrHeadOmitEmptyIntPtr",
-	"StructPtrHeadStringTagIntPtr",
 	"StructHeadUintPtr",
 	"StructHeadOmitEmptyUintPtr",
-	"StructHeadStringTagUintPtr",
 	"StructPtrHeadUintPtr",
 	"StructPtrHeadOmitEmptyUintPtr",
-	"StructPtrHeadStringTagUintPtr",
 	"StructHeadFloat32Ptr",
 	"StructHeadOmitEmptyFloat32Ptr",
-	"StructHeadStringTagFloat32Ptr",
 	"StructPtrHeadFloat32Ptr",
 	"StructPtrHeadOmitEmptyFloat32Ptr",
-	"StructPtrHeadStringTagFloat32Ptr",
 	"StructHeadFloat64Ptr",
 	"StructHeadOmitEmptyFloat64Ptr",
-	"StructHeadStringTagFloat64Ptr",
 	"StructPtrHeadFloat64Ptr",
 	"StructPtrHeadOmitEmptyFloat64Ptr",
-	"StructPtrHeadStringTagFloat64Ptr",
 	"StructHeadBoolPtr",
 	"StructHeadOmitEmptyBoolPtr",
-	"StructHeadStringTagBoolPtr",
 	"StructPtrHeadBoolPtr",
 	"StructPtrHeadOmitEmptyBoolPtr",
-	"StructPtrHeadStringTagBoolPtr",
 	"StructHeadStringPtr",
 	"StructHeadOmitEmptyStringPtr",
-	"StructHeadStringTagStringPtr",
 	"StructPtrHeadStringPtr",
 	"StructPtrHeadOmitEmptyStringPtr",
-	"StructPtrHeadStringTagStringPtr",
 	"StructHeadBytesPtr",
 	"StructHeadOmitEmptyBytesPtr",
-	"StructHeadStringTagBytesPtr",
 	"StructPtrHeadBytesPtr",
 	"StructPtrHeadOmitEmptyBytesPtr",
-	"StructPtrHeadStringTagBytesPtr",
 	"StructHeadNumberPtr",
 	"StructHeadOmitEmptyNumberPtr",
-	"StructHeadStringTagNumberPtr",
 	"StructPtrHeadNumberPtr",
 	"StructPtrHeadOmitEmptyNumberPtr",
-	"StructPtrHeadStringTagNumberPtr",
 	"StructHeadArrayPtr",
 	"StructHeadOmitEmptyArrayPtr",
-	"StructHeadStringTagArrayPtr",
 	"StructPtrHeadArrayPtr",
 	"StructPtrHeadOmitEmptyArrayPtr",
-	"StructPtrHeadStringTagArrayPtr",
 	"StructHeadMapPtr",
 	"StructHeadOmitEmptyMapPtr",
-	"StructHeadStringTagMapPtr",
 	"StructPtrHeadMapPtr",
 	"StructPtrHeadOmitEmptyMapPtr",
-	"StructPtrHeadStringTagMapPtr",
 	"StructHeadSlicePtr",
 	"StructHeadOmitEmptySlicePtr",
-	"StructHeadStringTagSlicePtr",
 	"StructPtrHeadSlicePtr",
 	"StructPtrHeadOmitEmptySlicePtr",
-	"StructPtrHeadStringTagSlicePtr",
 	"StructHeadMarshalJSONPtr",
 	"StructHeadOmitEmptyMarshalJSONPtr",
-	"StructHeadStringTagMarshalJSONPtr",
 	"StructPtrHeadMarshalJSONPtr",
 	"StructPtrHeadOmitEmptyMarshalJSONPtr",
-	"StructPtrHeadStringTagMarshalJSONPtr",
 	"StructHeadMarshalTextPtr",
 	"StructHeadOmitEmptyMarshalTextPtr",
-	"StructHeadStringTagMarshalTextPtr",
 	"StructPtrHeadMarshalTextPtr",
 	"StructPtrHeadOmitEmptyMarshalTextPtr",
-	"StructPtrHeadStringTagMarshalTextPtr",
 	"StructHeadInterfacePtr",
 	"StructHeadOmitEmptyInterfacePtr",
-	"StructHeadStringTagInterfacePtr",
 	"StructPtrHeadInterfacePtr",
 	"StructPtrHeadOmitEmptyInterfacePtr",
-	"StructPtrHeadStringTagInterfacePtr",
+	"StructHeadIntPtrString",
+	"StructHeadOmitEmptyIntPtrString",
+	"StructPtrHeadIntPtrString",
+	"StructPtrHeadOmitEmptyIntPtrString",
+	"StructHeadUintPtrString",
+	"StructHeadOmitEmptyUintPtrString",
+	"StructPtrHeadUintPtrString",
+	"StructPtrHeadOmitEmptyUintPtrString",
+	"StructHeadFloat32PtrString",
+	"StructHeadOmitEmptyFloat32PtrString",
+	"StructPtrHeadFloat32PtrString",
+	"StructPtrHeadOmitEmptyFloat32PtrString",
+	"StructHeadFloat64PtrString",
+	"StructHeadOmitEmptyFloat64PtrString",
+	"StructPtrHeadFloat64PtrString",
+	"StructPtrHeadOmitEmptyFloat64PtrString",
+	"StructHeadBoolPtrString",
+	"StructHeadOmitEmptyBoolPtrString",
+	"StructPtrHeadBoolPtrString",
+	"StructPtrHeadOmitEmptyBoolPtrString",
+	"StructHeadStringPtrString",
+	"StructHeadOmitEmptyStringPtrString",
+	"StructPtrHeadStringPtrString",
+	"StructPtrHeadOmitEmptyStringPtrString",
+	"StructHeadNumberPtrString",
+	"StructHeadOmitEmptyNumberPtrString",
+	"StructPtrHeadNumberPtrString",
+	"StructPtrHeadOmitEmptyNumberPtrString",
 	"StructHead",
 	"StructHeadOmitEmpty",
-	"StructHeadStringTag",
 	"StructPtrHead",
 	"StructPtrHeadOmitEmpty",
-	"StructPtrHeadStringTag",
 	"StructFieldInt",
 	"StructFieldOmitEmptyInt",
-	"StructFieldStringTagInt",
 	"StructEndInt",
 	"StructEndOmitEmptyInt",
-	"StructEndStringTagInt",
 	"StructFieldUint",
 	"StructFieldOmitEmptyUint",
-	"StructFieldStringTagUint",
 	"StructEndUint",
 	"StructEndOmitEmptyUint",
-	"StructEndStringTagUint",
 	"StructFieldFloat32",
 	"StructFieldOmitEmptyFloat32",
-	"StructFieldStringTagFloat32",
 	"StructEndFloat32",
 	"StructEndOmitEmptyFloat32",
-	"StructEndStringTagFloat32",
 	"StructFieldFloat64",
 	"StructFieldOmitEmptyFloat64",
-	"StructFieldStringTagFloat64",
 	"StructEndFloat64",
 	"StructEndOmitEmptyFloat64",
-	"StructEndStringTagFloat64",
 	"StructFieldBool",
 	"StructFieldOmitEmptyBool",
-	"StructFieldStringTagBool",
 	"StructEndBool",
 	"StructEndOmitEmptyBool",
-	"StructEndStringTagBool",
 	"StructFieldString",
 	"StructFieldOmitEmptyString",
-	"StructFieldStringTagString",
 	"StructEndString",
 	"StructEndOmitEmptyString",
-	"StructEndStringTagString",
 	"StructFieldBytes",
 	"StructFieldOmitEmptyBytes",
-	"StructFieldStringTagBytes",
 	"StructEndBytes",
 	"StructEndOmitEmptyBytes",
-	"StructEndStringTagBytes",
 	"StructFieldNumber",
 	"StructFieldOmitEmptyNumber",
-	"StructFieldStringTagNumber",
 	"StructEndNumber",
 	"StructEndOmitEmptyNumber",
-	"StructEndStringTagNumber",
 	"StructFieldArray",
 	"StructFieldOmitEmptyArray",
-	"StructFieldStringTagArray",
 	"StructEndArray",
 	"StructEndOmitEmptyArray",
-	"StructEndStringTagArray",
 	"StructFieldMap",
 	"StructFieldOmitEmptyMap",
-	"StructFieldStringTagMap",
 	"StructEndMap",
 	"StructEndOmitEmptyMap",
-	"StructEndStringTagMap",
 	"StructFieldSlice",
 	"StructFieldOmitEmptySlice",
-	"StructFieldStringTagSlice",
 	"StructEndSlice",
 	"StructEndOmitEmptySlice",
-	"StructEndStringTagSlice",
 	"StructFieldStruct",
 	"StructFieldOmitEmptyStruct",
-	"StructFieldStringTagStruct",
 	"StructEndStruct",
 	"StructEndOmitEmptyStruct",
-	"StructEndStringTagStruct",
 	"StructFieldMarshalJSON",
 	"StructFieldOmitEmptyMarshalJSON",
-	"StructFieldStringTagMarshalJSON",
 	"StructEndMarshalJSON",
 	"StructEndOmitEmptyMarshalJSON",
-	"StructEndStringTagMarshalJSON",
 	"StructFieldMarshalText",
 	"StructFieldOmitEmptyMarshalText",
-	"StructFieldStringTagMarshalText",
 	"StructEndMarshalText",
 	"StructEndOmitEmptyMarshalText",
-	"StructEndStringTagMarshalText",
 	"StructFieldIntString",
 	"StructFieldOmitEmptyIntString",
-	"StructFieldStringTagIntString",
 	"StructEndIntString",
 	"StructEndOmitEmptyIntString",
-	"StructEndStringTagIntString",
 	"StructFieldUintString",
 	"StructFieldOmitEmptyUintString",
-	"StructFieldStringTagUintString",
 	"StructEndUintString",
 	"StructEndOmitEmptyUintString",
-	"StructEndStringTagUintString",
+	"StructFieldFloat32String",
+	"StructFieldOmitEmptyFloat32String",
+	"StructEndFloat32String",
+	"StructEndOmitEmptyFloat32String",
+	"StructFieldFloat64String",
+	"StructFieldOmitEmptyFloat64String",
+	"StructEndFloat64String",
+	"StructEndOmitEmptyFloat64String",
+	"StructFieldBoolString",
+	"StructFieldOmitEmptyBoolString",
+	"StructEndBoolString",
+	"StructEndOmitEmptyBoolString",
+	"StructFieldStringString",
+	"StructFieldOmitEmptyStringString",
+	"StructEndStringString",
+	"StructEndOmitEmptyStringString",
+	"StructFieldNumberString",
+	"StructFieldOmitEmptyNumberString",
+	"StructEndNumberString",
+	"StructEndOmitEmptyNumberString",
 	"StructFieldIntPtr",
 	"StructFieldOmitEmptyIntPtr",
-	"StructFieldStringTagIntPtr",
 	"StructEndIntPtr",
 	"StructEndOmitEmptyIntPtr",
-	"StructEndStringTagIntPtr",
 	"StructFieldUintPtr",
 	"StructFieldOmitEmptyUintPtr",
-	"StructFieldStringTagUintPtr",
 	"StructEndUintPtr",
 	"StructEndOmitEmptyUintPtr",
-	"StructEndStringTagUintPtr",
 	"StructFieldFloat32Ptr",
 	"StructFieldOmitEmptyFloat32Ptr",
-	"StructFieldStringTagFloat32Ptr",
 	"StructEndFloat32Ptr",
 	"StructEndOmitEmptyFloat32Ptr",
-	"StructEndStringTagFloat32Ptr",
 	"StructFieldFloat64Ptr",
 	"StructFieldOmitEmptyFloat64Ptr",
-	"StructFieldStringTagFloat64Ptr",
 	"StructEndFloat64Ptr",
 	"StructEndOmitEmptyFloat64Ptr",
-	"StructEndStringTagFloat64Ptr",
 	"StructFieldBoolPtr",
 	"StructFieldOmitEmptyBoolPtr",
-	"StructFieldStringTagBoolPtr",
 	"StructEndBoolPtr",
 	"StructEndOmitEmptyBoolPtr",
-	"StructEndStringTagBoolPtr",
 	"StructFieldStringPtr",
 	"StructFieldOmitEmptyStringPtr",
-	"StructFieldStringTagStringPtr",
 	"StructEndStringPtr",
 	"StructEndOmitEmptyStringPtr",
-	"StructEndStringTagStringPtr",
 	"StructFieldBytesPtr",
 	"StructFieldOmitEmptyBytesPtr",
-	"StructFieldStringTagBytesPtr",
 	"StructEndBytesPtr",
 	"StructEndOmitEmptyBytesPtr",
-	"StructEndStringTagBytesPtr",
 	"StructFieldNumberPtr",
 	"StructFieldOmitEmptyNumberPtr",
-	"StructFieldStringTagNumberPtr",
 	"StructEndNumberPtr",
 	"StructEndOmitEmptyNumberPtr",
-	"StructEndStringTagNumberPtr",
 	"StructFieldArrayPtr",
 	"StructFieldOmitEmptyArrayPtr",
-	"StructFieldStringTagArrayPtr",
 	"StructEndArrayPtr",
 	"StructEndOmitEmptyArrayPtr",
-	"StructEndStringTagArrayPtr",
 	"StructFieldMapPtr",
 	"StructFieldOmitEmptyMapPtr",
-	"StructFieldStringTagMapPtr",
 	"StructEndMapPtr",
 	"StructEndOmitEmptyMapPtr",
-	"StructEndStringTagMapPtr",
 	"StructFieldSlicePtr",
 	"StructFieldOmitEmptySlicePtr",
-	"StructFieldStringTagSlicePtr",
 	"StructEndSlicePtr",
 	"StructEndOmitEmptySlicePtr",
-	"StructEndStringTagSlicePtr",
 	"StructFieldMarshalJSONPtr",
 	"StructFieldOmitEmptyMarshalJSONPtr",
-	"StructFieldStringTagMarshalJSONPtr",
 	"StructEndMarshalJSONPtr",
 	"StructEndOmitEmptyMarshalJSONPtr",
-	"StructEndStringTagMarshalJSONPtr",
 	"StructFieldMarshalTextPtr",
 	"StructFieldOmitEmptyMarshalTextPtr",
-	"StructFieldStringTagMarshalTextPtr",
 	"StructEndMarshalTextPtr",
 	"StructEndOmitEmptyMarshalTextPtr",
-	"StructEndStringTagMarshalTextPtr",
 	"StructFieldInterfacePtr",
 	"StructFieldOmitEmptyInterfacePtr",
-	"StructFieldStringTagInterfacePtr",
 	"StructEndInterfacePtr",
 	"StructEndOmitEmptyInterfacePtr",
-	"StructEndStringTagInterfacePtr",
+	"StructFieldIntPtrString",
+	"StructFieldOmitEmptyIntPtrString",
+	"StructEndIntPtrString",
+	"StructEndOmitEmptyIntPtrString",
+	"StructFieldUintPtrString",
+	"StructFieldOmitEmptyUintPtrString",
+	"StructEndUintPtrString",
+	"StructEndOmitEmptyUintPtrString",
+	"StructFieldFloat32PtrString",
+	"StructFieldOmitEmptyFloat32PtrString",
+	"StructEndFloat32PtrString",
+	"StructEndOmitEmptyFloat32PtrString",
+	"StructFieldFloat64PtrString",
+	"StructFieldOmitEmptyFloat64PtrString",
+	"StructEndFloat64PtrString",
+	"StructEndOmitEmptyFloat64PtrString",
+	"StructFieldBoolPtrString",
+	"StructFieldOmitEmptyBoolPtrString",
+	"StructEndBoolPtrString",
+	"StructEndOmitEmptyBoolPtrString",
+	"StructFieldStringPtrString",
+	"StructFieldOmitEmptyStringPtrString",
+	"StructEndStringPtrString",
+	"StructEndOmitEmptyStringPtrString",
+	"StructFieldNumberPtrString",
+	"StructFieldOmitEmptyNumberPtrString",
+	"StructEndNumberPtrString",
+	"StructEndOmitEmptyNumberPtrString",
 	"StructField",
 	"StructFieldOmitEmpty",
-	"StructFieldStringTag",
 	"StructEnd",
 	"StructEndOmitEmpty",
-	"StructEndStringTag",
 }
 
 type OpType int
 
 const (
-	OpEnd                                  OpType = 0
-	OpInterface                            OpType = 1
-	OpPtr                                  OpType = 2
-	OpSliceElem                            OpType = 3
-	OpSliceEnd                             OpType = 4
-	OpArrayElem                            OpType = 5
-	OpArrayEnd                             OpType = 6
-	OpMapKey                               OpType = 7
-	OpMapValue                             OpType = 8
-	OpMapEnd                               OpType = 9
-	OpRecursive                            OpType = 10
-	OpRecursivePtr                         OpType = 11
-	OpRecursiveEnd                         OpType = 12
-	OpStructAnonymousEnd                   OpType = 13
-	OpInt                                  OpType = 14
-	OpUint                                 OpType = 15
-	OpFloat32                              OpType = 16
-	OpFloat64                              OpType = 17
-	OpBool                                 OpType = 18
-	OpString                               OpType = 19
-	OpBytes                                OpType = 20
-	OpNumber                               OpType = 21
-	OpArray                                OpType = 22
-	OpMap                                  OpType = 23
-	OpSlice                                OpType = 24
-	OpStruct                               OpType = 25
-	OpMarshalJSON                          OpType = 26
-	OpMarshalText                          OpType = 27
-	OpIntString                            OpType = 28
-	OpUintString                           OpType = 29
-	OpIntPtr                               OpType = 30
-	OpUintPtr                              OpType = 31
-	OpFloat32Ptr                           OpType = 32
-	OpFloat64Ptr                           OpType = 33
-	OpBoolPtr                              OpType = 34
-	OpStringPtr                            OpType = 35
-	OpBytesPtr                             OpType = 36
-	OpNumberPtr                            OpType = 37
-	OpArrayPtr                             OpType = 38
-	OpMapPtr                               OpType = 39
-	OpSlicePtr                             OpType = 40
-	OpMarshalJSONPtr                       OpType = 41
-	OpMarshalTextPtr                       OpType = 42
-	OpInterfacePtr                         OpType = 43
-	OpStructHeadInt                        OpType = 44
-	OpStructHeadOmitEmptyInt               OpType = 45
-	OpStructHeadStringTagInt               OpType = 46
-	OpStructPtrHeadInt                     OpType = 47
-	OpStructPtrHeadOmitEmptyInt            OpType = 48
-	OpStructPtrHeadStringTagInt            OpType = 49
-	OpStructHeadUint                       OpType = 50
-	OpStructHeadOmitEmptyUint              OpType = 51
-	OpStructHeadStringTagUint              OpType = 52
-	OpStructPtrHeadUint                    OpType = 53
-	OpStructPtrHeadOmitEmptyUint           OpType = 54
-	OpStructPtrHeadStringTagUint           OpType = 55
-	OpStructHeadFloat32                    OpType = 56
-	OpStructHeadOmitEmptyFloat32           OpType = 57
-	OpStructHeadStringTagFloat32           OpType = 58
-	OpStructPtrHeadFloat32                 OpType = 59
-	OpStructPtrHeadOmitEmptyFloat32        OpType = 60
-	OpStructPtrHeadStringTagFloat32        OpType = 61
-	OpStructHeadFloat64                    OpType = 62
-	OpStructHeadOmitEmptyFloat64           OpType = 63
-	OpStructHeadStringTagFloat64           OpType = 64
-	OpStructPtrHeadFloat64                 OpType = 65
-	OpStructPtrHeadOmitEmptyFloat64        OpType = 66
-	OpStructPtrHeadStringTagFloat64        OpType = 67
-	OpStructHeadBool                       OpType = 68
-	OpStructHeadOmitEmptyBool              OpType = 69
-	OpStructHeadStringTagBool              OpType = 70
-	OpStructPtrHeadBool                    OpType = 71
-	OpStructPtrHeadOmitEmptyBool           OpType = 72
-	OpStructPtrHeadStringTagBool           OpType = 73
-	OpStructHeadString                     OpType = 74
-	OpStructHeadOmitEmptyString            OpType = 75
-	OpStructHeadStringTagString            OpType = 76
-	OpStructPtrHeadString                  OpType = 77
-	OpStructPtrHeadOmitEmptyString         OpType = 78
-	OpStructPtrHeadStringTagString         OpType = 79
-	OpStructHeadBytes                      OpType = 80
-	OpStructHeadOmitEmptyBytes             OpType = 81
-	OpStructHeadStringTagBytes             OpType = 82
-	OpStructPtrHeadBytes                   OpType = 83
-	OpStructPtrHeadOmitEmptyBytes          OpType = 84
-	OpStructPtrHeadStringTagBytes          OpType = 85
-	OpStructHeadNumber                     OpType = 86
-	OpStructHeadOmitEmptyNumber            OpType = 87
-	OpStructHeadStringTagNumber            OpType = 88
-	OpStructPtrHeadNumber                  OpType = 89
-	OpStructPtrHeadOmitEmptyNumber         OpType = 90
-	OpStructPtrHeadStringTagNumber         OpType = 91
-	OpStructHeadArray                      OpType = 92
-	OpStructHeadOmitEmptyArray             OpType = 93
-	OpStructHeadStringTagArray             OpType = 94
-	OpStructPtrHeadArray                   OpType = 95
-	OpStructPtrHeadOmitEmptyArray          OpType = 96
-	OpStructPtrHeadStringTagArray          OpType = 97
-	OpStructHeadMap                        OpType = 98
-	OpStructHeadOmitEmptyMap               OpType = 99
-	OpStructHeadStringTagMap               OpType = 100
-	OpStructPtrHeadMap                     OpType = 101
-	OpStructPtrHeadOmitEmptyMap            OpType = 102
-	OpStructPtrHeadStringTagMap            OpType = 103
-	OpStructHeadSlice                      OpType = 104
-	OpStructHeadOmitEmptySlice             OpType = 105
-	OpStructHeadStringTagSlice             OpType = 106
-	OpStructPtrHeadSlice                   OpType = 107
-	OpStructPtrHeadOmitEmptySlice          OpType = 108
-	OpStructPtrHeadStringTagSlice          OpType = 109
-	OpStructHeadStruct                     OpType = 110
-	OpStructHeadOmitEmptyStruct            OpType = 111
-	OpStructHeadStringTagStruct            OpType = 112
-	OpStructPtrHeadStruct                  OpType = 113
-	OpStructPtrHeadOmitEmptyStruct         OpType = 114
-	OpStructPtrHeadStringTagStruct         OpType = 115
-	OpStructHeadMarshalJSON                OpType = 116
-	OpStructHeadOmitEmptyMarshalJSON       OpType = 117
-	OpStructHeadStringTagMarshalJSON       OpType = 118
-	OpStructPtrHeadMarshalJSON             OpType = 119
-	OpStructPtrHeadOmitEmptyMarshalJSON    OpType = 120
-	OpStructPtrHeadStringTagMarshalJSON    OpType = 121
-	OpStructHeadMarshalText                OpType = 122
-	OpStructHeadOmitEmptyMarshalText       OpType = 123
-	OpStructHeadStringTagMarshalText       OpType = 124
-	OpStructPtrHeadMarshalText             OpType = 125
-	OpStructPtrHeadOmitEmptyMarshalText    OpType = 126
-	OpStructPtrHeadStringTagMarshalText    OpType = 127
-	OpStructHeadIntString                  OpType = 128
-	OpStructHeadOmitEmptyIntString         OpType = 129
-	OpStructHeadStringTagIntString         OpType = 130
-	OpStructPtrHeadIntString               OpType = 131
-	OpStructPtrHeadOmitEmptyIntString      OpType = 132
-	OpStructPtrHeadStringTagIntString      OpType = 133
-	OpStructHeadUintString                 OpType = 134
-	OpStructHeadOmitEmptyUintString        OpType = 135
-	OpStructHeadStringTagUintString        OpType = 136
-	OpStructPtrHeadUintString              OpType = 137
-	OpStructPtrHeadOmitEmptyUintString     OpType = 138
-	OpStructPtrHeadStringTagUintString     OpType = 139
-	OpStructHeadIntPtr                     OpType = 140
-	OpStructHeadOmitEmptyIntPtr            OpType = 141
-	OpStructHeadStringTagIntPtr            OpType = 142
-	OpStructPtrHeadIntPtr                  OpType = 143
-	OpStructPtrHeadOmitEmptyIntPtr         OpType = 144
-	OpStructPtrHeadStringTagIntPtr         OpType = 145
-	OpStructHeadUintPtr                    OpType = 146
-	OpStructHeadOmitEmptyUintPtr           OpType = 147
-	OpStructHeadStringTagUintPtr           OpType = 148
-	OpStructPtrHeadUintPtr                 OpType = 149
-	OpStructPtrHeadOmitEmptyUintPtr        OpType = 150
-	OpStructPtrHeadStringTagUintPtr        OpType = 151
-	OpStructHeadFloat32Ptr                 OpType = 152
-	OpStructHeadOmitEmptyFloat32Ptr        OpType = 153
-	OpStructHeadStringTagFloat32Ptr        OpType = 154
-	OpStructPtrHeadFloat32Ptr              OpType = 155
-	OpStructPtrHeadOmitEmptyFloat32Ptr     OpType = 156
-	OpStructPtrHeadStringTagFloat32Ptr     OpType = 157
-	OpStructHeadFloat64Ptr                 OpType = 158
-	OpStructHeadOmitEmptyFloat64Ptr        OpType = 159
-	OpStructHeadStringTagFloat64Ptr        OpType = 160
-	OpStructPtrHeadFloat64Ptr              OpType = 161
-	OpStructPtrHeadOmitEmptyFloat64Ptr     OpType = 162
-	OpStructPtrHeadStringTagFloat64Ptr     OpType = 163
-	OpStructHeadBoolPtr                    OpType = 164
-	OpStructHeadOmitEmptyBoolPtr           OpType = 165
-	OpStructHeadStringTagBoolPtr           OpType = 166
-	OpStructPtrHeadBoolPtr                 OpType = 167
-	OpStructPtrHeadOmitEmptyBoolPtr        OpType = 168
-	OpStructPtrHeadStringTagBoolPtr        OpType = 169
-	OpStructHeadStringPtr                  OpType = 170
-	OpStructHeadOmitEmptyStringPtr         OpType = 171
-	OpStructHeadStringTagStringPtr         OpType = 172
-	OpStructPtrHeadStringPtr               OpType = 173
-	OpStructPtrHeadOmitEmptyStringPtr      OpType = 174
-	OpStructPtrHeadStringTagStringPtr      OpType = 175
-	OpStructHeadBytesPtr                   OpType = 176
-	OpStructHeadOmitEmptyBytesPtr          OpType = 177
-	OpStructHeadStringTagBytesPtr          OpType = 178
-	OpStructPtrHeadBytesPtr                OpType = 179
-	OpStructPtrHeadOmitEmptyBytesPtr       OpType = 180
-	OpStructPtrHeadStringTagBytesPtr       OpType = 181
-	OpStructHeadNumberPtr                  OpType = 182
-	OpStructHeadOmitEmptyNumberPtr         OpType = 183
-	OpStructHeadStringTagNumberPtr         OpType = 184
-	OpStructPtrHeadNumberPtr               OpType = 185
-	OpStructPtrHeadOmitEmptyNumberPtr      OpType = 186
-	OpStructPtrHeadStringTagNumberPtr      OpType = 187
-	OpStructHeadArrayPtr                   OpType = 188
-	OpStructHeadOmitEmptyArrayPtr          OpType = 189
-	OpStructHeadStringTagArrayPtr          OpType = 190
-	OpStructPtrHeadArrayPtr                OpType = 191
-	OpStructPtrHeadOmitEmptyArrayPtr       OpType = 192
-	OpStructPtrHeadStringTagArrayPtr       OpType = 193
-	OpStructHeadMapPtr                     OpType = 194
-	OpStructHeadOmitEmptyMapPtr            OpType = 195
-	OpStructHeadStringTagMapPtr            OpType = 196
-	OpStructPtrHeadMapPtr                  OpType = 197
-	OpStructPtrHeadOmitEmptyMapPtr         OpType = 198
-	OpStructPtrHeadStringTagMapPtr         OpType = 199
-	OpStructHeadSlicePtr                   OpType = 200
-	OpStructHeadOmitEmptySlicePtr          OpType = 201
-	OpStructHeadStringTagSlicePtr          OpType = 202
-	OpStructPtrHeadSlicePtr                OpType = 203
-	OpStructPtrHeadOmitEmptySlicePtr       OpType = 204
-	OpStructPtrHeadStringTagSlicePtr       OpType = 205
-	OpStructHeadMarshalJSONPtr             OpType = 206
-	OpStructHeadOmitEmptyMarshalJSONPtr    OpType = 207
-	OpStructHeadStringTagMarshalJSONPtr    OpType = 208
-	OpStructPtrHeadMarshalJSONPtr          OpType = 209
-	OpStructPtrHeadOmitEmptyMarshalJSONPtr OpType = 210
-	OpStructPtrHeadStringTagMarshalJSONPtr OpType = 211
-	OpStructHeadMarshalTextPtr             OpType = 212
-	OpStructHeadOmitEmptyMarshalTextPtr    OpType = 213
-	OpStructHeadStringTagMarshalTextPtr    OpType = 214
-	OpStructPtrHeadMarshalTextPtr          OpType = 215
-	OpStructPtrHeadOmitEmptyMarshalTextPtr OpType = 216
-	OpStructPtrHeadStringTagMarshalTextPtr OpType = 217
-	OpStructHeadInterfacePtr               OpType = 218
-	OpStructHeadOmitEmptyInterfacePtr      OpType = 219
-	OpStructHeadStringTagInterfacePtr      OpType = 220
-	OpStructPtrHeadInterfacePtr            OpType = 221
-	OpStructPtrHeadOmitEmptyInterfacePtr   OpType = 222
-	OpStructPtrHeadStringTagInterfacePtr   OpType = 223
-	OpStructHead                           OpType = 224
-	OpStructHeadOmitEmpty                  OpType = 225
-	OpStructHeadStringTag                  OpType = 226
-	OpStructPtrHead                        OpType = 227
-	OpStructPtrHeadOmitEmpty               OpType = 228
-	OpStructPtrHeadStringTag               OpType = 229
-	OpStructFieldInt                       OpType = 230
-	OpStructFieldOmitEmptyInt              OpType = 231
-	OpStructFieldStringTagInt              OpType = 232
-	OpStructEndInt                         OpType = 233
-	OpStructEndOmitEmptyInt                OpType = 234
-	OpStructEndStringTagInt                OpType = 235
-	OpStructFieldUint                      OpType = 236
-	OpStructFieldOmitEmptyUint             OpType = 237
-	OpStructFieldStringTagUint             OpType = 238
-	OpStructEndUint                        OpType = 239
-	OpStructEndOmitEmptyUint               OpType = 240
-	OpStructEndStringTagUint               OpType = 241
-	OpStructFieldFloat32                   OpType = 242
-	OpStructFieldOmitEmptyFloat32          OpType = 243
-	OpStructFieldStringTagFloat32          OpType = 244
-	OpStructEndFloat32                     OpType = 245
-	OpStructEndOmitEmptyFloat32            OpType = 246
-	OpStructEndStringTagFloat32            OpType = 247
-	OpStructFieldFloat64                   OpType = 248
-	OpStructFieldOmitEmptyFloat64          OpType = 249
-	OpStructFieldStringTagFloat64          OpType = 250
-	OpStructEndFloat64                     OpType = 251
-	OpStructEndOmitEmptyFloat64            OpType = 252
-	OpStructEndStringTagFloat64            OpType = 253
-	OpStructFieldBool                      OpType = 254
-	OpStructFieldOmitEmptyBool             OpType = 255
-	OpStructFieldStringTagBool             OpType = 256
-	OpStructEndBool                        OpType = 257
-	OpStructEndOmitEmptyBool               OpType = 258
-	OpStructEndStringTagBool               OpType = 259
-	OpStructFieldString                    OpType = 260
-	OpStructFieldOmitEmptyString           OpType = 261
-	OpStructFieldStringTagString           OpType = 262
-	OpStructEndString                      OpType = 263
-	OpStructEndOmitEmptyString             OpType = 264
-	OpStructEndStringTagString             OpType = 265
-	OpStructFieldBytes                     OpType = 266
-	OpStructFieldOmitEmptyBytes            OpType = 267
-	OpStructFieldStringTagBytes            OpType = 268
-	OpStructEndBytes                       OpType = 269
-	OpStructEndOmitEmptyBytes              OpType = 270
-	OpStructEndStringTagBytes              OpType = 271
-	OpStructFieldNumber                    OpType = 272
-	OpStructFieldOmitEmptyNumber           OpType = 273
-	OpStructFieldStringTagNumber           OpType = 274
-	OpStructEndNumber                      OpType = 275
-	OpStructEndOmitEmptyNumber             OpType = 276
-	OpStructEndStringTagNumber             OpType = 277
-	OpStructFieldArray                     OpType = 278
-	OpStructFieldOmitEmptyArray            OpType = 279
-	OpStructFieldStringTagArray            OpType = 280
-	OpStructEndArray                       OpType = 281
-	OpStructEndOmitEmptyArray              OpType = 282
-	OpStructEndStringTagArray              OpType = 283
-	OpStructFieldMap                       OpType = 284
-	OpStructFieldOmitEmptyMap              OpType = 285
-	OpStructFieldStringTagMap              OpType = 286
-	OpStructEndMap                         OpType = 287
-	OpStructEndOmitEmptyMap                OpType = 288
-	OpStructEndStringTagMap                OpType = 289
-	OpStructFieldSlice                     OpType = 290
-	OpStructFieldOmitEmptySlice            OpType = 291
-	OpStructFieldStringTagSlice            OpType = 292
-	OpStructEndSlice                       OpType = 293
-	OpStructEndOmitEmptySlice              OpType = 294
-	OpStructEndStringTagSlice              OpType = 295
-	OpStructFieldStruct                    OpType = 296
-	OpStructFieldOmitEmptyStruct           OpType = 297
-	OpStructFieldStringTagStruct           OpType = 298
-	OpStructEndStruct                      OpType = 299
-	OpStructEndOmitEmptyStruct             OpType = 300
-	OpStructEndStringTagStruct             OpType = 301
-	OpStructFieldMarshalJSON               OpType = 302
-	OpStructFieldOmitEmptyMarshalJSON      OpType = 303
-	OpStructFieldStringTagMarshalJSON      OpType = 304
-	OpStructEndMarshalJSON                 OpType = 305
-	OpStructEndOmitEmptyMarshalJSON        OpType = 306
-	OpStructEndStringTagMarshalJSON        OpType = 307
-	OpStructFieldMarshalText               OpType = 308
-	OpStructFieldOmitEmptyMarshalText      OpType = 309
-	OpStructFieldStringTagMarshalText      OpType = 310
-	OpStructEndMarshalText                 OpType = 311
-	OpStructEndOmitEmptyMarshalText        OpType = 312
-	OpStructEndStringTagMarshalText        OpType = 313
-	OpStructFieldIntString                 OpType = 314
-	OpStructFieldOmitEmptyIntString        OpType = 315
-	OpStructFieldStringTagIntString        OpType = 316
-	OpStructEndIntString                   OpType = 317
-	OpStructEndOmitEmptyIntString          OpType = 318
-	OpStructEndStringTagIntString          OpType = 319
-	OpStructFieldUintString                OpType = 320
-	OpStructFieldOmitEmptyUintString       OpType = 321
-	OpStructFieldStringTagUintString       OpType = 322
-	OpStructEndUintString                  OpType = 323
-	OpStructEndOmitEmptyUintString         OpType = 324
-	OpStructEndStringTagUintString         OpType = 325
-	OpStructFieldIntPtr                    OpType = 326
-	OpStructFieldOmitEmptyIntPtr           OpType = 327
-	OpStructFieldStringTagIntPtr           OpType = 328
-	OpStructEndIntPtr                      OpType = 329
-	OpStructEndOmitEmptyIntPtr             OpType = 330
-	OpStructEndStringTagIntPtr             OpType = 331
-	OpStructFieldUintPtr                   OpType = 332
-	OpStructFieldOmitEmptyUintPtr          OpType = 333
-	OpStructFieldStringTagUintPtr          OpType = 334
-	OpStructEndUintPtr                     OpType = 335
-	OpStructEndOmitEmptyUintPtr            OpType = 336
-	OpStructEndStringTagUintPtr            OpType = 337
-	OpStructFieldFloat32Ptr                OpType = 338
-	OpStructFieldOmitEmptyFloat32Ptr       OpType = 339
-	OpStructFieldStringTagFloat32Ptr       OpType = 340
-	OpStructEndFloat32Ptr                  OpType = 341
-	OpStructEndOmitEmptyFloat32Ptr         OpType = 342
-	OpStructEndStringTagFloat32Ptr         OpType = 343
-	OpStructFieldFloat64Ptr                OpType = 344
-	OpStructFieldOmitEmptyFloat64Ptr       OpType = 345
-	OpStructFieldStringTagFloat64Ptr       OpType = 346
-	OpStructEndFloat64Ptr                  OpType = 347
-	OpStructEndOmitEmptyFloat64Ptr         OpType = 348
-	OpStructEndStringTagFloat64Ptr         OpType = 349
-	OpStructFieldBoolPtr                   OpType = 350
-	OpStructFieldOmitEmptyBoolPtr          OpType = 351
-	OpStructFieldStringTagBoolPtr          OpType = 352
-	OpStructEndBoolPtr                     OpType = 353
-	OpStructEndOmitEmptyBoolPtr            OpType = 354
-	OpStructEndStringTagBoolPtr            OpType = 355
-	OpStructFieldStringPtr                 OpType = 356
-	OpStructFieldOmitEmptyStringPtr        OpType = 357
-	OpStructFieldStringTagStringPtr        OpType = 358
-	OpStructEndStringPtr                   OpType = 359
-	OpStructEndOmitEmptyStringPtr          OpType = 360
-	OpStructEndStringTagStringPtr          OpType = 361
-	OpStructFieldBytesPtr                  OpType = 362
-	OpStructFieldOmitEmptyBytesPtr         OpType = 363
-	OpStructFieldStringTagBytesPtr         OpType = 364
-	OpStructEndBytesPtr                    OpType = 365
-	OpStructEndOmitEmptyBytesPtr           OpType = 366
-	OpStructEndStringTagBytesPtr           OpType = 367
-	OpStructFieldNumberPtr                 OpType = 368
-	OpStructFieldOmitEmptyNumberPtr        OpType = 369
-	OpStructFieldStringTagNumberPtr        OpType = 370
-	OpStructEndNumberPtr                   OpType = 371
-	OpStructEndOmitEmptyNumberPtr          OpType = 372
-	OpStructEndStringTagNumberPtr          OpType = 373
-	OpStructFieldArrayPtr                  OpType = 374
-	OpStructFieldOmitEmptyArrayPtr         OpType = 375
-	OpStructFieldStringTagArrayPtr         OpType = 376
-	OpStructEndArrayPtr                    OpType = 377
-	OpStructEndOmitEmptyArrayPtr           OpType = 378
-	OpStructEndStringTagArrayPtr           OpType = 379
-	OpStructFieldMapPtr                    OpType = 380
-	OpStructFieldOmitEmptyMapPtr           OpType = 381
-	OpStructFieldStringTagMapPtr           OpType = 382
-	OpStructEndMapPtr                      OpType = 383
-	OpStructEndOmitEmptyMapPtr             OpType = 384
-	OpStructEndStringTagMapPtr             OpType = 385
-	OpStructFieldSlicePtr                  OpType = 386
-	OpStructFieldOmitEmptySlicePtr         OpType = 387
-	OpStructFieldStringTagSlicePtr         OpType = 388
-	OpStructEndSlicePtr                    OpType = 389
-	OpStructEndOmitEmptySlicePtr           OpType = 390
-	OpStructEndStringTagSlicePtr           OpType = 391
-	OpStructFieldMarshalJSONPtr            OpType = 392
-	OpStructFieldOmitEmptyMarshalJSONPtr   OpType = 393
-	OpStructFieldStringTagMarshalJSONPtr   OpType = 394
-	OpStructEndMarshalJSONPtr              OpType = 395
-	OpStructEndOmitEmptyMarshalJSONPtr     OpType = 396
-	OpStructEndStringTagMarshalJSONPtr     OpType = 397
-	OpStructFieldMarshalTextPtr            OpType = 398
-	OpStructFieldOmitEmptyMarshalTextPtr   OpType = 399
-	OpStructFieldStringTagMarshalTextPtr   OpType = 400
-	OpStructEndMarshalTextPtr              OpType = 401
-	OpStructEndOmitEmptyMarshalTextPtr     OpType = 402
-	OpStructEndStringTagMarshalTextPtr     OpType = 403
-	OpStructFieldInterfacePtr              OpType = 404
-	OpStructFieldOmitEmptyInterfacePtr     OpType = 405
-	OpStructFieldStringTagInterfacePtr     OpType = 406
-	OpStructEndInterfacePtr                OpType = 407
-	OpStructEndOmitEmptyInterfacePtr       OpType = 408
-	OpStructEndStringTagInterfacePtr       OpType = 409
-	OpStructField                          OpType = 410
-	OpStructFieldOmitEmpty                 OpType = 411
-	OpStructFieldStringTag                 OpType = 412
-	OpStructEnd                            OpType = 413
-	OpStructEndOmitEmpty                   OpType = 414
-	OpStructEndStringTag                   OpType = 415
+	OpEnd                                    OpType = 0
+	OpInterface                              OpType = 1
+	OpPtr                                    OpType = 2
+	OpSliceElem                              OpType = 3
+	OpSliceEnd                               OpType = 4
+	OpArrayElem                              OpType = 5
+	OpArrayEnd                               OpType = 6
+	OpMapKey                                 OpType = 7
+	OpMapValue                               OpType = 8
+	OpMapEnd                                 OpType = 9
+	OpRecursive                              OpType = 10
+	OpRecursivePtr                           OpType = 11
+	OpRecursiveEnd                           OpType = 12
+	OpStructAnonymousEnd                     OpType = 13
+	OpInt                                    OpType = 14
+	OpUint                                   OpType = 15
+	OpFloat32                                OpType = 16
+	OpFloat64                                OpType = 17
+	OpBool                                   OpType = 18
+	OpString                                 OpType = 19
+	OpBytes                                  OpType = 20
+	OpNumber                                 OpType = 21
+	OpArray                                  OpType = 22
+	OpMap                                    OpType = 23
+	OpSlice                                  OpType = 24
+	OpStruct                                 OpType = 25
+	OpMarshalJSON                            OpType = 26
+	OpMarshalText                            OpType = 27
+	OpIntString                              OpType = 28
+	OpUintString                             OpType = 29
+	OpFloat32String                          OpType = 30
+	OpFloat64String                          OpType = 31
+	OpBoolString                             OpType = 32
+	OpStringString                           OpType = 33
+	OpNumberString                           OpType = 34
+	OpIntPtr                                 OpType = 35
+	OpUintPtr                                OpType = 36
+	OpFloat32Ptr                             OpType = 37
+	OpFloat64Ptr                             OpType = 38
+	OpBoolPtr                                OpType = 39
+	OpStringPtr                              OpType = 40
+	OpBytesPtr                               OpType = 41
+	OpNumberPtr                              OpType = 42
+	OpArrayPtr                               OpType = 43
+	OpMapPtr                                 OpType = 44
+	OpSlicePtr                               OpType = 45
+	OpMarshalJSONPtr                         OpType = 46
+	OpMarshalTextPtr                         OpType = 47
+	OpInterfacePtr                           OpType = 48
+	OpIntPtrString                           OpType = 49
+	OpUintPtrString                          OpType = 50
+	OpFloat32PtrString                       OpType = 51
+	OpFloat64PtrString                       OpType = 52
+	OpBoolPtrString                          OpType = 53
+	OpStringPtrString                        OpType = 54
+	OpNumberPtrString                        OpType = 55
+	OpStructHeadInt                          OpType = 56
+	OpStructHeadOmitEmptyInt                 OpType = 57
+	OpStructPtrHeadInt                       OpType = 58
+	OpStructPtrHeadOmitEmptyInt              OpType = 59
+	OpStructHeadUint                         OpType = 60
+	OpStructHeadOmitEmptyUint                OpType = 61
+	OpStructPtrHeadUint                      OpType = 62
+	OpStructPtrHeadOmitEmptyUint             OpType = 63
+	OpStructHeadFloat32                      OpType = 64
+	OpStructHeadOmitEmptyFloat32             OpType = 65
+	OpStructPtrHeadFloat32                   OpType = 66
+	OpStructPtrHeadOmitEmptyFloat32          OpType = 67
+	OpStructHeadFloat64                      OpType = 68
+	OpStructHeadOmitEmptyFloat64             OpType = 69
+	OpStructPtrHeadFloat64                   OpType = 70
+	OpStructPtrHeadOmitEmptyFloat64          OpType = 71
+	OpStructHeadBool                         OpType = 72
+	OpStructHeadOmitEmptyBool                OpType = 73
+	OpStructPtrHeadBool                      OpType = 74
+	OpStructPtrHeadOmitEmptyBool             OpType = 75
+	OpStructHeadString                       OpType = 76
+	OpStructHeadOmitEmptyString              OpType = 77
+	OpStructPtrHeadString                    OpType = 78
+	OpStructPtrHeadOmitEmptyString           OpType = 79
+	OpStructHeadBytes                        OpType = 80
+	OpStructHeadOmitEmptyBytes               OpType = 81
+	OpStructPtrHeadBytes                     OpType = 82
+	OpStructPtrHeadOmitEmptyBytes            OpType = 83
+	OpStructHeadNumber                       OpType = 84
+	OpStructHeadOmitEmptyNumber              OpType = 85
+	OpStructPtrHeadNumber                    OpType = 86
+	OpStructPtrHeadOmitEmptyNumber           OpType = 87
+	OpStructHeadArray                        OpType = 88
+	OpStructHeadOmitEmptyArray               OpType = 89
+	OpStructPtrHeadArray                     OpType = 90
+	OpStructPtrHeadOmitEmptyArray            OpType = 91
+	OpStructHeadMap                          OpType = 92
+	OpStructHeadOmitEmptyMap                 OpType = 93
+	OpStructPtrHeadMap                       OpType = 94
+	OpStructPtrHeadOmitEmptyMap              OpType = 95
+	OpStructHeadSlice                        OpType = 96
+	OpStructHeadOmitEmptySlice               OpType = 97
+	OpStructPtrHeadSlice                     OpType = 98
+	OpStructPtrHeadOmitEmptySlice            OpType = 99
+	OpStructHeadStruct                       OpType = 100
+	OpStructHeadOmitEmptyStruct              OpType = 101
+	OpStructPtrHeadStruct                    OpType = 102
+	OpStructPtrHeadOmitEmptyStruct           OpType = 103
+	OpStructHeadMarshalJSON                  OpType = 104
+	OpStructHeadOmitEmptyMarshalJSON         OpType = 105
+	OpStructPtrHeadMarshalJSON               OpType = 106
+	OpStructPtrHeadOmitEmptyMarshalJSON      OpType = 107
+	OpStructHeadMarshalText                  OpType = 108
+	OpStructHeadOmitEmptyMarshalText         OpType = 109
+	OpStructPtrHeadMarshalText               OpType = 110
+	OpStructPtrHeadOmitEmptyMarshalText      OpType = 111
+	OpStructHeadIntString                    OpType = 112
+	OpStructHeadOmitEmptyIntString           OpType = 113
+	OpStructPtrHeadIntString                 OpType = 114
+	OpStructPtrHeadOmitEmptyIntString        OpType = 115
+	OpStructHeadUintString                   OpType = 116
+	OpStructHeadOmitEmptyUintString          OpType = 117
+	OpStructPtrHeadUintString                OpType = 118
+	OpStructPtrHeadOmitEmptyUintString       OpType = 119
+	OpStructHeadFloat32String                OpType = 120
+	OpStructHeadOmitEmptyFloat32String       OpType = 121
+	OpStructPtrHeadFloat32String             OpType = 122
+	OpStructPtrHeadOmitEmptyFloat32String    OpType = 123
+	OpStructHeadFloat64String                OpType = 124
+	OpStructHeadOmitEmptyFloat64String       OpType = 125
+	OpStructPtrHeadFloat64String             OpType = 126
+	OpStructPtrHeadOmitEmptyFloat64String    OpType = 127
+	OpStructHeadBoolString                   OpType = 128
+	OpStructHeadOmitEmptyBoolString          OpType = 129
+	OpStructPtrHeadBoolString                OpType = 130
+	OpStructPtrHeadOmitEmptyBoolString       OpType = 131
+	OpStructHeadStringString                 OpType = 132
+	OpStructHeadOmitEmptyStringString        OpType = 133
+	OpStructPtrHeadStringString              OpType = 134
+	OpStructPtrHeadOmitEmptyStringString     OpType = 135
+	OpStructHeadNumberString                 OpType = 136
+	OpStructHeadOmitEmptyNumberString        OpType = 137
+	OpStructPtrHeadNumberString              OpType = 138
+	OpStructPtrHeadOmitEmptyNumberString     OpType = 139
+	OpStructHeadIntPtr                       OpType = 140
+	OpStructHeadOmitEmptyIntPtr              OpType = 141
+	OpStructPtrHeadIntPtr                    OpType = 142
+	OpStructPtrHeadOmitEmptyIntPtr           OpType = 143
+	OpStructHeadUintPtr                      OpType = 144
+	OpStructHeadOmitEmptyUintPtr             OpType = 145
+	OpStructPtrHeadUintPtr                   OpType = 146
+	OpStructPtrHeadOmitEmptyUintPtr          OpType = 147
+	OpStructHeadFloat32Ptr                   OpType = 148
+	OpStructHeadOmitEmptyFloat32Ptr          OpType = 149
+	OpStructPtrHeadFloat32Ptr                OpType = 150
+	OpStructPtrHeadOmitEmptyFloat32Ptr       OpType = 151
+	OpStructHeadFloat64Ptr                   OpType = 152
+	OpStructHeadOmitEmptyFloat64Ptr          OpType = 153
+	OpStructPtrHeadFloat64Ptr                OpType = 154
+	OpStructPtrHeadOmitEmptyFloat64Ptr       OpType = 155
+	OpStructHeadBoolPtr                      OpType = 156
+	OpStructHeadOmitEmptyBoolPtr             OpType = 157
+	OpStructPtrHeadBoolPtr                   OpType = 158
+	OpStructPtrHeadOmitEmptyBoolPtr          OpType = 159
+	OpStructHeadStringPtr                    OpType = 160
+	OpStructHeadOmitEmptyStringPtr           OpType = 161
+	OpStructPtrHeadStringPtr                 OpType = 162
+	OpStructPtrHeadOmitEmptyStringPtr        OpType = 163
+	OpStructHeadBytesPtr                     OpType = 164
+	OpStructHeadOmitEmptyBytesPtr            OpType = 165
+	OpStructPtrHeadBytesPtr                  OpType = 166
+	OpStructPtrHeadOmitEmptyBytesPtr         OpType = 167
+	OpStructHeadNumberPtr                    OpType = 168
+	OpStructHeadOmitEmptyNumberPtr           OpType = 169
+	OpStructPtrHeadNumberPtr                 OpType = 170
+	OpStructPtrHeadOmitEmptyNumberPtr        OpType = 171
+	OpStructHeadArrayPtr                     OpType = 172
+	OpStructHeadOmitEmptyArrayPtr            OpType = 173
+	OpStructPtrHeadArrayPtr                  OpType = 174
+	OpStructPtrHeadOmitEmptyArrayPtr         OpType = 175
+	OpStructHeadMapPtr                       OpType = 176
+	OpStructHeadOmitEmptyMapPtr              OpType = 177
+	OpStructPtrHeadMapPtr                    OpType = 178
+	OpStructPtrHeadOmitEmptyMapPtr           OpType = 179
+	OpStructHeadSlicePtr                     OpType = 180
+	OpStructHeadOmitEmptySlicePtr            OpType = 181
+	OpStructPtrHeadSlicePtr                  OpType = 182
+	OpStructPtrHeadOmitEmptySlicePtr         OpType = 183
+	OpStructHeadMarshalJSONPtr               OpType = 184
+	OpStructHeadOmitEmptyMarshalJSONPtr      OpType = 185
+	OpStructPtrHeadMarshalJSONPtr            OpType = 186
+	OpStructPtrHeadOmitEmptyMarshalJSONPtr   OpType = 187
+	OpStructHeadMarshalTextPtr               OpType = 188
+	OpStructHeadOmitEmptyMarshalTextPtr      OpType = 189
+	OpStructPtrHeadMarshalTextPtr            OpType = 190
+	OpStructPtrHeadOmitEmptyMarshalTextPtr   OpType = 191
+	OpStructHeadInterfacePtr                 OpType = 192
+	OpStructHeadOmitEmptyInterfacePtr        OpType = 193
+	OpStructPtrHeadInterfacePtr              OpType = 194
+	OpStructPtrHeadOmitEmptyInterfacePtr     OpType = 195
+	OpStructHeadIntPtrString                 OpType = 196
+	OpStructHeadOmitEmptyIntPtrString        OpType = 197
+	OpStructPtrHeadIntPtrString              OpType = 198
+	OpStructPtrHeadOmitEmptyIntPtrString     OpType = 199
+	OpStructHeadUintPtrString                OpType = 200
+	OpStructHeadOmitEmptyUintPtrString       OpType = 201
+	OpStructPtrHeadUintPtrString             OpType = 202
+	OpStructPtrHeadOmitEmptyUintPtrString    OpType = 203
+	OpStructHeadFloat32PtrString             OpType = 204
+	OpStructHeadOmitEmptyFloat32PtrString    OpType = 205
+	OpStructPtrHeadFloat32PtrString          OpType = 206
+	OpStructPtrHeadOmitEmptyFloat32PtrString OpType = 207
+	OpStructHeadFloat64PtrString             OpType = 208
+	OpStructHeadOmitEmptyFloat64PtrString    OpType = 209
+	OpStructPtrHeadFloat64PtrString          OpType = 210
+	OpStructPtrHeadOmitEmptyFloat64PtrString OpType = 211
+	OpStructHeadBoolPtrString                OpType = 212
+	OpStructHeadOmitEmptyBoolPtrString       OpType = 213
+	OpStructPtrHeadBoolPtrString             OpType = 214
+	OpStructPtrHeadOmitEmptyBoolPtrString    OpType = 215
+	OpStructHeadStringPtrString              OpType = 216
+	OpStructHeadOmitEmptyStringPtrString     OpType = 217
+	OpStructPtrHeadStringPtrString           OpType = 218
+	OpStructPtrHeadOmitEmptyStringPtrString  OpType = 219
+	OpStructHeadNumberPtrString              OpType = 220
+	OpStructHeadOmitEmptyNumberPtrString     OpType = 221
+	OpStructPtrHeadNumberPtrString           OpType = 222
+	OpStructPtrHeadOmitEmptyNumberPtrString  OpType = 223
+	OpStructHead                             OpType = 224
+	OpStructHeadOmitEmpty                    OpType = 225
+	OpStructPtrHead                          OpType = 226
+	OpStructPtrHeadOmitEmpty                 OpType = 227
+	OpStructFieldInt                         OpType = 228
+	OpStructFieldOmitEmptyInt                OpType = 229
+	OpStructEndInt                           OpType = 230
+	OpStructEndOmitEmptyInt                  OpType = 231
+	OpStructFieldUint                        OpType = 232
+	OpStructFieldOmitEmptyUint               OpType = 233
+	OpStructEndUint                          OpType = 234
+	OpStructEndOmitEmptyUint                 OpType = 235
+	OpStructFieldFloat32                     OpType = 236
+	OpStructFieldOmitEmptyFloat32            OpType = 237
+	OpStructEndFloat32                       OpType = 238
+	OpStructEndOmitEmptyFloat32              OpType = 239
+	OpStructFieldFloat64                     OpType = 240
+	OpStructFieldOmitEmptyFloat64            OpType = 241
+	OpStructEndFloat64                       OpType = 242
+	OpStructEndOmitEmptyFloat64              OpType = 243
+	OpStructFieldBool                        OpType = 244
+	OpStructFieldOmitEmptyBool               OpType = 245
+	OpStructEndBool                          OpType = 246
+	OpStructEndOmitEmptyBool                 OpType = 247
+	OpStructFieldString                      OpType = 248
+	OpStructFieldOmitEmptyString             OpType = 249
+	OpStructEndString                        OpType = 250
+	OpStructEndOmitEmptyString               OpType = 251
+	OpStructFieldBytes                       OpType = 252
+	OpStructFieldOmitEmptyBytes              OpType = 253
+	OpStructEndBytes                         OpType = 254
+	OpStructEndOmitEmptyBytes                OpType = 255
+	OpStructFieldNumber                      OpType = 256
+	OpStructFieldOmitEmptyNumber             OpType = 257
+	OpStructEndNumber                        OpType = 258
+	OpStructEndOmitEmptyNumber               OpType = 259
+	OpStructFieldArray                       OpType = 260
+	OpStructFieldOmitEmptyArray              OpType = 261
+	OpStructEndArray                         OpType = 262
+	OpStructEndOmitEmptyArray                OpType = 263
+	OpStructFieldMap                         OpType = 264
+	OpStructFieldOmitEmptyMap                OpType = 265
+	OpStructEndMap                           OpType = 266
+	OpStructEndOmitEmptyMap                  OpType = 267
+	OpStructFieldSlice                       OpType = 268
+	OpStructFieldOmitEmptySlice              OpType = 269
+	OpStructEndSlice                         OpType = 270
+	OpStructEndOmitEmptySlice                OpType = 271
+	OpStructFieldStruct                      OpType = 272
+	OpStructFieldOmitEmptyStruct             OpType = 273
+	OpStructEndStruct                        OpType = 274
+	OpStructEndOmitEmptyStruct               OpType = 275
+	OpStructFieldMarshalJSON                 OpType = 276
+	OpStructFieldOmitEmptyMarshalJSON        OpType = 277
+	OpStructEndMarshalJSON                   OpType = 278
+	OpStructEndOmitEmptyMarshalJSON          OpType = 279
+	OpStructFieldMarshalText                 OpType = 280
+	OpStructFieldOmitEmptyMarshalText        OpType = 281
+	OpStructEndMarshalText                   OpType = 282
+	OpStructEndOmitEmptyMarshalText          OpType = 283
+	OpStructFieldIntString                   OpType = 284
+	OpStructFieldOmitEmptyIntString          OpType = 285
+	OpStructEndIntString                     OpType = 286
+	OpStructEndOmitEmptyIntString            OpType = 287
+	OpStructFieldUintString                  OpType = 288
+	OpStructFieldOmitEmptyUintString         OpType = 289
+	OpStructEndUintString                    OpType = 290
+	OpStructEndOmitEmptyUintString           OpType = 291
+	OpStructFieldFloat32String               OpType = 292
+	OpStructFieldOmitEmptyFloat32String      OpType = 293
+	OpStructEndFloat32String                 OpType = 294
+	OpStructEndOmitEmptyFloat32String        OpType = 295
+	OpStructFieldFloat64String               OpType = 296
+	OpStructFieldOmitEmptyFloat64String      OpType = 297
+	OpStructEndFloat64String                 OpType = 298
+	OpStructEndOmitEmptyFloat64String        OpType = 299
+	OpStructFieldBoolString                  OpType = 300
+	OpStructFieldOmitEmptyBoolString         OpType = 301
+	OpStructEndBoolString                    OpType = 302
+	OpStructEndOmitEmptyBoolString           OpType = 303
+	OpStructFieldStringString                OpType = 304
+	OpStructFieldOmitEmptyStringString       OpType = 305
+	OpStructEndStringString                  OpType = 306
+	OpStructEndOmitEmptyStringString         OpType = 307
+	OpStructFieldNumberString                OpType = 308
+	OpStructFieldOmitEmptyNumberString       OpType = 309
+	OpStructEndNumberString                  OpType = 310
+	OpStructEndOmitEmptyNumberString         OpType = 311
+	OpStructFieldIntPtr                      OpType = 312
+	OpStructFieldOmitEmptyIntPtr             OpType = 313
+	OpStructEndIntPtr                        OpType = 314
+	OpStructEndOmitEmptyIntPtr               OpType = 315
+	OpStructFieldUintPtr                     OpType = 316
+	OpStructFieldOmitEmptyUintPtr            OpType = 317
+	OpStructEndUintPtr                       OpType = 318
+	OpStructEndOmitEmptyUintPtr              OpType = 319
+	OpStructFieldFloat32Ptr                  OpType = 320
+	OpStructFieldOmitEmptyFloat32Ptr         OpType = 321
+	OpStructEndFloat32Ptr                    OpType = 322
+	OpStructEndOmitEmptyFloat32Ptr           OpType = 323
+	OpStructFieldFloat64Ptr                  OpType = 324
+	OpStructFieldOmitEmptyFloat64Ptr         OpType = 325
+	OpStructEndFloat64Ptr                    OpType = 326
+	OpStructEndOmitEmptyFloat64Ptr           OpType = 327
+	OpStructFieldBoolPtr                     OpType = 328
+	OpStructFieldOmitEmptyBoolPtr            OpType = 329
+	OpStructEndBoolPtr                       OpType = 330
+	OpStructEndOmitEmptyBoolPtr              OpType = 331
+	OpStructFieldStringPtr                   OpType = 332
+	OpStructFieldOmitEmptyStringPtr          OpType = 333
+	OpStructEndStringPtr                     OpType = 334
+	OpStructEndOmitEmptyStringPtr            OpType = 335
+	OpStructFieldBytesPtr                    OpType = 336
+	OpStructFieldOmitEmptyBytesPtr           OpType = 337
+	OpStructEndBytesPtr                      OpType = 338
+	OpStructEndOmitEmptyBytesPtr             OpType = 339
+	OpStructFieldNumberPtr                   OpType = 340
+	OpStructFieldOmitEmptyNumberPtr          OpType = 341
+	OpStructEndNumberPtr                     OpType = 342
+	OpStructEndOmitEmptyNumberPtr            OpType = 343
+	OpStructFieldArrayPtr                    OpType = 344
+	OpStructFieldOmitEmptyArrayPtr           OpType = 345
+	OpStructEndArrayPtr                      OpType = 346
+	OpStructEndOmitEmptyArrayPtr             OpType = 347
+	OpStructFieldMapPtr                      OpType = 348
+	OpStructFieldOmitEmptyMapPtr             OpType = 349
+	OpStructEndMapPtr                        OpType = 350
+	OpStructEndOmitEmptyMapPtr               OpType = 351
+	OpStructFieldSlicePtr                    OpType = 352
+	OpStructFieldOmitEmptySlicePtr           OpType = 353
+	OpStructEndSlicePtr                      OpType = 354
+	OpStructEndOmitEmptySlicePtr             OpType = 355
+	OpStructFieldMarshalJSONPtr              OpType = 356
+	OpStructFieldOmitEmptyMarshalJSONPtr     OpType = 357
+	OpStructEndMarshalJSONPtr                OpType = 358
+	OpStructEndOmitEmptyMarshalJSONPtr       OpType = 359
+	OpStructFieldMarshalTextPtr              OpType = 360
+	OpStructFieldOmitEmptyMarshalTextPtr     OpType = 361
+	OpStructEndMarshalTextPtr                OpType = 362
+	OpStructEndOmitEmptyMarshalTextPtr       OpType = 363
+	OpStructFieldInterfacePtr                OpType = 364
+	OpStructFieldOmitEmptyInterfacePtr       OpType = 365
+	OpStructEndInterfacePtr                  OpType = 366
+	OpStructEndOmitEmptyInterfacePtr         OpType = 367
+	OpStructFieldIntPtrString                OpType = 368
+	OpStructFieldOmitEmptyIntPtrString       OpType = 369
+	OpStructEndIntPtrString                  OpType = 370
+	OpStructEndOmitEmptyIntPtrString         OpType = 371
+	OpStructFieldUintPtrString               OpType = 372
+	OpStructFieldOmitEmptyUintPtrString      OpType = 373
+	OpStructEndUintPtrString                 OpType = 374
+	OpStructEndOmitEmptyUintPtrString        OpType = 375
+	OpStructFieldFloat32PtrString            OpType = 376
+	OpStructFieldOmitEmptyFloat32PtrString   OpType = 377
+	OpStructEndFloat32PtrString              OpType = 378
+	OpStructEndOmitEmptyFloat32PtrString     OpType = 379
+	OpStructFieldFloat64PtrString            OpType = 380
+	OpStructFieldOmitEmptyFloat64PtrString   OpType = 381
+	OpStructEndFloat64PtrString              OpType = 382
+	OpStructEndOmitEmptyFloat64PtrString     OpType = 383
+	OpStructFieldBoolPtrString               OpType = 384
+	OpStructFieldOmitEmptyBoolPtrString      OpType = 385
+	OpStructEndBoolPtrString                 OpType = 386
+	OpStructEndOmitEmptyBoolPtrString        OpType = 387
+	OpStructFieldStringPtrString             OpType = 388
+	OpStructFieldOmitEmptyStringPtrString    OpType = 389
+	OpStructEndStringPtrString               OpType = 390
+	OpStructEndOmitEmptyStringPtrString      OpType = 391
+	OpStructFieldNumberPtrString             OpType = 392
+	OpStructFieldOmitEmptyNumberPtrString    OpType = 393
+	OpStructEndNumberPtrString               OpType = 394
+	OpStructEndOmitEmptyNumberPtrString      OpType = 395
+	OpStructField                            OpType = 396
+	OpStructFieldOmitEmpty                   OpType = 397
+	OpStructEnd                              OpType = 398
+	OpStructEndOmitEmpty                     OpType = 399
 )
 
 func (t OpType) String() string {
-	if int(t) >= 416 {
+	if int(t) >= 400 {
 		return ""
 	}
 	return opTypeStrings[int(t)]
@@ -909,7 +877,7 @@ func (t OpType) HeadToPtrHead() OpType {
 	}
 	suffix := "PtrHead" + t.String()[idx+len("Head"):]
 
-	const toPtrOffset = 3
+	const toPtrOffset = 2
 	if strings.Contains(OpType(int(t)+toPtrOffset).String(), suffix) {
 		return OpType(int(t) + toPtrOffset)
 	}
@@ -925,14 +893,6 @@ func (t OpType) HeadToOmitEmptyHead() OpType {
 	return t
 }
 
-func (t OpType) HeadToStringTagHead() OpType {
-	const toStringTagOffset = 2
-	if strings.Contains(OpType(int(t)+toStringTagOffset).String(), "StringTag") {
-		return OpType(int(t) + toStringTagOffset)
-	}
-	return t
-}
-
 func (t OpType) PtrHeadToHead() OpType {
 	idx := strings.Index(t.String(), "Ptr")
 	if idx == -1 {
@@ -940,7 +900,7 @@ func (t OpType) PtrHeadToHead() OpType {
 	}
 	suffix := t.String()[idx+len("Ptr"):]
 
-	const toPtrOffset = 3
+	const toPtrOffset = 2
 	if strings.Contains(OpType(int(t)-toPtrOffset).String(), suffix) {
 		return OpType(int(t) - toPtrOffset)
 	}
@@ -953,10 +913,10 @@ func (t OpType) FieldToEnd() OpType {
 		return t
 	}
 	suffix := t.String()[idx+len("Field"):]
-	if suffix == "" || suffix == "OmitEmpty" || suffix == "StringTag" {
+	if suffix == "" || suffix == "OmitEmpty" {
 		return t
 	}
-	const toEndOffset = 3
+	const toEndOffset = 2
 	if strings.Contains(OpType(int(t)+toEndOffset).String(), "End"+suffix) {
 		return OpType(int(t) + toEndOffset)
 	}
@@ -967,14 +927,6 @@ func (t OpType) FieldToOmitEmptyField() OpType {
 	const toOmitEmptyOffset = 1
 	if strings.Contains(OpType(int(t)+toOmitEmptyOffset).String(), "OmitEmpty") {
 		return OpType(int(t) + toOmitEmptyOffset)
-	}
-	return t
-}
-
-func (t OpType) FieldToStringTagField() OpType {
-	const toStringTagOffset = 2
-	if strings.Contains(OpType(int(t)+toStringTagOffset).String(), "StringTag") {
-		return OpType(int(t) + toStringTagOffset)
 	}
 	return t
 }

--- a/internal/encoder/vm/util.go
+++ b/internal/encoder/vm/util.go
@@ -79,3 +79,12 @@ func appendComma(b []byte) []byte {
 func appendStructEnd(b []byte) []byte {
 	return append(b, '}', ',')
 }
+
+func appendStructEndSkipLast(b []byte) []byte {
+	last := len(b) - 1
+	if b[last] == ',' {
+		b[last] = '}'
+		return appendComma(b)
+	}
+	return appendStructEnd(b)
+}

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -2630,8 +2630,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 				code = code.Next
 			}
 		case encoder.OpStructPtrHeadNumberPtr:
@@ -2787,8 +2787,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
@@ -4039,8 +4039,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
@@ -4096,8 +4096,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
@@ -4975,8 +4975,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(bb)
+				b = append(bb, '"')
+				b = appendStructEnd(b)
 			} else {
 				b = appendStructEndSkipLast(b)
 			}
@@ -5036,8 +5036,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(bb)
+				b = append(bb, '"')
+				b = appendStructEnd(b)
 			} else {
 				b = appendStructEndSkipLast(b)
 			}

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -729,6 +729,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadIntPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -837,6 +876,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadUint:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -938,6 +1013,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadUintPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1046,6 +1160,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadFloat32:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1146,6 +1296,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToFloat32(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat32Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1253,6 +1441,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadFloat64:
 			if code.Indirect {
@@ -1365,6 +1589,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToFloat64(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat64Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1485,6 +1750,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1584,6 +1889,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToString(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadStringPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1690,6 +2031,40 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadBool:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1790,6 +2165,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			} else {
+				code = code.NextField
+			}
 		case encoder.OpStructPtrHeadBoolPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1897,6 +2310,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadBytes:
 			if code.Indirect {
@@ -2144,6 +2593,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToNumber(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadNumberPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2261,6 +2751,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
@@ -2960,6 +3489,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldIntPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -2993,6 +3534,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldUint:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3016,6 +3568,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldUintPtr:
 			b = append(b, code.Key...)
@@ -3050,6 +3614,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat32:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3072,6 +3647,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat32Ptr:
 			b = append(b, code.Key...)
@@ -3106,6 +3692,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat64:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3139,6 +3736,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat64Ptr:
 			b = append(b, code.Key...)
@@ -3187,6 +3798,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3208,6 +3834,15 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldStringPtr:
 			b = append(b, code.Key...)
@@ -3240,6 +3875,15 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldBool:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3262,6 +3906,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBoolPtr:
 			b = append(b, code.Key...)
@@ -3295,6 +3950,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBytes:
 			p := load(ctxptr, code.HeadIdx)
@@ -3363,6 +4029,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
+			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3405,6 +4085,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
 			p := load(ctxptr, code.HeadIdx)
@@ -3666,13 +4360,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntString:
@@ -3682,6 +4370,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendInt(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndIntPtr:
 			b = append(b, code.Key...)
@@ -3702,13 +4404,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntPtrString:
@@ -3723,6 +4419,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndUint:
 			p := load(ctxptr, code.HeadIdx)
@@ -3739,13 +4448,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintString:
@@ -3755,6 +4458,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndUintPtr:
 			b = append(b, code.Key...)
@@ -3775,13 +4492,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintPtrString:
@@ -3797,6 +4508,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndFloat32:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3811,13 +4535,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32String:
@@ -3827,6 +4545,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32Ptr:
 			b = append(b, code.Key...)
@@ -3847,13 +4578,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, ptrToFloat32(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32PtrString:
@@ -3868,6 +4593,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64:
 			p := load(ctxptr, code.HeadIdx)
@@ -3890,13 +4628,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64String:
@@ -3910,6 +4642,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64Ptr:
 			b = append(b, code.Key...)
@@ -3940,13 +4688,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64PtrString:
@@ -3966,6 +4708,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3980,13 +4739,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringString:
@@ -3995,6 +4748,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndStringPtr:
 			b = append(b, code.Key...)
@@ -4015,13 +4779,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, ptrToString(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringPtrString:
@@ -4035,6 +4793,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, string(appendString([]byte{}, v)))
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				v := ptrToString(p)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndBool:
 			p := load(ctxptr, code.HeadIdx)
@@ -4050,13 +4820,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolString:
@@ -4066,6 +4830,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtr:
 			b = append(b, code.Key...)
@@ -4086,13 +4863,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, ptrToBool(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtrString:
@@ -4108,6 +4879,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndBytes:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -4122,13 +4906,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBytesPtr:
@@ -4150,13 +4928,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumber:
@@ -4179,13 +4951,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(bb)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberString:
@@ -4198,6 +4964,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = append(bb, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(bb)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtr:
 			b = append(b, code.Key...)
@@ -4225,13 +5007,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(bb)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtrString:
@@ -4249,6 +5025,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(bb)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpEnd:
 			goto END

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -628,35 +628,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && (code.Indirect || code.Next.Op == encoder.OpStructEnd) {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			p += code.Offset
-			b = append(b, code.Key...)
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructPtrHeadInt:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -725,7 +696,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagInt:
+		case encoder.OpStructPtrHeadIntString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -739,7 +710,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagInt:
+		case encoder.OpStructHeadIntString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -828,7 +799,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagIntPtr:
+		case encoder.OpStructPtrHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -840,7 +811,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagIntPtr:
+		case encoder.OpStructHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -934,7 +905,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagUint:
+		case encoder.OpStructPtrHeadUintString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -948,7 +919,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagUint:
+		case encoder.OpStructHeadUintString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1037,7 +1008,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagUintPtr:
+		case encoder.OpStructPtrHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1049,7 +1020,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagUintPtr:
+		case encoder.OpStructHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1142,7 +1113,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat32:
+		case encoder.OpStructPtrHeadFloat32String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1156,7 +1127,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32:
+		case encoder.OpStructHeadFloat32String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1245,7 +1216,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat32Ptr:
+		case encoder.OpStructPtrHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1257,7 +1228,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32Ptr:
+		case encoder.OpStructHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1357,7 +1328,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat64:
+		case encoder.OpStructPtrHeadFloat64String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1371,7 +1342,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64:
+		case encoder.OpStructHeadFloat64String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1472,7 +1443,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat64Ptr:
+		case encoder.OpStructPtrHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1484,7 +1455,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64Ptr:
+		case encoder.OpStructHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1581,7 +1552,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagString:
+		case encoder.OpStructPtrHeadStringString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1595,7 +1566,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagString:
+		case encoder.OpStructHeadStringString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1683,7 +1654,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagStringPtr:
+		case encoder.OpStructPtrHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1695,7 +1666,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagStringPtr:
+		case encoder.OpStructHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1786,7 +1757,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructPtrHeadStringTagBool:
+		case encoder.OpStructPtrHeadBoolString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1800,7 +1771,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagBool:
+		case encoder.OpStructHeadBoolString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1889,7 +1860,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBoolPtr:
+		case encoder.OpStructPtrHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1901,7 +1872,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagBoolPtr:
+		case encoder.OpStructHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1994,37 +1965,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagBytes:
-			if code.Indirect {
-				p := load(ctxptr, code.Idx)
-				if p == 0 {
-					if !code.AnonymousHead {
-						b = appendNull(b)
-						b = appendComma(b)
-					}
-					code = code.End.Next
-					break
-				}
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagBytes:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadBytesPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2094,42 +2034,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			if code.Indirect {
-				p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			}
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructPtrHeadNumber:
 			if code.Indirect {
@@ -2204,7 +2108,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagNumber:
+		case encoder.OpStructPtrHeadNumberString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2218,7 +2122,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagNumber:
+		case encoder.OpStructHeadNumberString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2317,7 +2221,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagNumberPtr:
+		case encoder.OpStructPtrHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2329,7 +2233,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagNumberPtr:
+		case encoder.OpStructHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2358,8 +2262,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadStringTagArray,
-			encoder.OpStructPtrHeadSlice, encoder.OpStructPtrHeadStringTagSlice:
+		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2373,8 +2276,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadArray, encoder.OpStructHeadStringTagArray,
-			encoder.OpStructHeadSlice, encoder.OpStructHeadStringTagSlice:
+		case encoder.OpStructHeadArray, encoder.OpStructHeadSlice:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2458,8 +2360,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadStringTagArrayPtr,
-			encoder.OpStructPtrHeadSlicePtr, encoder.OpStructPtrHeadStringTagSlicePtr:
+		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2471,8 +2372,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadStringTagArrayPtr,
-			encoder.OpStructHeadSlicePtr, encoder.OpStructHeadStringTagSlicePtr:
+		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2532,7 +2432,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMap, encoder.OpStructPtrHeadStringTagMap:
+		case encoder.OpStructPtrHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2544,7 +2444,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMap, encoder.OpStructHeadStringTagMap:
+		case encoder.OpStructHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2598,7 +2498,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMapPtr, encoder.OpStructPtrHeadStringTagMapPtr:
+		case encoder.OpStructPtrHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2610,7 +2510,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMapPtr, encoder.OpStructHeadStringTagMapPtr:
+		case encoder.OpStructHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2726,50 +2626,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalJSON {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalJSON(ctx, code, b, ptrToInterface(code, p), false)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2815,7 +2671,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalJSONPtr, encoder.OpStructPtrHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructPtrHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2827,7 +2683,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalJSONPtr, encoder.OpStructHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2939,50 +2795,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalText {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalText(code, b, ptrToInterface(code, p), false)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalText:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -3027,7 +2839,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalTextPtr, encoder.OpStructPtrHeadStringTagMarshalTextPtr:
+		case encoder.OpStructPtrHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -3039,7 +2851,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalTextPtr, encoder.OpStructHeadStringTagMarshalTextPtr:
+		case encoder.OpStructHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3124,12 +2936,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldStringTag:
-			p := load(ctxptr, code.HeadIdx)
-			p += code.Offset
-			b = append(b, code.Key...)
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructFieldInt:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3146,7 +2952,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagInt:
+		case encoder.OpStructFieldIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3174,7 +2980,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagIntPtr:
+		case encoder.OpStructFieldIntPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3203,7 +3009,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUint:
+		case encoder.OpStructFieldUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3231,7 +3037,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUintPtr:
+		case encoder.OpStructFieldUintPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3259,7 +3065,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32:
+		case encoder.OpStructFieldFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3287,7 +3093,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32Ptr:
+		case encoder.OpStructFieldFloat32PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3322,7 +3128,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64:
+		case encoder.OpStructFieldFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -3364,7 +3170,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64Ptr:
+		case encoder.OpStructFieldFloat64PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3396,7 +3202,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagString:
+		case encoder.OpStructFieldStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			s := ptrToString(p + code.Offset)
@@ -3423,7 +3229,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagStringPtr:
+		case encoder.OpStructFieldStringPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3449,7 +3255,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBool:
+		case encoder.OpStructFieldBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3477,7 +3283,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBoolPtr:
+		case encoder.OpStructFieldBoolPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3505,13 +3311,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			v := ptrToBytes(p + code.Offset)
-			b = append(b, code.Key...)
-			b = appendByteSlice(b, v)
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructFieldBytesPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3531,17 +3330,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructFieldStringTagBytesPtr:
-			b = append(b, code.Key...)
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructFieldNumber:
 			p := load(ctxptr, code.HeadIdx)
@@ -3564,7 +3352,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumber:
+		case encoder.OpStructFieldNumberString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3602,7 +3390,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumberPtr:
+		case encoder.OpStructFieldNumberPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3618,7 +3406,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSON, encoder.OpStructFieldStringTagMarshalJSON:
+		case encoder.OpStructFieldMarshalJSON:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p += code.Offset
@@ -3658,7 +3446,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSONPtr, encoder.OpStructFieldStringTagMarshalJSONPtr:
+		case encoder.OpStructFieldMarshalJSONPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3685,7 +3473,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldMarshalText, encoder.OpStructFieldStringTagMarshalText:
+		case encoder.OpStructFieldMarshalText:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p += code.Offset
@@ -3720,7 +3508,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalTextPtr, encoder.OpStructFieldStringTagMarshalTextPtr:
+		case encoder.OpStructFieldMarshalTextPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3747,7 +3535,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldArray, encoder.OpStructFieldStringTagArray:
+		case encoder.OpStructFieldArray:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
@@ -3759,7 +3547,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, code.Key...)
 			code = code.Next
 			store(ctxptr, code.Idx, p)
-		case encoder.OpStructFieldArrayPtr, encoder.OpStructFieldStringTagArrayPtr:
+		case encoder.OpStructFieldArrayPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3775,7 +3563,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldSlice, encoder.OpStructFieldStringTagSlice:
+		case encoder.OpStructFieldSlice:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
@@ -3792,7 +3580,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldSlicePtr, encoder.OpStructFieldStringTagSlicePtr:
+		case encoder.OpStructFieldSlicePtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3808,7 +3596,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldMap, encoder.OpStructFieldStringTagMap:
+		case encoder.OpStructFieldMap:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToPtr(p + code.Offset)
@@ -3824,7 +3612,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldMapPtr, encoder.OpStructFieldStringTagMapPtr:
+		case encoder.OpStructFieldMapPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToPtr(p + code.Offset)
@@ -3887,7 +3675,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagInt:
+		case encoder.OpStructEndIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3923,7 +3711,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagIntPtr:
+		case encoder.OpStructEndIntPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3960,7 +3748,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUint:
+		case encoder.OpStructEndUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3996,7 +3784,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUintPtr:
+		case encoder.OpStructEndUintPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4032,7 +3820,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32:
+		case encoder.OpStructEndFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4068,7 +3856,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32Ptr:
+		case encoder.OpStructEndFloat32PtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4111,7 +3899,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64:
+		case encoder.OpStructEndFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -4161,7 +3949,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64Ptr:
+		case encoder.OpStructEndFloat64PtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4201,7 +3989,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagString:
+		case encoder.OpStructEndStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			s := ptrToString(p + code.Offset)
@@ -4236,7 +4024,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagStringPtr:
+		case encoder.OpStructEndStringPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4271,7 +4059,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBool:
+		case encoder.OpStructEndBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4307,7 +4095,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBoolPtr:
+		case encoder.OpStructEndBoolPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4343,13 +4131,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			v := ptrToBytes(p + code.Offset)
-			b = append(b, code.Key...)
-			b = appendByteSlice(b, v)
-			b = appendStructEnd(b)
-			code = code.Next
 		case encoder.OpStructEndBytesPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -4377,17 +4158,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 					b = appendStructEnd(b)
 				}
 			}
-			code = code.Next
-		case encoder.OpStructEndStringTagBytesPtr:
-			b = append(b, code.Key...)
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendStructEnd(b)
 			code = code.Next
 		case encoder.OpStructEndNumber:
 			p := load(ctxptr, code.HeadIdx)
@@ -4418,7 +4188,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumber:
+		case encoder.OpStructEndNumberString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4464,7 +4234,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumberPtr:
+		case encoder.OpStructEndNumberPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)

--- a/internal/encoder/vm_debug/util.go
+++ b/internal/encoder/vm_debug/util.go
@@ -79,3 +79,12 @@ func appendComma(b []byte) []byte {
 func appendStructEnd(b []byte) []byte {
 	return append(b, '}', ',')
 }
+
+func appendStructEndSkipLast(b []byte) []byte {
+	last := len(b) - 1
+	if b[last] == ',' {
+		b[last] = '}'
+		return appendComma(b)
+	}
+	return appendStructEnd(b)
+}

--- a/internal/encoder/vm_debug/vm.go
+++ b/internal/encoder/vm_debug/vm.go
@@ -2643,8 +2643,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 				code = code.Next
 			}
 		case encoder.OpStructPtrHeadNumberPtr:
@@ -2800,8 +2800,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
@@ -4052,8 +4052,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
@@ -4109,8 +4109,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
@@ -4988,8 +4988,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(bb)
+				b = append(bb, '"')
+				b = appendStructEnd(b)
 			} else {
 				b = appendStructEndSkipLast(b)
 			}
@@ -5049,8 +5049,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(bb)
+				b = append(bb, '"')
+				b = appendStructEnd(b)
 			} else {
 				b = appendStructEndSkipLast(b)
 			}

--- a/internal/encoder/vm_debug/vm.go
+++ b/internal/encoder/vm_debug/vm.go
@@ -641,35 +641,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && (code.Indirect || code.Next.Op == encoder.OpStructEnd) {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			p += code.Offset
-			b = append(b, code.Key...)
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructPtrHeadInt:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -738,7 +709,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagInt:
+		case encoder.OpStructPtrHeadIntString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -752,7 +723,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagInt:
+		case encoder.OpStructHeadIntString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -841,7 +812,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagIntPtr:
+		case encoder.OpStructPtrHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -853,7 +824,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagIntPtr:
+		case encoder.OpStructHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -947,7 +918,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagUint:
+		case encoder.OpStructPtrHeadUintString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -961,7 +932,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagUint:
+		case encoder.OpStructHeadUintString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1050,7 +1021,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagUintPtr:
+		case encoder.OpStructPtrHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1062,7 +1033,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagUintPtr:
+		case encoder.OpStructHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1155,7 +1126,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat32:
+		case encoder.OpStructPtrHeadFloat32String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1169,7 +1140,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32:
+		case encoder.OpStructHeadFloat32String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1258,7 +1229,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat32Ptr:
+		case encoder.OpStructPtrHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1270,7 +1241,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32Ptr:
+		case encoder.OpStructHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1370,7 +1341,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat64:
+		case encoder.OpStructPtrHeadFloat64String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1384,7 +1355,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64:
+		case encoder.OpStructHeadFloat64String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1485,7 +1456,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat64Ptr:
+		case encoder.OpStructPtrHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1497,7 +1468,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64Ptr:
+		case encoder.OpStructHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1594,7 +1565,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagString:
+		case encoder.OpStructPtrHeadStringString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1608,7 +1579,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagString:
+		case encoder.OpStructHeadStringString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1696,7 +1667,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagStringPtr:
+		case encoder.OpStructPtrHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1708,7 +1679,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagStringPtr:
+		case encoder.OpStructHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1799,7 +1770,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructPtrHeadStringTagBool:
+		case encoder.OpStructPtrHeadBoolString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1813,7 +1784,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagBool:
+		case encoder.OpStructHeadBoolString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1902,7 +1873,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBoolPtr:
+		case encoder.OpStructPtrHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1914,7 +1885,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagBoolPtr:
+		case encoder.OpStructHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2007,37 +1978,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagBytes:
-			if code.Indirect {
-				p := load(ctxptr, code.Idx)
-				if p == 0 {
-					if !code.AnonymousHead {
-						b = appendNull(b)
-						b = appendComma(b)
-					}
-					code = code.End.Next
-					break
-				}
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagBytes:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadBytesPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2107,42 +2047,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			if code.Indirect {
-				p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			}
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructPtrHeadNumber:
 			if code.Indirect {
@@ -2217,7 +2121,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagNumber:
+		case encoder.OpStructPtrHeadNumberString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2231,7 +2135,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagNumber:
+		case encoder.OpStructHeadNumberString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2330,7 +2234,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagNumberPtr:
+		case encoder.OpStructPtrHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2342,7 +2246,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagNumberPtr:
+		case encoder.OpStructHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2371,8 +2275,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadStringTagArray,
-			encoder.OpStructPtrHeadSlice, encoder.OpStructPtrHeadStringTagSlice:
+		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2386,8 +2289,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadArray, encoder.OpStructHeadStringTagArray,
-			encoder.OpStructHeadSlice, encoder.OpStructHeadStringTagSlice:
+		case encoder.OpStructHeadArray, encoder.OpStructHeadSlice:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2471,8 +2373,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadStringTagArrayPtr,
-			encoder.OpStructPtrHeadSlicePtr, encoder.OpStructPtrHeadStringTagSlicePtr:
+		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2484,8 +2385,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadStringTagArrayPtr,
-			encoder.OpStructHeadSlicePtr, encoder.OpStructHeadStringTagSlicePtr:
+		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2545,7 +2445,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMap, encoder.OpStructPtrHeadStringTagMap:
+		case encoder.OpStructPtrHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2557,7 +2457,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMap, encoder.OpStructHeadStringTagMap:
+		case encoder.OpStructHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2611,7 +2511,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMapPtr, encoder.OpStructPtrHeadStringTagMapPtr:
+		case encoder.OpStructPtrHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2623,7 +2523,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMapPtr, encoder.OpStructHeadStringTagMapPtr:
+		case encoder.OpStructHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2739,50 +2639,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalJSON {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalJSON(ctx, code, b, ptrToInterface(code, p), false)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2828,7 +2684,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalJSONPtr, encoder.OpStructPtrHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructPtrHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2840,7 +2696,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalJSONPtr, encoder.OpStructHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2952,50 +2808,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.Key...)
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalText {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalText(code, b, ptrToInterface(code, p), false)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalText:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -3040,7 +2852,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalTextPtr, encoder.OpStructPtrHeadStringTagMarshalTextPtr:
+		case encoder.OpStructPtrHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -3052,7 +2864,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalTextPtr, encoder.OpStructHeadStringTagMarshalTextPtr:
+		case encoder.OpStructHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3137,12 +2949,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldStringTag:
-			p := load(ctxptr, code.HeadIdx)
-			p += code.Offset
-			b = append(b, code.Key...)
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructFieldInt:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3159,7 +2965,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagInt:
+		case encoder.OpStructFieldIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3187,7 +2993,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagIntPtr:
+		case encoder.OpStructFieldIntPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3216,7 +3022,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUint:
+		case encoder.OpStructFieldUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3244,7 +3050,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUintPtr:
+		case encoder.OpStructFieldUintPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3272,7 +3078,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32:
+		case encoder.OpStructFieldFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3300,7 +3106,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32Ptr:
+		case encoder.OpStructFieldFloat32PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3335,7 +3141,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64:
+		case encoder.OpStructFieldFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -3377,7 +3183,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64Ptr:
+		case encoder.OpStructFieldFloat64PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.Key...)
@@ -3409,7 +3215,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagString:
+		case encoder.OpStructFieldStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			s := ptrToString(p + code.Offset)
@@ -3436,7 +3242,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagStringPtr:
+		case encoder.OpStructFieldStringPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3462,7 +3268,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBool:
+		case encoder.OpStructFieldBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3490,7 +3296,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBoolPtr:
+		case encoder.OpStructFieldBoolPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3518,13 +3324,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			v := ptrToBytes(p + code.Offset)
-			b = append(b, code.Key...)
-			b = appendByteSlice(b, v)
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructFieldBytesPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3544,17 +3343,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructFieldStringTagBytesPtr:
-			b = append(b, code.Key...)
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructFieldNumber:
 			p := load(ctxptr, code.HeadIdx)
@@ -3577,7 +3365,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumber:
+		case encoder.OpStructFieldNumberString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3615,7 +3403,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumberPtr:
+		case encoder.OpStructFieldNumberPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3631,7 +3419,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSON, encoder.OpStructFieldStringTagMarshalJSON:
+		case encoder.OpStructFieldMarshalJSON:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p += code.Offset
@@ -3671,7 +3459,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSONPtr, encoder.OpStructFieldStringTagMarshalJSONPtr:
+		case encoder.OpStructFieldMarshalJSONPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3698,7 +3486,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldMarshalText, encoder.OpStructFieldStringTagMarshalText:
+		case encoder.OpStructFieldMarshalText:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p += code.Offset
@@ -3733,7 +3521,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalTextPtr, encoder.OpStructFieldStringTagMarshalTextPtr:
+		case encoder.OpStructFieldMarshalTextPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3760,7 +3548,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldArray, encoder.OpStructFieldStringTagArray:
+		case encoder.OpStructFieldArray:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
@@ -3772,7 +3560,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, code.Key...)
 			code = code.Next
 			store(ctxptr, code.Idx, p)
-		case encoder.OpStructFieldArrayPtr, encoder.OpStructFieldStringTagArrayPtr:
+		case encoder.OpStructFieldArrayPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3788,7 +3576,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldSlice, encoder.OpStructFieldStringTagSlice:
+		case encoder.OpStructFieldSlice:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
@@ -3805,7 +3593,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldSlicePtr, encoder.OpStructFieldStringTagSlicePtr:
+		case encoder.OpStructFieldSlicePtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3821,7 +3609,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldMap, encoder.OpStructFieldStringTagMap:
+		case encoder.OpStructFieldMap:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToPtr(p + code.Offset)
@@ -3837,7 +3625,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldMapPtr, encoder.OpStructFieldStringTagMapPtr:
+		case encoder.OpStructFieldMapPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToPtr(p + code.Offset)
@@ -3900,7 +3688,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagInt:
+		case encoder.OpStructEndIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -3936,7 +3724,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagIntPtr:
+		case encoder.OpStructEndIntPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3973,7 +3761,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUint:
+		case encoder.OpStructEndUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4009,7 +3797,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUintPtr:
+		case encoder.OpStructEndUintPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4045,7 +3833,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32:
+		case encoder.OpStructEndFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4081,7 +3869,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32Ptr:
+		case encoder.OpStructEndFloat32PtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4124,7 +3912,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64:
+		case encoder.OpStructEndFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -4174,7 +3962,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64Ptr:
+		case encoder.OpStructEndFloat64PtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4214,7 +4002,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagString:
+		case encoder.OpStructEndStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			s := ptrToString(p + code.Offset)
@@ -4249,7 +4037,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagStringPtr:
+		case encoder.OpStructEndStringPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4284,7 +4072,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBool:
+		case encoder.OpStructEndBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4320,7 +4108,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBoolPtr:
+		case encoder.OpStructEndBoolPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4356,13 +4144,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			v := ptrToBytes(p + code.Offset)
-			b = append(b, code.Key...)
-			b = appendByteSlice(b, v)
-			b = appendStructEnd(b)
-			code = code.Next
 		case encoder.OpStructEndBytesPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -4390,17 +4171,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 					b = appendStructEnd(b)
 				}
 			}
-			code = code.Next
-		case encoder.OpStructEndStringTagBytesPtr:
-			b = append(b, code.Key...)
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendStructEnd(b)
 			code = code.Next
 		case encoder.OpStructEndNumber:
 			p := load(ctxptr, code.HeadIdx)
@@ -4431,7 +4201,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumber:
+		case encoder.OpStructEndNumberString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
 			b = append(b, '"')
@@ -4477,7 +4247,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumberPtr:
+		case encoder.OpStructEndNumberPtrString:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)

--- a/internal/encoder/vm_debug/vm.go
+++ b/internal/encoder/vm_debug/vm.go
@@ -742,6 +742,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadIntPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -850,6 +889,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadUint:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -951,6 +1026,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadUintPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1059,6 +1173,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadFloat32:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1159,6 +1309,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToFloat32(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat32Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1266,6 +1454,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadFloat64:
 			if code.Indirect {
@@ -1378,6 +1602,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToFloat64(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat64Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1498,6 +1763,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1597,6 +1902,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToString(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadStringPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1703,6 +2044,40 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadBool:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1803,6 +2178,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			} else {
+				code = code.NextField
+			}
 		case encoder.OpStructPtrHeadBoolPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1910,6 +2323,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadBytes:
 			if code.Indirect {
@@ -2157,6 +2606,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToNumber(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadNumberPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2274,6 +2764,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
@@ -2973,6 +3502,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldIntPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3006,6 +3547,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldUint:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3029,6 +3581,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldUintPtr:
 			b = append(b, code.Key...)
@@ -3063,6 +3627,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat32:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3085,6 +3660,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat32Ptr:
 			b = append(b, code.Key...)
@@ -3119,6 +3705,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat64:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3152,6 +3749,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat64Ptr:
 			b = append(b, code.Key...)
@@ -3200,6 +3811,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3221,6 +3847,15 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldStringPtr:
 			b = append(b, code.Key...)
@@ -3253,6 +3888,15 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldBool:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3275,6 +3919,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBoolPtr:
 			b = append(b, code.Key...)
@@ -3308,6 +3963,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBytes:
 			p := load(ctxptr, code.HeadIdx)
@@ -3376,6 +4042,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
+			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
 			b = append(b, code.Key...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3418,6 +4098,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
 			p := load(ctxptr, code.HeadIdx)
@@ -3679,13 +4373,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntString:
@@ -3695,6 +4383,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendInt(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndIntPtr:
 			b = append(b, code.Key...)
@@ -3715,13 +4417,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntPtrString:
@@ -3736,6 +4432,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndUint:
 			p := load(ctxptr, code.HeadIdx)
@@ -3752,13 +4461,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintString:
@@ -3768,6 +4471,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndUintPtr:
 			b = append(b, code.Key...)
@@ -3788,13 +4505,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintPtrString:
@@ -3810,6 +4521,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndFloat32:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3824,13 +4548,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32String:
@@ -3840,6 +4558,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32Ptr:
 			b = append(b, code.Key...)
@@ -3860,13 +4591,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, ptrToFloat32(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32PtrString:
@@ -3881,6 +4606,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64:
 			p := load(ctxptr, code.HeadIdx)
@@ -3903,13 +4641,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64String:
@@ -3923,6 +4655,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64Ptr:
 			b = append(b, code.Key...)
@@ -3953,13 +4701,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64PtrString:
@@ -3979,6 +4721,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -3993,13 +4752,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringString:
@@ -4008,6 +4761,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndStringPtr:
 			b = append(b, code.Key...)
@@ -4028,13 +4792,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, ptrToString(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringPtrString:
@@ -4048,6 +4806,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, string(appendString([]byte{}, v)))
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				v := ptrToString(p)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndBool:
 			p := load(ctxptr, code.HeadIdx)
@@ -4063,13 +4833,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolString:
@@ -4079,6 +4843,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtr:
 			b = append(b, code.Key...)
@@ -4099,13 +4876,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, ptrToBool(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtrString:
@@ -4121,6 +4892,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndBytes:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.Key...)
@@ -4135,13 +4919,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBytesPtr:
@@ -4163,13 +4941,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumber:
@@ -4192,13 +4964,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(bb)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberString:
@@ -4211,6 +4977,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = append(bb, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(bb)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtr:
 			b = append(b, code.Key...)
@@ -4238,13 +5020,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(bb)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtrString:
@@ -4262,6 +5038,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.Key...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(bb)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpEnd:
 			goto END

--- a/internal/encoder/vm_escaped/util.go
+++ b/internal/encoder/vm_escaped/util.go
@@ -79,3 +79,12 @@ func appendComma(b []byte) []byte {
 func appendStructEnd(b []byte) []byte {
 	return append(b, '}', ',')
 }
+
+func appendStructEndSkipLast(b []byte) []byte {
+	last := len(b) - 1
+	if b[last] == ',' {
+		b[last] = '}'
+		return appendComma(b)
+	}
+	return appendStructEnd(b)
+}

--- a/internal/encoder/vm_escaped/vm.go
+++ b/internal/encoder/vm_escaped/vm.go
@@ -628,35 +628,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && (code.Indirect || code.Next.Op == encoder.OpStructEnd) {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			p += code.Offset
-			b = append(b, code.EscapedKey...)
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructPtrHeadInt:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -725,7 +696,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagInt:
+		case encoder.OpStructPtrHeadIntString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -739,7 +710,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagInt:
+		case encoder.OpStructHeadIntString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -828,7 +799,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagIntPtr:
+		case encoder.OpStructPtrHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -840,7 +811,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagIntPtr:
+		case encoder.OpStructHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -934,7 +905,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagUint:
+		case encoder.OpStructPtrHeadUintString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -948,7 +919,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagUint:
+		case encoder.OpStructHeadUintString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1037,7 +1008,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagUintPtr:
+		case encoder.OpStructPtrHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1049,7 +1020,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagUintPtr:
+		case encoder.OpStructHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1142,7 +1113,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat32:
+		case encoder.OpStructPtrHeadFloat32String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1156,7 +1127,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32:
+		case encoder.OpStructHeadFloat32String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1245,7 +1216,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat32Ptr:
+		case encoder.OpStructPtrHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1257,7 +1228,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32Ptr:
+		case encoder.OpStructHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1357,7 +1328,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat64:
+		case encoder.OpStructPtrHeadFloat64String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1371,7 +1342,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64:
+		case encoder.OpStructHeadFloat64String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1472,7 +1443,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat64Ptr:
+		case encoder.OpStructPtrHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1484,7 +1455,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64Ptr:
+		case encoder.OpStructHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1581,7 +1552,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagString:
+		case encoder.OpStructPtrHeadStringString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1595,7 +1566,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagString:
+		case encoder.OpStructHeadStringString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1683,7 +1654,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagStringPtr:
+		case encoder.OpStructPtrHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1695,7 +1666,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagStringPtr:
+		case encoder.OpStructHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1786,7 +1757,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructPtrHeadStringTagBool:
+		case encoder.OpStructPtrHeadBoolString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1800,7 +1771,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagBool:
+		case encoder.OpStructHeadBoolString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1889,7 +1860,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBoolPtr:
+		case encoder.OpStructPtrHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1901,7 +1872,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagBoolPtr:
+		case encoder.OpStructHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1994,37 +1965,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagBytes:
-			if code.Indirect {
-				p := load(ctxptr, code.Idx)
-				if p == 0 {
-					if !code.AnonymousHead {
-						b = appendNull(b)
-						b = appendComma(b)
-					}
-					code = code.End.Next
-					break
-				}
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagBytes:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.EscapedKey...)
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadBytesPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2094,42 +2034,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.EscapedKey...)
-			if code.Indirect {
-				p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			}
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructPtrHeadNumber:
 			if code.Indirect {
@@ -2204,7 +2108,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagNumber:
+		case encoder.OpStructPtrHeadNumberString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2218,7 +2122,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagNumber:
+		case encoder.OpStructHeadNumberString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2317,7 +2221,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagNumberPtr:
+		case encoder.OpStructPtrHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2329,7 +2233,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagNumberPtr:
+		case encoder.OpStructHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2358,8 +2262,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadStringTagArray,
-			encoder.OpStructPtrHeadSlice, encoder.OpStructPtrHeadStringTagSlice:
+		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2373,8 +2276,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadArray, encoder.OpStructHeadStringTagArray,
-			encoder.OpStructHeadSlice, encoder.OpStructHeadStringTagSlice:
+		case encoder.OpStructHeadArray, encoder.OpStructHeadSlice:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2458,8 +2360,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadStringTagArrayPtr,
-			encoder.OpStructPtrHeadSlicePtr, encoder.OpStructPtrHeadStringTagSlicePtr:
+		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2471,8 +2372,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadStringTagArrayPtr,
-			encoder.OpStructHeadSlicePtr, encoder.OpStructHeadStringTagSlicePtr:
+		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2532,7 +2432,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMap, encoder.OpStructPtrHeadStringTagMap:
+		case encoder.OpStructPtrHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2544,7 +2444,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMap, encoder.OpStructHeadStringTagMap:
+		case encoder.OpStructHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2598,7 +2498,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMapPtr, encoder.OpStructPtrHeadStringTagMapPtr:
+		case encoder.OpStructPtrHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2610,7 +2510,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMapPtr, encoder.OpStructHeadStringTagMapPtr:
+		case encoder.OpStructHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2726,50 +2626,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.EscapedKey...)
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalJSON {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalJSON(ctx, code, b, ptrToInterface(code, p), true)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2815,7 +2671,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalJSONPtr, encoder.OpStructPtrHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructPtrHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2827,7 +2683,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalJSONPtr, encoder.OpStructHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2939,50 +2795,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{')
-			}
-			b = append(b, code.EscapedKey...)
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalText {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalText(code, b, ptrToInterface(code, p), true)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalText:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -3027,7 +2839,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalTextPtr, encoder.OpStructPtrHeadStringTagMarshalTextPtr:
+		case encoder.OpStructPtrHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -3039,7 +2851,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalTextPtr, encoder.OpStructHeadStringTagMarshalTextPtr:
+		case encoder.OpStructHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3124,12 +2936,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldStringTag:
-			p := load(ctxptr, code.HeadIdx)
-			p += code.Offset
-			b = append(b, code.EscapedKey...)
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructFieldInt:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3146,7 +2952,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagInt:
+		case encoder.OpStructFieldIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3174,7 +2980,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagIntPtr:
+		case encoder.OpStructFieldIntPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.EscapedKey...)
@@ -3203,7 +3009,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUint:
+		case encoder.OpStructFieldUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3231,7 +3037,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUintPtr:
+		case encoder.OpStructFieldUintPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.EscapedKey...)
@@ -3259,7 +3065,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32:
+		case encoder.OpStructFieldFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3287,7 +3093,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32Ptr:
+		case encoder.OpStructFieldFloat32PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.EscapedKey...)
@@ -3322,7 +3128,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64:
+		case encoder.OpStructFieldFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -3364,7 +3170,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64Ptr:
+		case encoder.OpStructFieldFloat64PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = append(b, code.EscapedKey...)
@@ -3396,7 +3202,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagString:
+		case encoder.OpStructFieldStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			s := ptrToString(p + code.Offset)
@@ -3423,7 +3229,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagStringPtr:
+		case encoder.OpStructFieldStringPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3449,7 +3255,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBool:
+		case encoder.OpStructFieldBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3477,7 +3283,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBoolPtr:
+		case encoder.OpStructFieldBoolPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3505,13 +3311,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			v := ptrToBytes(p + code.Offset)
-			b = append(b, code.EscapedKey...)
-			b = appendByteSlice(b, v)
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructFieldBytesPtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3531,17 +3330,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructFieldStringTagBytesPtr:
-			b = append(b, code.EscapedKey...)
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructFieldNumber:
 			p := load(ctxptr, code.HeadIdx)
@@ -3564,7 +3352,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumber:
+		case encoder.OpStructFieldNumberString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3602,7 +3390,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumberPtr:
+		case encoder.OpStructFieldNumberPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3618,7 +3406,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSON, encoder.OpStructFieldStringTagMarshalJSON:
+		case encoder.OpStructFieldMarshalJSON:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			p += code.Offset
@@ -3658,7 +3446,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSONPtr, encoder.OpStructFieldStringTagMarshalJSONPtr:
+		case encoder.OpStructFieldMarshalJSONPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3685,7 +3473,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldMarshalText, encoder.OpStructFieldStringTagMarshalText:
+		case encoder.OpStructFieldMarshalText:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			p += code.Offset
@@ -3720,7 +3508,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalTextPtr, encoder.OpStructFieldStringTagMarshalTextPtr:
+		case encoder.OpStructFieldMarshalTextPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3747,7 +3535,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldArray, encoder.OpStructFieldStringTagArray:
+		case encoder.OpStructFieldArray:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
@@ -3759,7 +3547,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, code.EscapedKey...)
 			code = code.Next
 			store(ctxptr, code.Idx, p)
-		case encoder.OpStructFieldArrayPtr, encoder.OpStructFieldStringTagArrayPtr:
+		case encoder.OpStructFieldArrayPtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3775,7 +3563,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldSlice, encoder.OpStructFieldStringTagSlice:
+		case encoder.OpStructFieldSlice:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
@@ -3792,7 +3580,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldSlicePtr, encoder.OpStructFieldStringTagSlicePtr:
+		case encoder.OpStructFieldSlicePtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3808,7 +3596,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldMap, encoder.OpStructFieldStringTagMap:
+		case encoder.OpStructFieldMap:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToPtr(p + code.Offset)
@@ -3824,7 +3612,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldMapPtr, encoder.OpStructFieldStringTagMapPtr:
+		case encoder.OpStructFieldMapPtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToPtr(p + code.Offset)
@@ -3887,7 +3675,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagInt:
+		case encoder.OpStructEndIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3923,7 +3711,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagIntPtr:
+		case encoder.OpStructEndIntPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -3960,7 +3748,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUint:
+		case encoder.OpStructEndUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -3996,7 +3784,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUintPtr:
+		case encoder.OpStructEndUintPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4032,7 +3820,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32:
+		case encoder.OpStructEndFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -4068,7 +3856,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32Ptr:
+		case encoder.OpStructEndFloat32PtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4111,7 +3899,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64:
+		case encoder.OpStructEndFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -4161,7 +3949,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64Ptr:
+		case encoder.OpStructEndFloat64PtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4201,7 +3989,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagString:
+		case encoder.OpStructEndStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			s := ptrToString(p + code.Offset)
@@ -4236,7 +4024,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagStringPtr:
+		case encoder.OpStructEndStringPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4271,7 +4059,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBool:
+		case encoder.OpStructEndBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -4307,7 +4095,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBoolPtr:
+		case encoder.OpStructEndBoolPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
@@ -4343,13 +4131,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			v := ptrToBytes(p + code.Offset)
-			b = append(b, code.EscapedKey...)
-			b = appendByteSlice(b, v)
-			b = appendStructEnd(b)
-			code = code.Next
 		case encoder.OpStructEndBytesPtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
@@ -4377,17 +4158,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 					b = appendStructEnd(b)
 				}
 			}
-			code = code.Next
-		case encoder.OpStructEndStringTagBytesPtr:
-			b = append(b, code.EscapedKey...)
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendStructEnd(b)
 			code = code.Next
 		case encoder.OpStructEndNumber:
 			p := load(ctxptr, code.HeadIdx)
@@ -4418,7 +4188,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumber:
+		case encoder.OpStructEndNumberString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
 			b = append(b, '"')
@@ -4464,7 +4234,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumberPtr:
+		case encoder.OpStructEndNumberPtrString:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)

--- a/internal/encoder/vm_escaped/vm.go
+++ b/internal/encoder/vm_escaped/vm.go
@@ -2630,8 +2630,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 				code = code.Next
 			}
 		case encoder.OpStructPtrHeadNumberPtr:
@@ -2787,8 +2787,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
@@ -4039,8 +4039,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
@@ -4096,8 +4096,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
@@ -4975,8 +4975,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(bb)
+				b = append(bb, '"')
+				b = appendStructEnd(b)
 			} else {
 				b = appendStructEndSkipLast(b)
 			}
@@ -5036,8 +5036,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(bb)
+				b = append(bb, '"')
+				b = appendStructEnd(b)
 			} else {
 				b = appendStructEndSkipLast(b)
 			}

--- a/internal/encoder/vm_escaped/vm.go
+++ b/internal/encoder/vm_escaped/vm.go
@@ -729,6 +729,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadIntPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -837,6 +876,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadUint:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -938,6 +1013,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadUintPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1046,6 +1160,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadFloat32:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1146,6 +1296,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToFloat32(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat32Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1253,6 +1441,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadFloat64:
 			if code.Indirect {
@@ -1365,6 +1589,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToFloat64(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat64Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1485,6 +1750,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1584,6 +1889,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToString(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = append(b, code.EscapedKey...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadStringPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1690,6 +2031,40 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadBool:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1790,6 +2165,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			} else {
+				code = code.NextField
+			}
 		case encoder.OpStructPtrHeadBoolPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1897,6 +2310,42 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadBytes:
 			if code.Indirect {
@@ -2144,6 +2593,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			v := ptrToNumber(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadNumberPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2261,6 +2751,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
@@ -2960,6 +3489,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldIntPtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
@@ -2993,6 +3534,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldUint:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3016,6 +3568,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldUintPtr:
 			b = append(b, code.EscapedKey...)
@@ -3050,6 +3614,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat32:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3072,6 +3647,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat32Ptr:
 			b = append(b, code.EscapedKey...)
@@ -3106,6 +3692,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat64:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3139,6 +3736,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat64Ptr:
 			b = append(b, code.EscapedKey...)
@@ -3187,6 +3798,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3208,6 +3834,15 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = append(b, code.EscapedKey...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldStringPtr:
 			b = append(b, code.EscapedKey...)
@@ -3240,6 +3875,15 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldBool:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3262,6 +3906,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBoolPtr:
 			b = append(b, code.EscapedKey...)
@@ -3295,6 +3950,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBytes:
 			p := load(ctxptr, code.HeadIdx)
@@ -3363,6 +4029,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
+			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
 			b = append(b, code.EscapedKey...)
 			p := load(ctxptr, code.HeadIdx)
@@ -3405,6 +4085,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
 			p := load(ctxptr, code.HeadIdx)
@@ -3666,13 +4360,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntString:
@@ -3682,6 +4370,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendInt(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndIntPtr:
 			b = append(b, code.EscapedKey...)
@@ -3702,13 +4404,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntPtrString:
@@ -3723,6 +4419,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndUint:
 			p := load(ctxptr, code.HeadIdx)
@@ -3739,13 +4448,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, u64, code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintString:
@@ -3755,6 +4458,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndUintPtr:
 			b = append(b, code.EscapedKey...)
@@ -3775,13 +4492,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintPtrString:
@@ -3797,6 +4508,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndFloat32:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3811,13 +4535,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32String:
@@ -3827,6 +4545,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32Ptr:
 			b = append(b, code.EscapedKey...)
@@ -3847,13 +4578,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, ptrToFloat32(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32PtrString:
@@ -3868,6 +4593,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64:
 			p := load(ctxptr, code.HeadIdx)
@@ -3890,13 +4628,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64String:
@@ -3910,6 +4642,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64Ptr:
 			b = append(b, code.EscapedKey...)
@@ -3940,13 +4688,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64PtrString:
@@ -3966,6 +4708,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = append(b, '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndString:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -3980,13 +4739,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringString:
@@ -3995,6 +4748,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = append(b, code.EscapedKey...)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndStringPtr:
 			b = append(b, code.EscapedKey...)
@@ -4015,13 +4779,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, ptrToString(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringPtrString:
@@ -4035,6 +4793,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, string(appendString([]byte{}, v)))
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				v := ptrToString(p)
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndBool:
 			p := load(ctxptr, code.HeadIdx)
@@ -4050,13 +4820,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolString:
@@ -4066,6 +4830,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtr:
 			b = append(b, code.EscapedKey...)
@@ -4086,13 +4863,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, ptrToBool(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtrString:
@@ -4108,6 +4879,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(b)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendStructEnd(b)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
+			code = code.Next
 		case encoder.OpStructEndBytes:
 			p := load(ctxptr, code.HeadIdx)
 			b = append(b, code.EscapedKey...)
@@ -4122,13 +4906,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, v)
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndBytesPtr:
@@ -4150,13 +4928,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendStructEnd(b)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumber:
@@ -4179,13 +4951,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(bb)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberString:
@@ -4198,6 +4964,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = append(bb, '"')
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(bb)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtr:
 			b = append(b, code.EscapedKey...)
@@ -4225,13 +5007,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(bb)
 			} else {
-				last := len(b) - 1
-				if b[last] == ',' {
-					b[last] = '}'
-					b = appendComma(b)
-				} else {
-					b = appendStructEnd(b)
-				}
+				b = appendStructEndSkipLast(b)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtrString:
@@ -4249,6 +5025,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendStructEnd(b)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = append(b, code.EscapedKey...)
+				b = append(b, '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(bb)
+			} else {
+				b = appendStructEndSkipLast(b)
+			}
 			code = code.Next
 		case encoder.OpEnd:
 			goto END

--- a/internal/encoder/vm_escaped_indent/util.go
+++ b/internal/encoder/vm_escaped_indent/util.go
@@ -75,3 +75,19 @@ func appendNull(b []byte) []byte {
 func appendComma(b []byte) []byte {
 	return append(b, ',', '\n')
 }
+
+func appendStructEndSkipLast(ctx *encoder.RuntimeContext, b []byte, code *encoder.Opcode) []byte {
+	last := len(b) - 1
+	if b[last-1] == '{' {
+		b[last] = '}'
+	} else {
+		if b[last] == '\n' {
+			// to remove ',' and '\n' characters
+			b = b[:len(b)-2]
+		}
+		b = append(b, '\n')
+		b = appendIndent(ctx, b, code.Indent-1)
+		b = append(b, '}')
+	}
+	return appendComma(b)
+}

--- a/internal/encoder/vm_escaped_indent/vm.go
+++ b/internal/encoder/vm_escaped_indent/vm.go
@@ -761,6 +761,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadIntPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -875,6 +915,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadUint:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -981,6 +1058,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadUintPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1095,6 +1212,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadFloat32:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1200,6 +1354,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToFloat32(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat32Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1313,6 +1506,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadFloat64:
 			if code.Indirect {
@@ -1430,6 +1660,48 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToFloat64(p + code.Offset)
+			if math.IsInf(v, 0) || math.IsNaN(v) {
+				return nil, errUnsupportedFloat(v)
+			}
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat64Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1556,6 +1828,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1661,6 +1974,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendString(b, string(appendString([]byte{}, v)))
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToString(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadStringPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1773,6 +2124,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadBool:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1878,6 +2266,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			} else {
+				code = code.NextField
+			}
 		case encoder.OpStructPtrHeadBoolPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1991,6 +2418,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadBytes:
 			if code.Indirect {
@@ -2252,6 +2716,48 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToNumber(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadNumberPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2375,6 +2881,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
@@ -3117,6 +3663,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldIntPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3156,6 +3715,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldUint:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3184,6 +3755,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldUintPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3224,6 +3808,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat32:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3251,6 +3847,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat32Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3291,6 +3899,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat64:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3329,6 +3949,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat64Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3381,6 +4016,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3408,6 +4059,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldStringPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3446,6 +4108,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldBool:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3473,6 +4146,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBoolPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3512,6 +4197,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBytes:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3594,6 +4291,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
+			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3642,6 +4354,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3969,19 +4696,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, u64, code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntString:
@@ -3992,6 +4707,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendInt(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndIntPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4016,19 +4746,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntPtrString:
@@ -4045,6 +4763,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndUint:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4065,19 +4797,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, u64, code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintString:
@@ -4088,6 +4808,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndUintPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4112,19 +4847,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintPtrString:
@@ -4141,6 +4864,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4160,19 +4897,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32String:
@@ -4183,6 +4908,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4207,19 +4946,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, ptrToFloat32(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32PtrString:
@@ -4236,6 +4963,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4262,19 +5003,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64String:
@@ -4289,6 +5018,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4321,19 +5067,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64PtrString:
@@ -4355,6 +5089,24 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
+			code = code.Next
 		case encoder.OpStructEndString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4373,19 +5125,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringString:
@@ -4396,6 +5136,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndStringPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4420,19 +5173,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, ptrToString(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringPtrString:
@@ -4447,6 +5188,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndBool:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4466,19 +5220,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolString:
@@ -4489,6 +5231,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4513,19 +5269,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, ptrToBool(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtrString:
@@ -4542,6 +5286,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndBytes:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4561,19 +5319,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndBytesPtr:
@@ -4599,19 +5345,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumber:
@@ -4638,19 +5372,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(ctx, bb, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberString:
@@ -4665,6 +5387,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = append(bb, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(ctx, bb, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4696,19 +5435,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(ctx, bb, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtrString:
@@ -4728,6 +5455,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.EscapedKey...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(ctx, bb, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpEnd:
 			goto END

--- a/internal/encoder/vm_escaped_indent/vm.go
+++ b/internal/encoder/vm_escaped_indent/vm.go
@@ -655,37 +655,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && (code.Indirect || code.Next.Op == encoder.OpStructEnd) {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			p += code.Offset
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructPtrHeadInt:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -758,7 +727,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagInt:
+		case encoder.OpStructPtrHeadIntString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -772,7 +741,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagInt:
+		case encoder.OpStructHeadIntString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -866,7 +835,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagIntPtr:
+		case encoder.OpStructPtrHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -878,7 +847,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagIntPtr:
+		case encoder.OpStructHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -978,7 +947,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagUint:
+		case encoder.OpStructPtrHeadUintString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -992,7 +961,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagUint:
+		case encoder.OpStructHeadUintString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1086,7 +1055,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagUintPtr:
+		case encoder.OpStructPtrHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1098,7 +1067,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagUintPtr:
+		case encoder.OpStructHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1197,7 +1166,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat32:
+		case encoder.OpStructPtrHeadFloat32String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1211,7 +1180,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32:
+		case encoder.OpStructHeadFloat32String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1305,7 +1274,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat32Ptr:
+		case encoder.OpStructPtrHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1317,7 +1286,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32Ptr:
+		case encoder.OpStructHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1423,7 +1392,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat64:
+		case encoder.OpStructPtrHeadFloat64String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1437,7 +1406,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64:
+		case encoder.OpStructHeadFloat64String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1543,7 +1512,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat64Ptr:
+		case encoder.OpStructPtrHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1555,7 +1524,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64Ptr:
+		case encoder.OpStructHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1658,7 +1627,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagString:
+		case encoder.OpStructPtrHeadStringString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1672,7 +1641,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagString:
+		case encoder.OpStructHeadStringString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1766,7 +1735,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagStringPtr:
+		case encoder.OpStructPtrHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1778,7 +1747,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagStringPtr:
+		case encoder.OpStructHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1875,7 +1844,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructPtrHeadStringTagBool:
+		case encoder.OpStructPtrHeadBoolString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1889,7 +1858,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagBool:
+		case encoder.OpStructHeadBoolString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1983,7 +1952,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBoolPtr:
+		case encoder.OpStructPtrHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1995,7 +1964,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagBoolPtr:
+		case encoder.OpStructHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2094,39 +2063,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagBytes:
-			if code.Indirect {
-				p := load(ctxptr, code.Idx)
-				if p == 0 {
-					if !code.AnonymousHead {
-						b = appendNull(b)
-						b = appendComma(b)
-					}
-					code = code.End.Next
-					break
-				}
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagBytes:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadBytesPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2200,44 +2136,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			if code.Indirect {
-				p = ptrToPtr(p + code.Offset)
-			}
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructPtrHeadNumber:
 			if code.Indirect {
@@ -2316,7 +2214,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagNumber:
+		case encoder.OpStructPtrHeadNumberString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2330,7 +2228,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagNumber:
+		case encoder.OpStructHeadNumberString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2435,7 +2333,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagNumberPtr:
+		case encoder.OpStructPtrHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2447,7 +2345,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagNumberPtr:
+		case encoder.OpStructHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2478,8 +2376,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadStringTagArray,
-			encoder.OpStructPtrHeadSlice, encoder.OpStructPtrHeadStringTagSlice:
+		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2493,8 +2390,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadArray, encoder.OpStructHeadStringTagArray,
-			encoder.OpStructHeadSlice, encoder.OpStructHeadStringTagSlice:
+		case encoder.OpStructHeadArray, encoder.OpStructHeadSlice:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2584,8 +2480,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadStringTagArrayPtr,
-			encoder.OpStructPtrHeadSlicePtr, encoder.OpStructPtrHeadStringTagSlicePtr:
+		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2597,8 +2492,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadStringTagArrayPtr,
-			encoder.OpStructHeadSlicePtr, encoder.OpStructHeadStringTagSlicePtr:
+		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2662,7 +2556,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMap, encoder.OpStructPtrHeadStringTagMap:
+		case encoder.OpStructPtrHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2674,7 +2568,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMap, encoder.OpStructHeadStringTagMap:
+		case encoder.OpStructHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2732,7 +2626,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMapPtr, encoder.OpStructPtrHeadStringTagMapPtr:
+		case encoder.OpStructPtrHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2744,7 +2638,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMapPtr, encoder.OpStructHeadStringTagMapPtr:
+		case encoder.OpStructHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2866,52 +2760,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalJSON {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalJSON(ctx, code, b, ptrToInterface(code, p), code.Indent+1, true)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2959,7 +2807,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalJSONPtr, encoder.OpStructPtrHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructPtrHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2971,7 +2819,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalJSONPtr, encoder.OpStructHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3089,52 +2937,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalText {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalText(code, b, ptrToInterface(code, p), true)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalText:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -3181,7 +2983,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalTextPtr, encoder.OpStructPtrHeadStringTagMarshalTextPtr:
+		case encoder.OpStructPtrHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -3193,7 +2995,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalTextPtr, encoder.OpStructHeadStringTagMarshalTextPtr:
+		case encoder.OpStructHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3286,14 +3088,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldStringTag:
-			p := load(ctxptr, code.HeadIdx)
-			p += code.Offset
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructFieldInt:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3314,7 +3108,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagInt:
+		case encoder.OpStructFieldIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3347,7 +3141,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagIntPtr:
+		case encoder.OpStructFieldIntPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3382,7 +3176,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUint:
+		case encoder.OpStructFieldUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3415,7 +3209,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUintPtr:
+		case encoder.OpStructFieldUintPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3449,7 +3243,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32:
+		case encoder.OpStructFieldFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3482,7 +3276,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32Ptr:
+		case encoder.OpStructFieldFloat32PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3523,7 +3317,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64:
+		case encoder.OpStructFieldFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -3568,7 +3362,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64Ptr:
+		case encoder.OpStructFieldFloat64PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3606,7 +3400,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagString:
+		case encoder.OpStructFieldStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3639,7 +3433,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagStringPtr:
+		case encoder.OpStructFieldStringPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -3671,7 +3465,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBool:
+		case encoder.OpStructFieldBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3704,7 +3498,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBoolPtr:
+		case encoder.OpStructFieldBoolPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -3738,14 +3532,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructFieldBytesPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3769,19 +3555,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructFieldStringTagBytesPtr:
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructFieldNumber:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3808,7 +3581,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumber:
+		case encoder.OpStructFieldNumberString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -3852,7 +3625,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumberPtr:
+		case encoder.OpStructFieldNumberPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -3870,7 +3643,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSON, encoder.OpStructFieldStringTagMarshalJSON:
+		case encoder.OpStructFieldMarshalJSON:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -3914,7 +3687,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSONPtr, encoder.OpStructFieldStringTagMarshalJSONPtr:
+		case encoder.OpStructFieldMarshalJSONPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3945,7 +3718,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldMarshalText, encoder.OpStructFieldStringTagMarshalText:
+		case encoder.OpStructFieldMarshalText:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -3984,7 +3757,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalTextPtr, encoder.OpStructFieldStringTagMarshalTextPtr:
+		case encoder.OpStructFieldMarshalTextPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4015,7 +3788,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldArray, encoder.OpStructFieldStringTagArray:
+		case encoder.OpStructFieldArray:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4031,7 +3804,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			p += code.Offset
 			code = code.Next
 			store(ctxptr, code.Idx, p)
-		case encoder.OpStructFieldArrayPtr, encoder.OpStructFieldStringTagArrayPtr:
+		case encoder.OpStructFieldArrayPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4051,7 +3824,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldSlice, encoder.OpStructFieldStringTagSlice:
+		case encoder.OpStructFieldSlice:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4072,7 +3845,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldSlicePtr, encoder.OpStructFieldStringTagSlicePtr:
+		case encoder.OpStructFieldSlicePtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4092,7 +3865,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldMap, encoder.OpStructFieldStringTagMap:
+		case encoder.OpStructFieldMap:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4112,7 +3885,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldMapPtr, encoder.OpStructFieldStringTagMapPtr:
+		case encoder.OpStructFieldMapPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4138,7 +3911,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldStruct, encoder.OpStructFieldStringTagStruct:
+		case encoder.OpStructFieldStruct:
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
 			b = appendIndent(ctx, b, code.Indent)
@@ -4211,7 +3984,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagInt:
+		case encoder.OpStructEndIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4258,7 +4031,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagIntPtr:
+		case encoder.OpStructEndIntPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4307,7 +4080,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUint:
+		case encoder.OpStructEndUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4354,7 +4127,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUintPtr:
+		case encoder.OpStructEndUintPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4402,7 +4175,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32:
+		case encoder.OpStructEndFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4449,7 +4222,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32Ptr:
+		case encoder.OpStructEndFloat32PtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4504,7 +4277,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64:
+		case encoder.OpStructEndFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -4563,7 +4336,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64Ptr:
+		case encoder.OpStructEndFloat64PtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4615,7 +4388,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagString:
+		case encoder.OpStructEndStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4662,7 +4435,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagStringPtr:
+		case encoder.OpStructEndStringPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4708,7 +4481,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBool:
+		case encoder.OpStructEndBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4755,7 +4528,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBoolPtr:
+		case encoder.OpStructEndBoolPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4803,14 +4576,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendStructEnd(ctx, b, code.Indent-1)
-			code = code.Next
 		case encoder.OpStructEndBytesPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
@@ -4848,19 +4613,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructEndStringTagBytesPtr:
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.EscapedKey...)
-			b = append(b, ' ')
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendStructEnd(ctx, b, code.Indent-1)
 			code = code.Next
 		case encoder.OpStructEndNumber:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4901,7 +4653,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumber:
+		case encoder.OpStructEndNumberString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')
@@ -4959,7 +4711,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumberPtr:
+		case encoder.OpStructEndNumberPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.EscapedKey...)
 			b = append(b, ' ')

--- a/internal/encoder/vm_escaped_indent/vm.go
+++ b/internal/encoder/vm_escaped_indent/vm.go
@@ -2155,9 +2155,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			if p != 0 {
 				b = appendIndent(ctx, b, code.Indent+1)
 				b = append(b, code.EscapedKey...)
-				b = append(b, ' ', '"')
+				b = append(b, ' ')
 				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
-				b = append(b, '"')
 				b = appendComma(b)
 			}
 			code = code.Next

--- a/internal/encoder/vm_escaped_indent/vm.go
+++ b/internal/encoder/vm_escaped_indent/vm.go
@@ -2754,8 +2754,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 				code = code.Next
 			}
 		case encoder.OpStructPtrHeadNumberPtr:
@@ -2918,8 +2918,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
@@ -4302,8 +4302,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
@@ -4366,8 +4366,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
@@ -5399,8 +5399,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(ctx, bb, code.Indent-1)
+				b = append(bb, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
 				b = appendStructEndSkipLast(ctx, b, code)
 			}
@@ -5467,8 +5467,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(ctx, bb, code.Indent-1)
+				b = append(bb, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
 				b = appendStructEndSkipLast(ctx, b, code)
 			}

--- a/internal/encoder/vm_indent/util.go
+++ b/internal/encoder/vm_indent/util.go
@@ -75,3 +75,19 @@ func appendNull(b []byte) []byte {
 func appendComma(b []byte) []byte {
 	return append(b, ',', '\n')
 }
+
+func appendStructEndSkipLast(ctx *encoder.RuntimeContext, b []byte, code *encoder.Opcode) []byte {
+	last := len(b) - 1
+	if b[last-1] == '{' {
+		b[last] = '}'
+	} else {
+		if b[last] == '\n' {
+			// to remove ',' and '\n' characters
+			b = b[:len(b)-2]
+		}
+		b = append(b, '\n')
+		b = appendIndent(ctx, b, code.Indent-1)
+		b = append(b, '}')
+	}
+	return appendComma(b)
+}

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -655,37 +655,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTag:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && (code.Indirect || code.Next.Op == encoder.OpStructEnd) {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			p += code.Offset
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructPtrHeadInt:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -758,7 +727,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagInt:
+		case encoder.OpStructPtrHeadIntString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -772,7 +741,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagInt:
+		case encoder.OpStructHeadIntString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -866,7 +835,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagIntPtr:
+		case encoder.OpStructPtrHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -878,7 +847,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagIntPtr:
+		case encoder.OpStructHeadIntPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -978,7 +947,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagUint:
+		case encoder.OpStructPtrHeadUintString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -992,7 +961,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagUint:
+		case encoder.OpStructHeadUintString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1086,7 +1055,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagUintPtr:
+		case encoder.OpStructPtrHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1098,7 +1067,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagUintPtr:
+		case encoder.OpStructHeadUintPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1197,7 +1166,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat32:
+		case encoder.OpStructPtrHeadFloat32String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1211,7 +1180,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32:
+		case encoder.OpStructHeadFloat32String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1305,7 +1274,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat32Ptr:
+		case encoder.OpStructPtrHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1317,7 +1286,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat32Ptr:
+		case encoder.OpStructHeadFloat32PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1423,7 +1392,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagFloat64:
+		case encoder.OpStructPtrHeadFloat64String:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1437,7 +1406,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64:
+		case encoder.OpStructHeadFloat64String:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1543,7 +1512,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagFloat64Ptr:
+		case encoder.OpStructPtrHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1555,7 +1524,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagFloat64Ptr:
+		case encoder.OpStructHeadFloat64PtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1658,7 +1627,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagString:
+		case encoder.OpStructPtrHeadStringString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1672,7 +1641,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagString:
+		case encoder.OpStructHeadStringString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1766,7 +1735,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagStringPtr:
+		case encoder.OpStructPtrHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1778,7 +1747,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagStringPtr:
+		case encoder.OpStructHeadStringPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -1875,7 +1844,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructPtrHeadStringTagBool:
+		case encoder.OpStructPtrHeadBoolString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -1889,7 +1858,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagBool:
+		case encoder.OpStructHeadBoolString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1983,7 +1952,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBoolPtr:
+		case encoder.OpStructPtrHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -1995,7 +1964,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagBoolPtr:
+		case encoder.OpStructHeadBoolPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2094,39 +2063,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagBytes:
-			if code.Indirect {
-				p := load(ctxptr, code.Idx)
-				if p == 0 {
-					if !code.AnonymousHead {
-						b = appendNull(b)
-						b = appendComma(b)
-					}
-					code = code.End.Next
-					break
-				}
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagBytes:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadBytesPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2200,44 +2136,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructPtrHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			fallthrough
-		case encoder.OpStructHeadStringTagBytesPtr:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			if code.Indirect {
-				p = ptrToPtr(p + code.Offset)
-			}
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructPtrHeadNumber:
 			if code.Indirect {
@@ -2316,7 +2214,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadStringTagNumber:
+		case encoder.OpStructPtrHeadNumberString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2330,7 +2228,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadStringTagNumber:
+		case encoder.OpStructHeadNumberString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2435,7 +2333,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagNumberPtr:
+		case encoder.OpStructPtrHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2447,7 +2345,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadStringTagNumberPtr:
+		case encoder.OpStructHeadNumberPtrString:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2478,8 +2376,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadStringTagArray,
-			encoder.OpStructPtrHeadSlice, encoder.OpStructPtrHeadStringTagSlice:
+		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
 				if p == 0 {
@@ -2493,8 +2390,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			}
 			fallthrough
-		case encoder.OpStructHeadArray, encoder.OpStructHeadStringTagArray,
-			encoder.OpStructHeadSlice, encoder.OpStructHeadStringTagSlice:
+		case encoder.OpStructHeadArray, encoder.OpStructHeadSlice:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2584,8 +2480,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadStringTagArrayPtr,
-			encoder.OpStructPtrHeadSlicePtr, encoder.OpStructPtrHeadStringTagSlicePtr:
+		case encoder.OpStructPtrHeadArrayPtr, encoder.OpStructPtrHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2597,8 +2492,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadStringTagArrayPtr,
-			encoder.OpStructHeadSlicePtr, encoder.OpStructHeadStringTagSlicePtr:
+		case encoder.OpStructHeadArrayPtr, encoder.OpStructHeadSlicePtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2662,7 +2556,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMap, encoder.OpStructPtrHeadStringTagMap:
+		case encoder.OpStructPtrHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2674,7 +2568,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMap, encoder.OpStructHeadStringTagMap:
+		case encoder.OpStructHeadMap:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2732,7 +2626,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructPtrHeadMapPtr, encoder.OpStructPtrHeadStringTagMapPtr:
+		case encoder.OpStructPtrHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2744,7 +2638,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMapPtr, encoder.OpStructHeadStringTagMapPtr:
+		case encoder.OpStructHeadMapPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -2866,52 +2760,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalJSON:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalJSON {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalJSON(ctx, code, b, ptrToInterface(code, p), code.Indent+1, false)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2959,7 +2807,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalJSONPtr, encoder.OpStructPtrHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructPtrHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -2971,7 +2819,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalJSONPtr, encoder.OpStructHeadStringTagMarshalJSONPtr:
+		case encoder.OpStructHeadMarshalJSONPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3089,52 +2937,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructPtrHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if code.Indirect {
-				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
-			}
-			fallthrough
-		case encoder.OpStructHeadStringTagMarshalText:
-			p := load(ctxptr, code.Idx)
-			if p == 0 && code.Indirect {
-				if !code.AnonymousHead {
-					b = appendNull(b)
-					b = appendComma(b)
-				}
-				code = code.End.Next
-				break
-			}
-			if !code.AnonymousHead {
-				b = append(b, '{', '\n')
-			}
-			b = appendIndent(ctx, b, code.Indent+1)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			if code.IsNilableType {
-				if code.Indirect || code.Op == encoder.OpStructPtrHeadStringTagMarshalText {
-					p = ptrToPtr(p + code.Offset)
-				}
-			}
-			if p == 0 && code.Nilcheck {
-				b = appendNull(b)
-			} else {
-				bb, err := appendMarshalText(code, b, ptrToInterface(code, p), false)
-				if err != nil {
-					return nil, err
-				}
-				b = bb
-			}
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructPtrHeadOmitEmptyMarshalText:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -3181,7 +2983,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 				code = code.Next
 			}
-		case encoder.OpStructPtrHeadMarshalTextPtr, encoder.OpStructPtrHeadStringTagMarshalTextPtr:
+		case encoder.OpStructPtrHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
 				if !code.AnonymousHead {
@@ -3193,7 +2995,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
 			fallthrough
-		case encoder.OpStructHeadMarshalTextPtr, encoder.OpStructHeadStringTagMarshalTextPtr:
+		case encoder.OpStructHeadMarshalTextPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 && code.Indirect {
 				if !code.AnonymousHead {
@@ -3286,14 +3088,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldStringTag:
-			p := load(ctxptr, code.HeadIdx)
-			p += code.Offset
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			code = code.Next
-			store(ctxptr, code.Idx, p)
 		case encoder.OpStructFieldInt:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3314,7 +3108,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagInt:
+		case encoder.OpStructFieldIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3347,7 +3141,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagIntPtr:
+		case encoder.OpStructFieldIntPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3382,7 +3176,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUint:
+		case encoder.OpStructFieldUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3415,7 +3209,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagUintPtr:
+		case encoder.OpStructFieldUintPtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3449,7 +3243,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32:
+		case encoder.OpStructFieldFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3482,7 +3276,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat32Ptr:
+		case encoder.OpStructFieldFloat32PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3523,7 +3317,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64:
+		case encoder.OpStructFieldFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -3568,7 +3362,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagFloat64Ptr:
+		case encoder.OpStructFieldFloat64PtrString:
 			p := load(ctxptr, code.HeadIdx)
 			p = ptrToNPtr(p+code.Offset, code.PtrNum)
 			b = appendIndent(ctx, b, code.Indent)
@@ -3606,7 +3400,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagString:
+		case encoder.OpStructFieldStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3639,7 +3433,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagStringPtr:
+		case encoder.OpStructFieldStringPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -3671,7 +3465,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBool:
+		case encoder.OpStructFieldBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3704,7 +3498,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBoolPtr:
+		case encoder.OpStructFieldBoolPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -3738,14 +3532,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendComma(b)
-			code = code.Next
 		case encoder.OpStructFieldBytesPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3769,19 +3555,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructFieldStringTagBytesPtr:
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendComma(b)
 			code = code.Next
 		case encoder.OpStructFieldNumber:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3808,7 +3581,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumber:
+		case encoder.OpStructFieldNumberString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -3852,7 +3625,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldStringTagNumberPtr:
+		case encoder.OpStructFieldNumberPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -3870,7 +3643,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSON, encoder.OpStructFieldStringTagMarshalJSON:
+		case encoder.OpStructFieldMarshalJSON:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -3914,7 +3687,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalJSONPtr, encoder.OpStructFieldStringTagMarshalJSONPtr:
+		case encoder.OpStructFieldMarshalJSONPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3945,7 +3718,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldMarshalText, encoder.OpStructFieldStringTagMarshalText:
+		case encoder.OpStructFieldMarshalText:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3984,7 +3757,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(bb)
 			code = code.Next
-		case encoder.OpStructFieldMarshalTextPtr, encoder.OpStructFieldStringTagMarshalTextPtr:
+		case encoder.OpStructFieldMarshalTextPtr:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4015,7 +3788,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(bb)
 			}
 			code = code.Next
-		case encoder.OpStructFieldArray, encoder.OpStructFieldStringTagArray:
+		case encoder.OpStructFieldArray:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4031,7 +3804,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			p += code.Offset
 			code = code.Next
 			store(ctxptr, code.Idx, p)
-		case encoder.OpStructFieldArrayPtr, encoder.OpStructFieldStringTagArrayPtr:
+		case encoder.OpStructFieldArrayPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4051,7 +3824,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldSlice, encoder.OpStructFieldStringTagSlice:
+		case encoder.OpStructFieldSlice:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4072,7 +3845,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldSlicePtr, encoder.OpStructFieldStringTagSlicePtr:
+		case encoder.OpStructFieldSlicePtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4092,7 +3865,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldMap, encoder.OpStructFieldStringTagMap:
+		case encoder.OpStructFieldMap:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4112,7 +3885,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				code = code.Next
 				store(ctxptr, code.Idx, p)
 			}
-		case encoder.OpStructFieldMapPtr, encoder.OpStructFieldStringTagMapPtr:
+		case encoder.OpStructFieldMapPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4138,7 +3911,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			} else {
 				code = code.NextField
 			}
-		case encoder.OpStructFieldStruct, encoder.OpStructFieldStringTagStruct:
+		case encoder.OpStructFieldStruct:
 			p := load(ctxptr, code.HeadIdx)
 			p += code.Offset
 			b = appendIndent(ctx, b, code.Indent)
@@ -4211,7 +3984,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagInt:
+		case encoder.OpStructEndIntString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4258,7 +4031,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagIntPtr:
+		case encoder.OpStructEndIntPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4307,7 +4080,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUint:
+		case encoder.OpStructEndUintString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4354,7 +4127,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagUintPtr:
+		case encoder.OpStructEndUintPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4402,7 +4175,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32:
+		case encoder.OpStructEndFloat32String:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4449,7 +4222,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat32Ptr:
+		case encoder.OpStructEndFloat32PtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4504,7 +4277,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64:
+		case encoder.OpStructEndFloat64String:
 			p := load(ctxptr, code.HeadIdx)
 			v := ptrToFloat64(p + code.Offset)
 			if math.IsInf(v, 0) || math.IsNaN(v) {
@@ -4563,7 +4336,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagFloat64Ptr:
+		case encoder.OpStructEndFloat64PtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4615,7 +4388,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagString:
+		case encoder.OpStructEndStringString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4662,7 +4435,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagStringPtr:
+		case encoder.OpStructEndStringPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4708,7 +4481,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBool:
+		case encoder.OpStructEndBoolString:
 			p := load(ctxptr, code.HeadIdx)
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4755,7 +4528,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBoolPtr:
+		case encoder.OpStructEndBoolPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4803,14 +4576,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagBytes:
-			p := load(ctxptr, code.HeadIdx)
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			b = appendByteSlice(b, ptrToBytes(p+code.Offset))
-			b = appendStructEnd(ctx, b, code.Indent-1)
-			code = code.Next
 		case encoder.OpStructEndBytesPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4848,19 +4613,6 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendComma(b)
 			}
-			code = code.Next
-		case encoder.OpStructEndStringTagBytesPtr:
-			b = appendIndent(ctx, b, code.Indent)
-			b = append(b, code.Key...)
-			b = append(b, ' ')
-			p := load(ctxptr, code.HeadIdx)
-			p = ptrToNPtr(p+code.Offset, code.PtrNum)
-			if p == 0 {
-				b = appendNull(b)
-			} else {
-				b = appendByteSlice(b, ptrToBytes(p))
-			}
-			b = appendStructEnd(ctx, b, code.Indent-1)
 			code = code.Next
 		case encoder.OpStructEndNumber:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4901,7 +4653,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumber:
+		case encoder.OpStructEndNumberString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')
@@ -4959,7 +4711,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendComma(b)
 			}
 			code = code.Next
-		case encoder.OpStructEndStringTagNumberPtr:
+		case encoder.OpStructEndNumberPtrString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
 			b = append(b, ' ')

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -2155,9 +2155,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			if p != 0 {
 				b = appendIndent(ctx, b, code.Indent+1)
 				b = append(b, code.Key...)
-				b = append(b, ' ', '"')
+				b = append(b, ' ')
 				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
-				b = append(b, '"')
 				b = appendComma(b)
 			}
 			code = code.Next

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -761,6 +761,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadIntPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -875,6 +915,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyIntPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadUint:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -981,6 +1058,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadUintPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1095,6 +1212,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyUintPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadFloat32:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1200,6 +1354,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToFloat32(p + code.Offset)
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat32Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1313,6 +1506,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadFloat64:
 			if code.Indirect {
@@ -1430,6 +1660,48 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64String:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64String:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToFloat64(p + code.Offset)
+			if math.IsInf(v, 0) || math.IsNaN(v) {
+				return nil, errUnsupportedFloat(v)
+			}
+			if v == 0 {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadFloat64Ptr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1556,6 +1828,47 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadString:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1661,6 +1974,44 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendString(b, string(appendString([]byte{}, v)))
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToString(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadStringPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1773,6 +2124,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyStringPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructPtrHeadBool:
 			if code.Indirect {
 				p := load(ctxptr, code.Idx)
@@ -1878,6 +2266,45 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+				code = code.Next
+			} else {
+				code = code.NextField
+			}
 		case encoder.OpStructPtrHeadBoolPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -1991,6 +2418,43 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadBytes:
 			if code.Indirect {
@@ -2252,6 +2716,48 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberString:
+			if code.Indirect {
+				p := load(ctxptr, code.Idx)
+				if p == 0 {
+					if !code.AnonymousHead {
+						b = appendNull(b)
+						b = appendComma(b)
+					}
+					code = code.End.Next
+					break
+				}
+				store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			}
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			v := ptrToNumber(p + code.Offset)
+			if v == "" {
+				code = code.NextField
+			} else {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+				code = code.Next
+			}
 		case encoder.OpStructPtrHeadNumberPtr:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
@@ -2375,6 +2881,46 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructPtrHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			store(ctxptr, code.Idx, ptrToNPtr(p, code.PtrNum))
+			fallthrough
+		case encoder.OpStructHeadOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.Idx)
+			if p == 0 && code.Indirect {
+				if !code.AnonymousHead {
+					b = appendNull(b)
+					b = appendComma(b)
+				}
+				code = code.End.Next
+				break
+			}
+			if !code.AnonymousHead {
+				b = append(b, '{', '\n')
+			}
+			if code.Indirect {
+				p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			}
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent+1)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
 			if code.Indirect {
@@ -3117,6 +3663,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(b, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldIntPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3156,6 +3715,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldUint:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3184,6 +3755,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldUintPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3224,6 +3808,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat32:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3251,6 +3847,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat32Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3291,6 +3899,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldFloat64:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3329,6 +3949,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldFloat64Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3381,6 +4016,22 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3408,6 +4059,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldStringPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3446,6 +4108,17 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendComma(b)
+			}
+			code = code.Next
 		case encoder.OpStructFieldBool:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3473,6 +4146,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBoolPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3512,6 +4197,18 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendComma(b)
+			}
 			code = code.Next
 		case encoder.OpStructFieldBytes:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3594,6 +4291,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = append(bb, '"')
 			b = appendComma(b)
 			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
+			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -3642,6 +4354,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendComma(b)
+			code = code.Next
+		case encoder.OpStructFieldOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendComma(bb)
+			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
 			b = appendIndent(ctx, b, code.Indent)
@@ -3969,19 +4696,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, u64, code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntString:
@@ -3992,6 +4707,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendInt(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndIntPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4016,19 +4746,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendInt(b, ptrToUint64(p), code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndIntPtrString:
@@ -4045,6 +4763,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyIntPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendInt(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndUint:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4065,19 +4797,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, u64, code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintString:
@@ -4088,6 +4808,21 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendUint(b, ptrToUint64(p+code.Offset), code)
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintString:
+			p := load(ctxptr, code.HeadIdx)
+			u64 := ptrToUint64(p + code.Offset)
+			v := u64 & code.Mask
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, u64, code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndUintPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4112,19 +4847,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendUint(b, ptrToUint64(p), code)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndUintPtrString:
@@ -4141,6 +4864,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyUintPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendUint(b, ptrToUint64(p), code)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4160,19 +4897,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32String:
@@ -4183,6 +4908,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat32(b, ptrToFloat32(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat32(p + code.Offset)
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat32Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4207,19 +4946,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat32(b, ptrToFloat32(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat32PtrString:
@@ -4236,6 +4963,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat32PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendFloat32(b, ptrToFloat32(p))
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4262,19 +5003,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64String:
@@ -4289,6 +5018,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendFloat64(b, v)
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64String:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToFloat64(p + code.Offset)
+			if v != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndFloat64Ptr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4321,19 +5067,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendFloat64(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndFloat64PtrString:
@@ -4355,6 +5089,24 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
 			code = code.Next
+		case encoder.OpStructEndOmitEmptyFloat64PtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				v := ptrToFloat64(p)
+				if math.IsInf(v, 0) || math.IsNaN(v) {
+					return nil, errUnsupportedFloat(v)
+				}
+				b = appendFloat64(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
+			code = code.Next
 		case encoder.OpStructEndString:
 			b = appendIndent(ctx, b, code.Indent)
 			b = append(b, code.Key...)
@@ -4373,19 +5125,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringString:
@@ -4396,6 +5136,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			s := ptrToString(p + code.Offset)
 			b = appendString(b, string(appendString([]byte{}, s)))
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToString(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, v)))
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndStringPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4420,19 +5173,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, ptrToString(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndStringPtrString:
@@ -4447,6 +5188,19 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyStringPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ')
+				b = appendString(b, string(appendString([]byte{}, ptrToString(p))))
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndBool:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4466,19 +5220,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolString:
@@ -4489,6 +5231,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			b = appendBool(b, ptrToBool(p+code.Offset))
 			b = append(b, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToBool(p + code.Offset)
+			if v {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, v)
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4513,19 +5269,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendBool(b, ptrToBool(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndBoolPtrString:
@@ -4542,6 +5286,20 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(b, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyBoolPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				b = appendBool(b, ptrToBool(p))
+				b = append(b, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndBytes:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4561,19 +5319,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, v)
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndBytesPtr:
@@ -4599,19 +5345,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = appendByteSlice(b, ptrToBytes(p))
 				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumber:
@@ -4638,19 +5372,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(ctx, bb, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberString:
@@ -4665,6 +5387,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 			}
 			b = append(bb, '"')
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberString:
+			p := load(ctxptr, code.HeadIdx)
+			v := ptrToNumber(p + code.Offset)
+			if v != "" {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, v)
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(ctx, bb, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtr:
 			b = appendIndent(ctx, b, code.Indent)
@@ -4696,19 +5435,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				}
 				b = appendStructEnd(ctx, bb, code.Indent-1)
 			} else {
-				last := len(b) - 1
-				if b[last-1] == '{' {
-					b[last] = '}'
-				} else {
-					if b[last] == '\n' {
-						// to remove ',' and '\n' characters
-						b = b[:len(b)-2]
-					}
-					b = append(b, '\n')
-					b = appendIndent(ctx, b, code.Indent-1)
-					b = append(b, '}')
-				}
-				b = appendComma(b)
+				b = appendStructEndSkipLast(ctx, b, code)
 			}
 			code = code.Next
 		case encoder.OpStructEndNumberPtrString:
@@ -4728,6 +5455,23 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				b = append(bb, '"')
 			}
 			b = appendStructEnd(ctx, b, code.Indent-1)
+			code = code.Next
+		case encoder.OpStructEndOmitEmptyNumberPtrString:
+			p := load(ctxptr, code.HeadIdx)
+			p = ptrToNPtr(p+code.Offset, code.PtrNum)
+			if p != 0 {
+				b = appendIndent(ctx, b, code.Indent)
+				b = append(b, code.Key...)
+				b = append(b, ' ', '"')
+				bb, err := appendNumber(b, ptrToNumber(p))
+				if err != nil {
+					return nil, err
+				}
+				b = append(b, '"')
+				b = appendStructEnd(ctx, bb, code.Indent-1)
+			} else {
+				b = appendStructEndSkipLast(ctx, b, code)
+			}
 			code = code.Next
 		case encoder.OpEnd:
 			goto END

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -2754,8 +2754,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 				code = code.Next
 			}
 		case encoder.OpStructPtrHeadNumberPtr:
@@ -2918,8 +2918,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructPtrHeadArray, encoder.OpStructPtrHeadSlice:
@@ -4302,8 +4302,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldNumberPtr:
@@ -4366,8 +4366,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendComma(bb)
+				b = append(bb, '"')
+				b = appendComma(b)
 			}
 			code = code.Next
 		case encoder.OpStructFieldMarshalJSON:
@@ -5399,8 +5399,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(ctx, bb, code.Indent-1)
+				b = append(bb, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
 				b = appendStructEndSkipLast(ctx, b, code)
 			}
@@ -5467,8 +5467,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet, opt 
 				if err != nil {
 					return nil, err
 				}
-				b = append(b, '"')
-				b = appendStructEnd(ctx, bb, code.Indent-1)
+				b = append(bb, '"')
+				b = appendStructEnd(ctx, b, code.Indent-1)
 			} else {
 				b = appendStructEndSkipLast(ctx, b, code)
 			}

--- a/internal/runtime/struct_field.go
+++ b/internal/runtime/struct_field.go
@@ -74,8 +74,14 @@ func StructTagFromField(field reflect.StructField) *StructTag {
 	}
 	st.Key = keyName
 	if len(opts) > 1 {
-		st.IsOmitEmpty = opts[1] == "omitempty"
-		st.IsString = opts[1] == "string"
+		for _, opt := range opts[1:] {
+			switch opt {
+			case "omitempty":
+				st.IsOmitEmpty = true
+			case "string":
+				st.IsString = true
+			}
+		}
 	}
 	return st
 }


### PR DESCRIPTION
fix https://github.com/goccy/go-json/issues/191

Rename the operation created by the `string` tag from a `StringTag` .