### PR TITLE
Fix opcode layout

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -179,7 +179,13 @@ func encode(ctx *encoder.RuntimeContext, v interface{}, opt EncodeOption) ([]byt
 	}
 
 	p := uintptr(header.ptr)
-	ctx.Init(p, codeSet.CodeLength)
+	var code *encoder.Opcode
+	if (opt & EncodeOptionHTMLEscape) != 0 {
+		code = codeSet.EscapeKeyCode
+	} else {
+		code = codeSet.NoescapeKeyCode
+	}
+	ctx.Init(code, p, codeSet.CodeLength)
 	ctx.KeepRefs = append(ctx.KeepRefs, header.ptr)
 
 	buf, err := encodeRunCode(ctx, b, codeSet, opt)
@@ -206,8 +212,14 @@ func encodeNoEscape(ctx *encoder.RuntimeContext, v interface{}, opt EncodeOption
 		return nil, err
 	}
 
+	var code *encoder.Opcode
+	if (opt & EncodeOptionHTMLEscape) != 0 {
+		code = codeSet.EscapeKeyCode
+	} else {
+		code = codeSet.NoescapeKeyCode
+	}
 	p := uintptr(header.ptr)
-	ctx.Init(p, codeSet.CodeLength)
+	ctx.Init(code, p, codeSet.CodeLength)
 	buf, err := encodeRunCode(ctx, b, codeSet, opt)
 	if err != nil {
 		return nil, err
@@ -233,8 +245,14 @@ func encodeIndent(ctx *encoder.RuntimeContext, v interface{}, prefix, indent str
 		return nil, err
 	}
 
+	var code *encoder.Opcode
+	if (opt & EncodeOptionHTMLEscape) != 0 {
+		code = codeSet.EscapeKeyCode
+	} else {
+		code = codeSet.NoescapeKeyCode
+	}
 	p := uintptr(header.ptr)
-	ctx.Init(p, codeSet.CodeLength)
+	ctx.Init(code, p, codeSet.CodeLength)
 	buf, err := encodeRunIndentCode(ctx, b, codeSet, prefix, indent, opt)
 
 	ctx.KeepRefs = append(ctx.KeepRefs, header.ptr)

--- a/internal/cmd/generator/main.go
+++ b/internal/cmd/generator/main.go
@@ -48,7 +48,7 @@ var opTypeStrings = [{{ .OpLen }}]string{
 {{- end }}
 }
 
-type OpType int
+type OpType uint16
 
 const (
 {{- range $index, $type := .OpTypes }}

--- a/internal/encoder/compiler_norace.go
+++ b/internal/encoder/compiler_norace.go
@@ -20,19 +20,29 @@ func CompileToGetCodeSet(typeptr uintptr) (*OpcodeSet, error) {
 	// noescape trick for header.typ ( reflect.*rtype )
 	copiedType := *(**runtime.Type)(unsafe.Pointer(&typeptr))
 
-	code, err := compileHead(&compileContext{
+	noescapeKeyCode, err := compileHead(&compileContext{
 		typ:                      copiedType,
 		structTypeToCompiledCode: map[uintptr]*CompiledCode{},
 	})
 	if err != nil {
 		return nil, err
 	}
-	code = copyOpcode(code)
-	codeLength := code.TotalLength()
+	escapeKeyCode, err := compileHead(&compileContext{
+		typ:                      copiedType,
+		structTypeToCompiledCode: map[uintptr]*CompiledCode{},
+		escapeKey:                true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	noescapeKeyCode = copyOpcode(noescapeKeyCode)
+	escapeKeyCode = copyOpcode(escapeKeyCode)
+	codeLength := noescapeKeyCode.TotalLength()
 	codeSet := &OpcodeSet{
-		Type:       copiedType,
-		Code:       code,
-		CodeLength: codeLength,
+		Type:            copiedType,
+		NoescapeKeyCode: noescapeKeyCode,
+		EscapeKeyCode:   escapeKeyCode,
+		CodeLength:      codeLength,
 	}
 	cachedOpcodeSets[index] = codeSet
 	return codeSet, nil

--- a/internal/encoder/compiler_race.go
+++ b/internal/encoder/compiler_race.go
@@ -26,19 +26,30 @@ func CompileToGetCodeSet(typeptr uintptr) (*OpcodeSet, error) {
 	// noescape trick for header.typ ( reflect.*rtype )
 	copiedType := *(**runtime.Type)(unsafe.Pointer(&typeptr))
 
-	code, err := compileHead(&compileContext{
+	noescapeKeyCode, err := compileHead(&compileContext{
 		typ:                      copiedType,
 		structTypeToCompiledCode: map[uintptr]*CompiledCode{},
 	})
 	if err != nil {
 		return nil, err
 	}
-	code = copyOpcode(code)
-	codeLength := code.TotalLength()
+	escapeKeyCode, err := compileHead(&compileContext{
+		typ:                      copiedType,
+		structTypeToCompiledCode: map[uintptr]*CompiledCode{},
+		escapeKey:                true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	noescapeKeyCode = copyOpcode(noescapeKeyCode)
+	escapeKeyCode = copyOpcode(escapeKeyCode)
+	codeLength := noescapeKeyCode.TotalLength()
 	codeSet := &OpcodeSet{
-		Type:       copiedType,
-		Code:       code,
-		CodeLength: codeLength,
+		Type:            copiedType,
+		NoescapeKeyCode: noescapeKeyCode,
+		EscapeKeyCode:   escapeKeyCode,
+		CodeLength:      codeLength,
 	}
 	setsMu.Lock()
 	cachedOpcodeSets[index] = codeSet

--- a/internal/encoder/context.go
+++ b/internal/encoder/context.go
@@ -9,9 +9,10 @@ import (
 
 type compileContext struct {
 	typ                      *runtime.Type
-	opcodeIndex              int
+	opcodeIndex              uint32
 	ptrIndex                 int
-	indent                   int
+	indent                   uint32
+	escapeKey                bool
 	structTypeToCompiledCode map[uintptr]*CompiledCode
 
 	parent *compileContext
@@ -23,6 +24,7 @@ func (c *compileContext) context() *compileContext {
 		opcodeIndex:              c.opcodeIndex,
 		ptrIndex:                 c.ptrIndex,
 		indent:                   c.indent,
+		escapeKey:                c.escapeKey,
 		structTypeToCompiledCode: c.structTypeToCompiledCode,
 		parent:                   c,
 	}
@@ -106,12 +108,13 @@ type RuntimeContext struct {
 	Ptrs       []uintptr
 	KeepRefs   []unsafe.Pointer
 	SeenPtr    []uintptr
-	BaseIndent int
+	BaseIndent uint32
 	Prefix     []byte
 	IndentStr  []byte
+	Code       *Opcode
 }
 
-func (c *RuntimeContext) Init(p uintptr, codelen int) {
+func (c *RuntimeContext) Init(code *Opcode, p uintptr, codelen int) {
 	if len(c.Ptrs) < codelen {
 		c.Ptrs = make([]uintptr, codelen)
 	}
@@ -119,6 +122,7 @@ func (c *RuntimeContext) Init(p uintptr, codelen int) {
 	c.KeepRefs = c.KeepRefs[:0]
 	c.SeenPtr = c.SeenPtr[:0]
 	c.BaseIndent = 0
+	c.Code = code
 }
 
 func (c *RuntimeContext) Ptr() uintptr {

--- a/internal/encoder/encode_opcode_test.go
+++ b/internal/encoder/encode_opcode_test.go
@@ -14,5 +14,5 @@ func TestDumpOpcode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	codeSet.Code.Dump()
+	codeSet.EscapeKeyCode.Dump()
 }

--- a/internal/encoder/int.go
+++ b/internal/encoder/int.go
@@ -49,9 +49,14 @@ var intBELookup = [100]uint16{
 
 var intLookup = [2]*[100]uint16{&intLELookup, &intBELookup}
 
+func numMask(numBitSize uint8) uint64 {
+	return 1<<numBitSize - 1
+}
+
 func AppendInt(out []byte, u64 uint64, code *Opcode) []byte {
-	n := u64 & code.Mask
-	negative := (u64>>code.RshiftNum)&1 == 1
+	mask := numMask(code.NumBitSize)
+	n := u64 & mask
+	negative := (u64>>(code.NumBitSize-1))&1 == 1
 	if !negative {
 		if n < 10 {
 			return append(out, byte(n+'0'))
@@ -60,7 +65,7 @@ func AppendInt(out []byte, u64 uint64, code *Opcode) []byte {
 			return append(out, byte(u), byte(u>>8))
 		}
 	} else {
-		n = -n & code.Mask
+		n = -n & mask
 	}
 
 	lookup := intLookup[endianness]
@@ -92,7 +97,8 @@ func AppendInt(out []byte, u64 uint64, code *Opcode) []byte {
 }
 
 func AppendUint(out []byte, u64 uint64, code *Opcode) []byte {
-	n := u64 & code.Mask
+	mask := numMask(code.NumBitSize)
+	n := u64 & mask
 	if n < 10 {
 		return append(out, byte(n+'0'))
 	} else if n < 100 {

--- a/internal/encoder/optype.go
+++ b/internal/encoder/optype.go
@@ -425,7 +425,7 @@ var opTypeStrings = [400]string{
 	"StructEndOmitEmpty",
 }
 
-type OpType int
+type OpType uint16
 
 const (
 	OpEnd                                    OpType = 0

--- a/internal/encoder/vm/debug_vm.go
+++ b/internal/encoder/vm/debug_vm.go
@@ -14,7 +14,7 @@ func DebugRun(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet,
 			fmt.Println(codeSet.Type)
 			fmt.Printf("\n")
 			fmt.Println("* [ALL OPCODE]")
-			fmt.Println(codeSet.Code.Dump())
+			fmt.Println(ctx.Code.Dump())
 			fmt.Printf("\n")
 			fmt.Println("* [CONTEXT]")
 			fmt.Printf("%+v\n", ctx)

--- a/internal/encoder/vm/util.go
+++ b/internal/encoder/vm/util.go
@@ -37,20 +37,20 @@ func errUnimplementedOp(op encoder.OpType) error {
 	return fmt.Errorf("encoder: opcode %s has not been implemented", op)
 }
 
-func load(base uintptr, idx uintptr) uintptr {
-	addr := base + idx
+func load(base uintptr, idx uint32) uintptr {
+	addr := base + uintptr(idx)
 	return **(**uintptr)(unsafe.Pointer(&addr))
 }
 
-func store(base uintptr, idx uintptr, p uintptr) {
-	addr := base + idx
+func store(base uintptr, idx uint32, p uintptr) {
+	addr := base + uintptr(idx)
 	**(**uintptr)(unsafe.Pointer(&addr)) = p
 }
 
-func loadNPtr(base uintptr, idx uintptr, ptrNum int) uintptr {
-	addr := base + idx
+func loadNPtr(base uintptr, idx uint32, ptrNum uint8) uintptr {
+	addr := base + uintptr(idx)
 	p := **(**uintptr)(unsafe.Pointer(&addr))
-	for i := 0; i < ptrNum; i++ {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -70,8 +70,8 @@ func ptrToSlice(p uintptr) *runtime.SliceHeader { return *(**runtime.SliceHeader
 func ptrToPtr(p uintptr) uintptr {
 	return uintptr(**(**unsafe.Pointer)(unsafe.Pointer(&p)))
 }
-func ptrToNPtr(p uintptr, ptrNum int) uintptr {
-	for i := 0; i < ptrNum; i++ {
+func ptrToNPtr(p uintptr, ptrNum uint8) uintptr {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -146,6 +146,7 @@ func appendInterface(ctx *encoder.RuntimeContext, codeSet *encoder.OpcodeSet, op
 	newPtrs[0] = uintptr(iface.ptr)
 
 	ctx.Ptrs = newPtrs
+	ctx.Code = ifaceCodeSet.NoescapeKeyCode
 
 	bb, err := Run(ctx, b, ifaceCodeSet, opt)
 	if err != nil {

--- a/internal/encoder/vm_escaped/debug_vm.go
+++ b/internal/encoder/vm_escaped/debug_vm.go
@@ -14,7 +14,7 @@ func DebugRun(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet,
 			fmt.Println(codeSet.Type)
 			fmt.Printf("\n")
 			fmt.Println("* [ALL OPCODE]")
-			fmt.Println(codeSet.Code.Dump())
+			fmt.Println(ctx.Code.Dump())
 			fmt.Printf("\n")
 			fmt.Println("* [CONTEXT]")
 			fmt.Printf("%+v\n", ctx)

--- a/internal/encoder/vm_escaped/util.go
+++ b/internal/encoder/vm_escaped/util.go
@@ -37,20 +37,20 @@ func errUnimplementedOp(op encoder.OpType) error {
 	return fmt.Errorf("encoder (escaped): opcode %s has not been implemented", op)
 }
 
-func load(base uintptr, idx uintptr) uintptr {
-	addr := base + idx
+func load(base uintptr, idx uint32) uintptr {
+	addr := base + uintptr(idx)
 	return **(**uintptr)(unsafe.Pointer(&addr))
 }
 
-func store(base uintptr, idx uintptr, p uintptr) {
-	addr := base + idx
+func store(base uintptr, idx uint32, p uintptr) {
+	addr := base + uintptr(idx)
 	**(**uintptr)(unsafe.Pointer(&addr)) = p
 }
 
-func loadNPtr(base uintptr, idx uintptr, ptrNum int) uintptr {
-	addr := base + idx
+func loadNPtr(base uintptr, idx uint32, ptrNum uint8) uintptr {
+	addr := base + uintptr(idx)
 	p := **(**uintptr)(unsafe.Pointer(&addr))
-	for i := 0; i < ptrNum; i++ {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -70,8 +70,8 @@ func ptrToSlice(p uintptr) *runtime.SliceHeader { return *(**runtime.SliceHeader
 func ptrToPtr(p uintptr) uintptr {
 	return uintptr(**(**unsafe.Pointer)(unsafe.Pointer(&p)))
 }
-func ptrToNPtr(p uintptr, ptrNum int) uintptr {
-	for i := 0; i < ptrNum; i++ {
+func ptrToNPtr(p uintptr, ptrNum uint8) uintptr {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -146,6 +146,7 @@ func appendInterface(ctx *encoder.RuntimeContext, codeSet *encoder.OpcodeSet, op
 	newPtrs[0] = uintptr(iface.ptr)
 
 	ctx.Ptrs = newPtrs
+	ctx.Code = ifaceCodeSet.EscapeKeyCode
 
 	bb, err := Run(ctx, b, ifaceCodeSet, opt)
 	if err != nil {
@@ -193,7 +194,7 @@ func appendStructHead(b []byte) []byte {
 }
 
 func appendStructKey(_ *encoder.RuntimeContext, code *encoder.Opcode, b []byte) []byte {
-	return append(b, code.EscapedKey...)
+	return append(b, code.Key...)
 }
 
 func appendStructEnd(_ *encoder.RuntimeContext, _ *encoder.Opcode, b []byte) []byte {

--- a/internal/encoder/vm_escaped_indent/debug_vm.go
+++ b/internal/encoder/vm_escaped_indent/debug_vm.go
@@ -14,7 +14,7 @@ func DebugRun(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet,
 			fmt.Println(codeSet.Type)
 			fmt.Printf("\n")
 			fmt.Println("* [ALL OPCODE]")
-			fmt.Println(codeSet.Code.Dump())
+			fmt.Println(ctx.Code.Dump())
 			fmt.Printf("\n")
 			fmt.Println("* [CONTEXT]")
 			fmt.Printf("%+v\n", ctx)

--- a/internal/encoder/vm_escaped_indent/util.go
+++ b/internal/encoder/vm_escaped_indent/util.go
@@ -39,20 +39,20 @@ func errUnimplementedOp(op encoder.OpType) error {
 	return fmt.Errorf("encoder (indent+escaped): opcode %s has not been implemented", op)
 }
 
-func load(base uintptr, idx uintptr) uintptr {
-	addr := base + idx
+func load(base uintptr, idx uint32) uintptr {
+	addr := base + uintptr(idx)
 	return **(**uintptr)(unsafe.Pointer(&addr))
 }
 
-func store(base uintptr, idx uintptr, p uintptr) {
-	addr := base + idx
+func store(base uintptr, idx uint32, p uintptr) {
+	addr := base + uintptr(idx)
 	**(**uintptr)(unsafe.Pointer(&addr)) = p
 }
 
-func loadNPtr(base uintptr, idx uintptr, ptrNum int) uintptr {
-	addr := base + idx
+func loadNPtr(base uintptr, idx uint32, ptrNum uint8) uintptr {
+	addr := base + uintptr(idx)
 	p := **(**uintptr)(unsafe.Pointer(&addr))
-	for i := 0; i < ptrNum; i++ {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -72,8 +72,8 @@ func ptrToSlice(p uintptr) *runtime.SliceHeader { return *(**runtime.SliceHeader
 func ptrToPtr(p uintptr) uintptr {
 	return uintptr(**(**unsafe.Pointer)(unsafe.Pointer(&p)))
 }
-func ptrToNPtr(p uintptr, ptrNum int) uintptr {
-	for i := 0; i < ptrNum; i++ {
+func ptrToNPtr(p uintptr, ptrNum uint8) uintptr {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -137,6 +137,7 @@ func appendInterface(ctx *encoder.RuntimeContext, codeSet *encoder.OpcodeSet, op
 
 	oldBaseIndent := ctx.BaseIndent
 	ctx.BaseIndent = code.Indent
+	ctx.Code = ifaceCodeSet.EscapeKeyCode
 	bb, err := Run(ctx, b, ifaceCodeSet, opt)
 	if err != nil {
 		return nil, err
@@ -204,7 +205,7 @@ func appendStructHead(b []byte) []byte {
 
 func appendStructKey(ctx *encoder.RuntimeContext, code *encoder.Opcode, b []byte) []byte {
 	b = appendIndent(ctx, b, code.Indent)
-	b = append(b, code.EscapedKey...)
+	b = append(b, code.Key...)
 	return append(b, ' ')
 }
 
@@ -225,7 +226,7 @@ func appendStructEndSkipLast(ctx *encoder.RuntimeContext, code *encoder.Opcode, 
 }
 
 func restoreIndent(ctx *encoder.RuntimeContext, code *encoder.Opcode, ctxptr uintptr) {
-	ctx.BaseIndent = int(load(ctxptr, code.Length))
+	ctx.BaseIndent = uint32(load(ctxptr, code.Length))
 }
 
 func storeIndent(ctxptr uintptr, code *encoder.Opcode, indent uintptr) {

--- a/internal/encoder/vm_indent/debug_vm.go
+++ b/internal/encoder/vm_indent/debug_vm.go
@@ -14,7 +14,7 @@ func DebugRun(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet,
 			fmt.Println(codeSet.Type)
 			fmt.Printf("\n")
 			fmt.Println("* [ALL OPCODE]")
-			fmt.Println(codeSet.Code.Dump())
+			fmt.Println(ctx.Code.Dump())
 			fmt.Printf("\n")
 			fmt.Println("* [CONTEXT]")
 			fmt.Printf("%+v\n", ctx)

--- a/internal/encoder/vm_indent/util.go
+++ b/internal/encoder/vm_indent/util.go
@@ -39,20 +39,20 @@ func errUnimplementedOp(op encoder.OpType) error {
 	return fmt.Errorf("encoder (indent): opcode %s has not been implemented", op)
 }
 
-func load(base uintptr, idx uintptr) uintptr {
-	addr := base + idx
+func load(base uintptr, idx uint32) uintptr {
+	addr := base + uintptr(idx)
 	return **(**uintptr)(unsafe.Pointer(&addr))
 }
 
-func store(base uintptr, idx uintptr, p uintptr) {
-	addr := base + idx
+func store(base uintptr, idx uint32, p uintptr) {
+	addr := base + uintptr(idx)
 	**(**uintptr)(unsafe.Pointer(&addr)) = p
 }
 
-func loadNPtr(base uintptr, idx uintptr, ptrNum int) uintptr {
-	addr := base + idx
+func loadNPtr(base uintptr, idx uint32, ptrNum uint8) uintptr {
+	addr := base + uintptr(idx)
 	p := **(**uintptr)(unsafe.Pointer(&addr))
-	for i := 0; i < ptrNum; i++ {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -72,8 +72,8 @@ func ptrToSlice(p uintptr) *runtime.SliceHeader { return *(**runtime.SliceHeader
 func ptrToPtr(p uintptr) uintptr {
 	return uintptr(**(**unsafe.Pointer)(unsafe.Pointer(&p)))
 }
-func ptrToNPtr(p uintptr, ptrNum int) uintptr {
-	for i := 0; i < ptrNum; i++ {
+func ptrToNPtr(p uintptr, ptrNum uint8) uintptr {
+	for i := uint8(0); i < ptrNum; i++ {
 		if p == 0 {
 			return 0
 		}
@@ -137,6 +137,7 @@ func appendInterface(ctx *encoder.RuntimeContext, codeSet *encoder.OpcodeSet, op
 
 	oldBaseIndent := ctx.BaseIndent
 	ctx.BaseIndent = code.Indent
+	ctx.Code = ifaceCodeSet.NoescapeKeyCode
 	bb, err := Run(ctx, b, ifaceCodeSet, opt)
 	if err != nil {
 		return nil, err
@@ -225,7 +226,7 @@ func appendStructEndSkipLast(ctx *encoder.RuntimeContext, code *encoder.Opcode, 
 }
 
 func restoreIndent(ctx *encoder.RuntimeContext, code *encoder.Opcode, ctxptr uintptr) {
-	ctx.BaseIndent = int(load(ctxptr, code.Length))
+	ctx.BaseIndent = uint32(load(ctxptr, code.Length))
 }
 
 func storeIndent(ctxptr uintptr, code *encoder.Opcode, indent uintptr) {

--- a/size_test.go
+++ b/size_test.go
@@ -1,0 +1,18 @@
+package json
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/goccy/go-json/internal/encoder"
+)
+
+func TestOpcodeSize(t *testing.T) {
+	const uintptrSize = 4 << (^uintptr(0) >> 63)
+	if uintptrSize == 8 {
+		size := unsafe.Sizeof(encoder.Opcode{})
+		if size != 128 {
+			t.Fatalf("unexpected opcode size: expected 128bytes but got %dbytes", size)
+		}
+	}
+}


### PR DESCRIPTION
Adjust memory layout of the opcode to 128 bytes in a 64-bit environment