### PR TITLE
Add DecodeFieldPriorityFirstWin option

### DIFF
--- a/benchmarks/decode_test.go
+++ b/benchmarks/decode_test.go
@@ -375,6 +375,34 @@ func Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscape(b *testing.B) {
 	}
 }
 
+func Benchmark_Decode_LargeStruct_Unmarshal_GoJsonFirstWinMode(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := LargePayload{}
+		if err := gojson.UnmarshalWithOption(
+			LargeFixture,
+			&result,
+			gojson.DecodeFieldPriorityFirstWin(),
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscapeFirstWinMode(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := LargePayload{}
+		if err := gojson.UnmarshalNoEscape(
+			LargeFixture,
+			&result,
+			gojson.DecodeFieldPriorityFirstWin(),
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func Benchmark_Decode_LargeStruct_Stream_EncodingJson(b *testing.B) {
 	b.ReportAllocs()
 	reader := bytes.NewReader(LargeFixture)

--- a/benchmarks/decode_test.go
+++ b/benchmarks/decode_test.go
@@ -462,3 +462,18 @@ func Benchmark_Decode_LargeStruct_Stream_GoJson(b *testing.B) {
 		}
 	}
 }
+
+func Benchmark_Decode_LargeStruct_Stream_GoJsonFirstWinMode(b *testing.B) {
+	b.ReportAllocs()
+	reader := bytes.NewReader(LargeFixture)
+	for i := 0; i < b.N; i++ {
+		result := LargePayload{}
+		reader.Reset(LargeFixture)
+		if err := gojson.NewDecoder(reader).DecodeWithOption(
+			&result,
+			gojson.DecodeFieldPriorityFirstWin(),
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/decode.go
+++ b/decode.go
@@ -134,6 +134,10 @@ func (d *Decoder) Buffered() io.Reader {
 // See the documentation for Unmarshal for details about
 // the conversion of JSON into a Go value.
 func (d *Decoder) Decode(v interface{}) error {
+	return d.DecodeWithOption(v)
+}
+
+func (d *Decoder) DecodeWithOption(v interface{}, optFuncs ...DecodeOptionFunc) error {
 	header := (*emptyInterface)(unsafe.Pointer(&v))
 	typ := header.typ
 	ptr := uintptr(header.ptr)
@@ -153,6 +157,9 @@ func (d *Decoder) Decode(v interface{}) error {
 		return err
 	}
 	s := d.s
+	for _, optFunc := range optFuncs {
+		optFunc(s.Option)
+	}
 	if err := dec.DecodeStream(s, 0, header.ptr); err != nil {
 		return err
 	}

--- a/decode.go
+++ b/decode.go
@@ -39,7 +39,7 @@ func unmarshal(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
 	}
 	ctx := decoder.TakeRuntimeContext()
 	ctx.Buf = src
-	ctx.Option.FirstWin = false
+	ctx.Option.Flag = 0
 	for _, optFunc := range optFuncs {
 		optFunc(ctx.Option)
 	}
@@ -68,7 +68,7 @@ func unmarshalNoEscape(data []byte, v interface{}, optFuncs ...DecodeOptionFunc)
 
 	ctx := decoder.TakeRuntimeContext()
 	ctx.Buf = src
-	ctx.Option.FirstWin = false
+	ctx.Option.Flag = 0
 	for _, optFunc := range optFuncs {
 		optFunc(ctx.Option)
 	}

--- a/decode.go
+++ b/decode.go
@@ -39,6 +39,7 @@ func unmarshal(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
 	}
 	ctx := decoder.TakeRuntimeContext()
 	ctx.Buf = src
+	ctx.Option.FirstWin = false
 	for _, optFunc := range optFuncs {
 		optFunc(ctx.Option)
 	}
@@ -67,6 +68,7 @@ func unmarshalNoEscape(data []byte, v interface{}, optFuncs ...DecodeOptionFunc)
 
 	ctx := decoder.TakeRuntimeContext()
 	ctx.Buf = src
+	ctx.Option.FirstWin = false
 	for _, optFunc := range optFuncs {
 		optFunc(ctx.Option)
 	}

--- a/decode.go
+++ b/decode.go
@@ -24,7 +24,7 @@ type emptyInterface struct {
 	ptr unsafe.Pointer
 }
 
-func unmarshal(data []byte, v interface{}) error {
+func unmarshal(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
 	src := make([]byte, len(data)+1) // append nul byte to the end
 	copy(src, data)
 

--- a/internal/decoder/anonymous_field.go
+++ b/internal/decoder/anonymous_field.go
@@ -28,10 +28,10 @@ func (d *anonymousFieldDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Po
 	return d.dec.DecodeStream(s, depth, unsafe.Pointer(uintptr(p)+d.offset))
 }
 
-func (d *anonymousFieldDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *anonymousFieldDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
 	if *(*unsafe.Pointer)(p) == nil {
 		*(*unsafe.Pointer)(p) = unsafe_New(d.structType)
 	}
 	p = *(*unsafe.Pointer)(p)
-	return d.dec.Decode(buf, cursor, depth, unsafe.Pointer(uintptr(p)+d.offset))
+	return d.dec.Decode(ctx, cursor, depth, unsafe.Pointer(uintptr(p)+d.offset))
 }

--- a/internal/decoder/array.go
+++ b/internal/decoder/array.go
@@ -91,7 +91,8 @@ ERROR:
 	return errors.ErrUnexpectedEndOfJSON("array", s.totalOffset())
 }
 
-func (d *arrayDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *arrayDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	depth++
 	if depth > maxDecodeNestingDepth {
 		return 0, errors.ErrExceededMaxDepth(buf[cursor], cursor)
@@ -113,7 +114,7 @@ func (d *arrayDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer)
 			for {
 				cursor++
 				if idx < d.alen {
-					c, err := d.valueDecoder.Decode(buf, cursor, depth, unsafe.Pointer(uintptr(p)+uintptr(idx)*d.size))
+					c, err := d.valueDecoder.Decode(ctx, cursor, depth, unsafe.Pointer(uintptr(p)+uintptr(idx)*d.size))
 					if err != nil {
 						return 0, err
 					}

--- a/internal/decoder/array.go
+++ b/internal/decoder/array.go
@@ -58,8 +58,7 @@ func (d *arrayDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) er
 					}
 				}
 				idx++
-				s.skipWhiteSpace()
-				switch s.char() {
+				switch s.skipWhiteSpace() {
 				case ']':
 					for idx < d.alen {
 						*(*unsafe.Pointer)(unsafe.Pointer(uintptr(p) + uintptr(idx)*d.size)) = d.zeroValue

--- a/internal/decoder/bool.go
+++ b/internal/decoder/bool.go
@@ -49,7 +49,8 @@ ERROR:
 	return errors.ErrUnexpectedEndOfJSON("bool", s.totalOffset())
 }
 
-func (d *boolDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *boolDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	cursor = skipWhiteSpace(buf, cursor)
 	switch buf[cursor] {
 	case 't':

--- a/internal/decoder/bool.go
+++ b/internal/decoder/bool.go
@@ -16,9 +16,9 @@ func newBoolDecoder(structName, fieldName string) *boolDecoder {
 }
 
 func (d *boolDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) error {
-	s.skipWhiteSpace()
+	c := s.skipWhiteSpace()
 	for {
-		switch s.char() {
+		switch c {
 		case 't':
 			if err := trueBytes(s); err != nil {
 				return err
@@ -38,6 +38,7 @@ func (d *boolDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) err
 			return nil
 		case nul:
 			if s.read() {
+				c = s.char()
 				continue
 			}
 			goto ERROR

--- a/internal/decoder/bytes.go
+++ b/internal/decoder/bytes.go
@@ -57,8 +57,8 @@ func (d *bytesDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) er
 	return nil
 }
 
-func (d *bytesDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	bytes, c, err := d.decodeBinary(buf, cursor, depth, p)
+func (d *bytesDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	bytes, c, err := d.decodeBinary(ctx, cursor, depth, p)
 	if err != nil {
 		return 0, err
 	}
@@ -131,7 +131,8 @@ func (d *bytesDecoder) decodeStreamBinary(s *Stream, depth int64, p unsafe.Point
 	return nil, errors.ErrNotAtBeginningOfValue(s.totalOffset())
 }
 
-func (d *bytesDecoder) decodeBinary(buf []byte, cursor, depth int64, p unsafe.Pointer) ([]byte, int64, error) {
+func (d *bytesDecoder) decodeBinary(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) ([]byte, int64, error) {
+	buf := ctx.Buf
 	for {
 		switch buf[cursor] {
 		case ' ', '\n', '\t', '\r':
@@ -157,7 +158,7 @@ func (d *bytesDecoder) decodeBinary(buf []byte, cursor, depth int64, p unsafe.Po
 					Offset: cursor,
 				}
 			}
-			c, err := d.sliceDecoder.Decode(buf, cursor, depth, p)
+			c, err := d.sliceDecoder.Decode(ctx, cursor, depth, p)
 			if err != nil {
 				return nil, 0, err
 			}

--- a/internal/decoder/context.go
+++ b/internal/decoder/context.go
@@ -1,10 +1,34 @@
 package decoder
 
 import (
+	"sync"
 	"unsafe"
 
 	"github.com/goccy/go-json/internal/errors"
 )
+
+type RuntimeContext struct {
+	Buf    []byte
+	Option *Option
+}
+
+var (
+	runtimeContextPool = sync.Pool{
+		New: func() interface{} {
+			return &RuntimeContext{
+				Option: &Option{},
+			}
+		},
+	}
+)
+
+func TakeRuntimeContext() *RuntimeContext {
+	return runtimeContextPool.Get().(*RuntimeContext)
+}
+
+func ReleaseRuntimeContext(ctx *RuntimeContext) {
+	runtimeContextPool.Put(ctx)
+}
 
 var (
 	isWhiteSpace = [256]bool{}

--- a/internal/decoder/float.go
+++ b/internal/decoder/float.go
@@ -135,7 +135,8 @@ func (d *floatDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) er
 	return nil
 }
 
-func (d *floatDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *floatDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	bytes, c, err := d.decodeByte(buf, cursor)
 	if err != nil {
 		return 0, err

--- a/internal/decoder/int.go
+++ b/internal/decoder/int.go
@@ -209,8 +209,8 @@ func (d *intDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 	return nil
 }
 
-func (d *intDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	bytes, c, err := d.decodeByte(buf, cursor)
+func (d *intDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	bytes, c, err := d.decodeByte(ctx.Buf, cursor)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/decoder/interface.go
+++ b/internal/decoder/interface.go
@@ -203,7 +203,7 @@ func (d *interfaceDecoder) decodeStreamEmptyInterface(s *Stream, depth int64, p 
 			for {
 				switch s.char() {
 				case '\\':
-					if err := decodeEscapeString(s); err != nil {
+					if _, err := decodeEscapeString(s, nil); err != nil {
 						return err
 					}
 				case '"':

--- a/internal/decoder/interface.go
+++ b/internal/decoder/interface.go
@@ -176,9 +176,9 @@ func decodeTextUnmarshaler(buf []byte, cursor, depth int64, unmarshaler encoding
 }
 
 func (d *interfaceDecoder) decodeStreamEmptyInterface(s *Stream, depth int64, p unsafe.Pointer) error {
-	s.skipWhiteSpace()
+	c := s.skipWhiteSpace()
 	for {
-		switch s.char() {
+		switch c {
 		case '{':
 			var v map[string]interface{}
 			ptr := unsafe.Pointer(&v)
@@ -239,6 +239,7 @@ func (d *interfaceDecoder) decodeStreamEmptyInterface(s *Stream, depth int64, p 
 			return nil
 		case nul:
 			if s.read() {
+				c = s.char()
 				continue
 			}
 		}
@@ -265,8 +266,7 @@ func (d *interfaceDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer
 		if u, ok := rv.Interface().(encoding.TextUnmarshaler); ok {
 			return decodeStreamTextUnmarshaler(s, depth, u, p)
 		}
-		s.skipWhiteSpace()
-		if s.char() == 'n' {
+		if s.skipWhiteSpace() == 'n' {
 			if err := nullBytes(s); err != nil {
 				return err
 			}
@@ -285,8 +285,7 @@ func (d *interfaceDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer
 	if typ.Kind() == reflect.Ptr && typ.Elem() == d.typ || typ.Kind() != reflect.Ptr {
 		return d.decodeStreamEmptyInterface(s, depth, p)
 	}
-	s.skipWhiteSpace()
-	if s.char() == 'n' {
+	if s.skipWhiteSpace() == 'n' {
 		if err := nullBytes(s); err != nil {
 			return err
 		}

--- a/internal/decoder/map.go
+++ b/internal/decoder/map.go
@@ -90,7 +90,8 @@ func (d *mapDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 	}
 }
 
-func (d *mapDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *mapDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	depth++
 	if depth > maxDecodeNestingDepth {
 		return 0, errors.ErrExceededMaxDepth(buf[cursor], cursor)
@@ -126,7 +127,7 @@ func (d *mapDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (
 	}
 	for {
 		k := unsafe_New(d.keyType)
-		keyCursor, err := d.keyDecoder.Decode(buf, cursor, depth, k)
+		keyCursor, err := d.keyDecoder.Decode(ctx, cursor, depth, k)
 		if err != nil {
 			return 0, err
 		}
@@ -136,7 +137,7 @@ func (d *mapDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (
 		}
 		cursor++
 		v := unsafe_New(d.valueType)
-		valueCursor, err := d.valueDecoder.Decode(buf, cursor, depth, v)
+		valueCursor, err := d.valueDecoder.Decode(ctx, cursor, depth, v)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/decoder/map.go
+++ b/internal/decoder/map.go
@@ -42,8 +42,7 @@ func (d *mapDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 		return errors.ErrExceededMaxDepth(s.char(), s.cursor)
 	}
 
-	s.skipWhiteSpace()
-	switch s.char() {
+	switch s.skipWhiteSpace() {
 	case 'n':
 		if err := nullBytes(s); err != nil {
 			return err
@@ -54,7 +53,6 @@ func (d *mapDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 	default:
 		return errors.ErrExpected("{ character for map value", s.totalOffset())
 	}
-	s.skipWhiteSpace()
 	mapValue := *(*unsafe.Pointer)(p)
 	if mapValue == nil {
 		mapValue = makemap(d.mapType, 0)

--- a/internal/decoder/number.go
+++ b/internal/decoder/number.go
@@ -37,8 +37,8 @@ func (d *numberDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 	return nil
 }
 
-func (d *numberDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	bytes, c, err := d.decodeByte(buf, cursor)
+func (d *numberDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	bytes, c, err := d.decodeByte(ctx.Buf, cursor)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/decoder/option.go
+++ b/internal/decoder/option.go
@@ -1,5 +1,11 @@
 package decoder
 
+type OptionFlag int
+
+const (
+	FirstWinOption OptionFlag = 1 << iota
+)
+
 type Option struct {
-	FirstWin bool
+	Flag OptionFlag
 }

--- a/internal/decoder/option.go
+++ b/internal/decoder/option.go
@@ -1,0 +1,5 @@
+package decoder
+
+type Option struct {
+	FirstWin bool
+}

--- a/internal/decoder/ptr.go
+++ b/internal/decoder/ptr.go
@@ -35,8 +35,7 @@ func (d *ptrDecoder) contentDecoder() Decoder {
 func unsafe_New(*runtime.Type) unsafe.Pointer
 
 func (d *ptrDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) error {
-	s.skipWhiteSpace()
-	if s.char() == nul {
+	if s.skipWhiteSpace() == nul {
 		s.read()
 	}
 	if s.char() == 'n' {

--- a/internal/decoder/ptr.go
+++ b/internal/decoder/ptr.go
@@ -58,7 +58,8 @@ func (d *ptrDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 	return nil
 }
 
-func (d *ptrDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *ptrDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	cursor = skipWhiteSpace(buf, cursor)
 	if buf[cursor] == 'n' {
 		if err := validateNull(buf, cursor); err != nil {
@@ -77,7 +78,7 @@ func (d *ptrDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (
 	} else {
 		newptr = *(*unsafe.Pointer)(p)
 	}
-	c, err := d.dec.Decode(buf, cursor, depth, newptr)
+	c, err := d.dec.Decode(ctx, cursor, depth, newptr)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/decoder/slice.go
+++ b/internal/decoder/slice.go
@@ -111,8 +111,7 @@ func (d *sliceDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) er
 			return nil
 		case '[':
 			s.cursor++
-			s.skipWhiteSpace()
-			if s.char() == ']' {
+			if s.skipWhiteSpace() == ']' {
 				dst := (*sliceHeader)(p)
 				if dst.data == nil {
 					dst.data = newArray(d.elemType, 0)

--- a/internal/decoder/slice.go
+++ b/internal/decoder/slice.go
@@ -199,7 +199,8 @@ ERROR:
 	return errors.ErrUnexpectedEndOfJSON("slice", s.totalOffset())
 }
 
-func (d *sliceDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *sliceDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	depth++
 	if depth > maxDecodeNestingDepth {
 		return 0, errors.ErrExceededMaxDepth(buf[cursor], cursor)
@@ -253,7 +254,7 @@ func (d *sliceDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer)
 						typedmemmove(d.elemType, ep, unsafe_New(d.elemType))
 					}
 				}
-				c, err := d.valueDecoder.Decode(buf, cursor, depth, ep)
+				c, err := d.valueDecoder.Decode(ctx, cursor, depth, ep)
 				if err != nil {
 					return 0, err
 				}

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -25,6 +25,7 @@ type Stream struct {
 	allRead               bool
 	UseNumber             bool
 	DisallowUnknownFields bool
+	Option                *Option
 }
 
 func NewStream(r io.Reader) *Stream {
@@ -32,6 +33,7 @@ func NewStream(r io.Reader) *Stream {
 		r:       r,
 		bufSize: initBufSize,
 		buf:     make([]byte, initBufSize),
+		Option:  &Option{},
 	}
 }
 

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -198,6 +198,7 @@ func (s *Stream) readBuf() []byte {
 		}
 		remainNotNulCharNum++
 	}
+	s.length = s.cursor + remainNotNulCharNum
 	return s.buf[s.cursor+remainNotNulCharNum:]
 }
 
@@ -209,7 +210,7 @@ func (s *Stream) read() bool {
 	last := len(buf) - 1
 	buf[last] = nul
 	n, err := s.r.Read(buf[:last])
-	s.length = s.cursor + int64(n)
+	s.length += int64(n)
 	if n == last {
 		s.filledBuffer = true
 	} else {

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -31,7 +31,7 @@ func NewStream(r io.Reader) *Stream {
 	return &Stream{
 		r:       r,
 		bufSize: initBufSize,
-		buf:     []byte{nul},
+		buf:     make([]byte, initBufSize),
 	}
 }
 

--- a/internal/decoder/string.go
+++ b/internal/decoder/string.go
@@ -45,8 +45,8 @@ func (d *stringDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 	return nil
 }
 
-func (d *stringDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	bytes, c, err := d.decodeByte(buf, cursor)
+func (d *stringDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	bytes, c, err := d.decodeByte(ctx.Buf, cursor)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/decoder/string.go
+++ b/internal/decoder/string.go
@@ -93,38 +93,40 @@ func unicodeToRune(code []byte) rune {
 	return r
 }
 
-func decodeUnicodeRune(s *Stream) (rune, int64, error) {
+func decodeUnicodeRune(s *Stream, p unsafe.Pointer) (rune, int64, unsafe.Pointer, error) {
 	const defaultOffset = 5
 	const surrogateOffset = 11
 
 	if s.cursor+defaultOffset >= s.length {
 		if !s.read() {
-			return rune(0), 0, errors.ErrInvalidCharacter(s.char(), "escaped string", s.totalOffset())
+			return rune(0), 0, nil, errors.ErrInvalidCharacter(s.char(), "escaped string", s.totalOffset())
 		}
+		p = s.bufptr()
 	}
 
 	r := unicodeToRune(s.buf[s.cursor+1 : s.cursor+defaultOffset])
 	if utf16.IsSurrogate(r) {
 		if s.cursor+surrogateOffset >= s.length {
 			s.read()
+			p = s.bufptr()
 		}
 		if s.cursor+surrogateOffset >= s.length || s.buf[s.cursor+defaultOffset] != '\\' || s.buf[s.cursor+defaultOffset+1] != 'u' {
-			return unicode.ReplacementChar, defaultOffset, nil
+			return unicode.ReplacementChar, defaultOffset, p, nil
 		}
 		r2 := unicodeToRune(s.buf[s.cursor+defaultOffset+2 : s.cursor+surrogateOffset])
 		if r := utf16.DecodeRune(r, r2); r != unicode.ReplacementChar {
-			return r, surrogateOffset, nil
+			return r, surrogateOffset, p, nil
 		}
 	}
-	return r, defaultOffset, nil
+	return r, defaultOffset, p, nil
 }
 
-func decodeUnicode(s *Stream) error {
+func decodeUnicode(s *Stream, p unsafe.Pointer) (unsafe.Pointer, error) {
 	const backSlashAndULen = 2 // length of \u
 
-	r, offset, err := decodeUnicodeRune(s)
+	r, offset, pp, err := decodeUnicodeRune(s, p)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	unicode := []byte(string(r))
 	unicodeLen := int64(len(unicode))
@@ -132,10 +134,10 @@ func decodeUnicode(s *Stream) error {
 	unicodeOrgLen := offset - 1
 	s.length = s.length - (backSlashAndULen + (unicodeOrgLen - unicodeLen))
 	s.cursor = s.cursor - backSlashAndULen + unicodeLen
-	return nil
+	return pp, nil
 }
 
-func decodeEscapeString(s *Stream) error {
+func decodeEscapeString(s *Stream, p unsafe.Pointer) (unsafe.Pointer, error) {
 	s.cursor++
 RETRY:
 	switch s.buf[s.cursor] {
@@ -156,19 +158,19 @@ RETRY:
 	case 't':
 		s.buf[s.cursor] = '\t'
 	case 'u':
-		return decodeUnicode(s)
+		return decodeUnicode(s, p)
 	case nul:
 		if !s.read() {
-			return errors.ErrInvalidCharacter(s.char(), "escaped string", s.totalOffset())
+			return nil, errors.ErrInvalidCharacter(s.char(), "escaped string", s.totalOffset())
 		}
 		goto RETRY
 	default:
-		return errors.ErrUnexpectedEndOfJSON("string", s.totalOffset())
+		return nil, errors.ErrUnexpectedEndOfJSON("string", s.totalOffset())
 	}
 	s.buf = append(s.buf[:s.cursor-1], s.buf[s.cursor:]...)
 	s.length--
 	s.cursor--
-	return nil
+	return p, nil
 }
 
 var (
@@ -184,9 +186,11 @@ func stringBytes(s *Stream) ([]byte, error) {
 		switch char(p, cursor) {
 		case '\\':
 			s.cursor = cursor
-			if err := decodeEscapeString(s); err != nil {
+			pp, err := decodeEscapeString(s, p)
+			if err != nil {
 				return nil, err
 			}
+			p = pp
 			cursor = s.cursor
 		case '"':
 			literal := s.buf[start:cursor]

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -680,7 +680,8 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 	}
 }
 
-func (d *structDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *structDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	depth++
 	if depth > maxDecodeNestingDepth {
 		return 0, errors.ErrExceededMaxDepth(buf[cursor], cursor)
@@ -722,7 +723,7 @@ func (d *structDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer
 			if field.err != nil {
 				return 0, field.err
 			}
-			c, err := field.dec.Decode(buf, cursor, depth, unsafe.Pointer(uintptr(p)+field.offset))
+			c, err := field.dec.Decode(ctx, cursor, depth, unsafe.Pointer(uintptr(p)+field.offset))
 			if err != nil {
 				return 0, err
 			}

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -627,23 +627,20 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 		return errors.ErrExceededMaxDepth(s.char(), s.cursor)
 	}
 
-	s.skipWhiteSpace()
-	switch s.char() {
+	c := s.skipWhiteSpace()
+	switch c {
 	case 'n':
 		if err := nullBytes(s); err != nil {
 			return err
 		}
 		return nil
-	case nul:
-		s.read()
 	default:
 		if s.char() != '{' {
 			return errors.ErrNotAtBeginningOfValue(s.totalOffset())
 		}
 	}
 	s.cursor++
-	s.skipWhiteSpace()
-	if s.char() == '}' {
+	if s.skipWhiteSpace() == '}' {
 		s.cursor++
 		return nil
 	}
@@ -653,16 +650,10 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 		if err != nil {
 			return err
 		}
-		s.skipWhiteSpace()
-		if s.char() != ':' {
+		if s.skipWhiteSpace() != ':' {
 			return errors.ErrExpected("colon after object key", s.totalOffset())
 		}
 		s.cursor++
-		if s.char() == nul {
-			if !s.read() {
-				return errors.ErrExpected("object value after colon", s.totalOffset())
-			}
-		}
 		if field != nil {
 			if field.err != nil {
 				return field.err
@@ -677,8 +668,7 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 				return err
 			}
 		}
-		s.skipWhiteSpace()
-		c := s.char()
+		c := s.skipWhiteSpace()
 		if c == '}' {
 			s.cursor++
 			return nil

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -727,7 +727,7 @@ func (d *structDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsaf
 		seenFields   map[int]struct{}
 		seenFieldNum int
 	)
-	firstWin := ctx.Option.FirstWin
+	firstWin := (ctx.Option.Flag & FirstWinOption) != 0
 	if firstWin {
 		seenFields = make(map[int]struct{}, d.fieldUniqueNameNum)
 	}

--- a/internal/decoder/type.go
+++ b/internal/decoder/type.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Decoder interface {
-	Decode([]byte, int64, int64, unsafe.Pointer) (int64, error)
+	Decode(*RuntimeContext, int64, int64, unsafe.Pointer) (int64, error)
 	DecodeStream(*Stream, int64, unsafe.Pointer) error
 }
 

--- a/internal/decoder/uint.go
+++ b/internal/decoder/uint.go
@@ -158,8 +158,8 @@ func (d *uintDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) err
 	return nil
 }
 
-func (d *uintDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	bytes, c, err := d.decodeByte(buf, cursor)
+func (d *uintDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	bytes, c, err := d.decodeByte(ctx.Buf, cursor)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/decoder/unmarshal_json.go
+++ b/internal/decoder/unmarshal_json.go
@@ -53,7 +53,8 @@ func (d *unmarshalJSONDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Poi
 	return nil
 }
 
-func (d *unmarshalJSONDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *unmarshalJSONDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	cursor = skipWhiteSpace(buf, cursor)
 	start := cursor
 	end, err := skipValue(buf, cursor, depth)

--- a/internal/decoder/unmarshal_text.go
+++ b/internal/decoder/unmarshal_text.go
@@ -91,7 +91,8 @@ func (d *unmarshalTextDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Poi
 	return nil
 }
 
-func (d *unmarshalTextDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+func (d *unmarshalTextDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	buf := ctx.Buf
 	cursor = skipWhiteSpace(buf, cursor)
 	start := cursor
 	end, err := skipValue(buf, cursor, depth)

--- a/internal/decoder/wrapped_string.go
+++ b/internal/decoder/wrapped_string.go
@@ -40,14 +40,14 @@ func (d *wrappedStringDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Poi
 	}
 	b := make([]byte, len(bytes)+1)
 	copy(b, bytes)
-	if _, err := d.dec.Decode(b, 0, depth, p); err != nil {
+	if _, err := d.dec.Decode(&RuntimeContext{Buf: b}, 0, depth, p); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (d *wrappedStringDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	bytes, c, err := d.stringDecoder.decodeByte(buf, cursor)
+func (d *wrappedStringDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	bytes, c, err := d.stringDecoder.decodeByte(ctx.Buf, cursor)
 	if err != nil {
 		return 0, err
 	}
@@ -58,7 +58,7 @@ func (d *wrappedStringDecoder) Decode(buf []byte, cursor, depth int64, p unsafe.
 		return c, nil
 	}
 	bytes = append(bytes, nul)
-	if _, err := d.dec.Decode(bytes, 0, depth, p); err != nil {
+	if _, err := d.dec.Decode(ctx, 0, depth, p); err != nil {
 		return 0, err
 	}
 	return c, nil

--- a/internal/decoder/wrapped_string.go
+++ b/internal/decoder/wrapped_string.go
@@ -58,8 +58,11 @@ func (d *wrappedStringDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, 
 		return c, nil
 	}
 	bytes = append(bytes, nul)
+	oldBuf := ctx.Buf
+	ctx.Buf = bytes
 	if _, err := d.dec.Decode(ctx, 0, depth, p); err != nil {
 		return 0, err
 	}
+	ctx.Buf = oldBuf
 	return c, nil
 }

--- a/json.go
+++ b/json.go
@@ -262,8 +262,8 @@ func UnmarshalWithOption(data []byte, v interface{}, optFuncs ...DecodeOptionFun
 	return unmarshal(data, v, optFuncs...)
 }
 
-func UnmarshalNoEscape(data []byte, v interface{}) error {
-	return unmarshalNoEscape(data, v)
+func UnmarshalNoEscape(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
+	return unmarshalNoEscape(data, v, optFuncs...)
 }
 
 // A Token holds a value of one of these types:

--- a/json.go
+++ b/json.go
@@ -258,6 +258,10 @@ func Unmarshal(data []byte, v interface{}) error {
 	return unmarshal(data, v)
 }
 
+func UnmarshalWithOption(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
+	return unmarshal(data, v, optFuncs...)
+}
+
 func UnmarshalNoEscape(data []byte, v interface{}) error {
 	return unmarshalNoEscape(data, v)
 }

--- a/option.go
+++ b/option.go
@@ -8,18 +8,21 @@ import (
 type EncodeOption = encoder.Option
 type EncodeOptionFunc func(*EncodeOption)
 
+// UnorderedMap doesn't sort when encoding map type.
 func UnorderedMap() EncodeOptionFunc {
 	return func(opt *EncodeOption) {
 		opt.Flag |= encoder.UnorderedMapOption
 	}
 }
 
+// Debug outputs debug information when panic occurs during encoding.
 func Debug() EncodeOptionFunc {
 	return func(opt *EncodeOption) {
 		opt.Flag |= encoder.DebugOption
 	}
 }
 
+// Colorize add an identifier for coloring to the string of the encoded result.
 func Colorize(scheme *ColorScheme) EncodeOptionFunc {
 	return func(opt *EncodeOption) {
 		opt.Flag |= encoder.ColorizeOption
@@ -30,6 +33,12 @@ func Colorize(scheme *ColorScheme) EncodeOptionFunc {
 type DecodeOption = decoder.Option
 type DecodeOptionFunc func(*DecodeOption)
 
+// DecodeFieldPriorityFirstWin
+// in the default behavior, go-json, like encoding/json,
+// will reflect the result of the last evaluation when a field with the same name exists.
+// This option allow you to change this behavior.
+// this option reflects the result of the first evaluation if a field with the same name exists.
+// This behavior has a performance advantage as it allows the subsequent strings to be skipped if all fields have been evaluated.
 func DecodeFieldPriorityFirstWin() DecodeOptionFunc {
 	return func(opt *DecodeOption) {
 		opt.Flag |= decoder.FirstWinOption

--- a/option.go
+++ b/option.go
@@ -32,6 +32,6 @@ type DecodeOptionFunc func(*DecodeOption)
 
 func DecodeFieldPriorityFirstWin() DecodeOptionFunc {
 	return func(opt *DecodeOption) {
-		opt.FirstWin = true
+		opt.Flag |= decoder.FirstWinOption
 	}
 }

--- a/option.go
+++ b/option.go
@@ -1,11 +1,11 @@
 package json
 
 import (
+	"github.com/goccy/go-json/internal/decoder"
 	"github.com/goccy/go-json/internal/encoder"
 )
 
 type EncodeOption = encoder.Option
-
 type EncodeOptionFunc func(*EncodeOption)
 
 func UnorderedMap() EncodeOptionFunc {
@@ -24,5 +24,14 @@ func Colorize(scheme *ColorScheme) EncodeOptionFunc {
 	return func(opt *EncodeOption) {
 		opt.Flag |= encoder.ColorizeOption
 		opt.ColorScheme = scheme
+	}
+}
+
+type DecodeOption = decoder.Option
+type DecodeOptionFunc func(*DecodeOption)
+
+func DecodeFieldPriorityFirstWin() DecodeOptionFunc {
+	return func(opt *DecodeOption) {
+		opt.FirstWin = true
 	}
 }


### PR DESCRIPTION
### Summary

In the default behavior, go-json, like `encoding/json`, will reflect the result of the last evaluation when a field with the same name exists. I've added new options to allow you to change this behavior. `json.DecodeFieldPriorityFirstWin` option reflects the result of the first evaluation if a field with the same name exists. This behavior has a performance advantage as it allows the subsequent strings to be skipped if all fields have been evaluated.


### Benchmark

Results

```
goos: darwin
goarch: amd64
pkg: benchmark
Benchmark_Decode_SmallStruct_Unmarshal_EncodingJson-16                            418848              2395 ns/op             400 B/op         10 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_FastJson-16                                720466              1624 ns/op            3376 B/op         11 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_JsonIter-16                               1602945               745 ns/op             208 B/op         13 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJay-16                                  2604565               455 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJayUnsafe-16                            3026695               397 ns/op             112 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_SegmentioJson-16                          1260757               959 ns/op             192 B/op          5 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJson-16                                 2852440               417 ns/op             256 B/op          2 allocs/op
Benchmark_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-16                         3440616               348 ns/op             144 B/op          1 allocs/op
Benchmark_Decode_SmallStruct_Stream_EncodingJson-16                               429216              2710 ns/op            1104 B/op         12 allocs/op
Benchmark_Decode_SmallStruct_Stream_JsonIter-16                                  1236762               969 ns/op             872 B/op         16 allocs/op
Benchmark_Decode_SmallStruct_Stream_GoJay-16                                     2147300               562 ns/op             720 B/op          3 allocs/op
Benchmark_Decode_SmallStruct_Stream_SegmentioJson-16                              208017              5250 ns/op           32960 B/op          6 allocs/op
Benchmark_Decode_SmallStruct_Stream_GoJson-16                                    1919298               613 ns/op             728 B/op          4 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_EncodingJson-16                            79514             14821 ns/op             696 B/op         19 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_FastJson-16                               115572              9728 ns/op           17304 B/op         54 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_JsonIter-16                               214368              5383 ns/op             792 B/op         82 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJay-16                                  361904              3341 ns/op            2449 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJayUnsafe-16                            391798              2793 ns/op             144 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_SegmentioJson-16                          220917              5706 ns/op             296 B/op          9 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJson-16                                 297412              3448 ns/op            2451 B/op          8 allocs/op
Benchmark_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-16                         381306              3220 ns/op            2419 B/op          7 allocs/op
Benchmark_Decode_MediumStruct_Stream_EncodingJson-16                               65142             18784 ns/op            7136 B/op         26 allocs/op
Benchmark_Decode_MediumStruct_Stream_JsonIter-16                                  182212              6607 ns/op            1792 B/op         91 allocs/op
Benchmark_Decode_MediumStruct_Stream_GoJay-16                                     270672              4545 ns/op            7920 B/op         12 allocs/op
Benchmark_Decode_MediumStruct_Stream_SegmentioJson-16                              78078             14739 ns/op           33064 B/op         10 allocs/op
Benchmark_Decode_MediumStruct_Stream_GoJson-16                                    277111              4223 ns/op            3834 B/op         12 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_EncodingJson-16                              5744            204362 ns/op            6240 B/op        191 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_FastJson-16                                  7574            134493 ns/op          283204 B/op        540 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_JsonIter-16                                 10000            102447 ns/op           17179 B/op       1271 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJay-16                                    29066             39675 ns/op           31252 B/op         77 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJayUnsafe-16                              36532             32485 ns/op            2561 B/op         76 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_SegmentioJson-16                            13063             90192 ns/op            4400 B/op        132 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJson-16                                   23830             44974 ns/op           30792 B/op         67 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-16                           26092             45308 ns/op           30759 B/op         66 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonFirstWinMode-16                       27903             38975 ns/op           30792 B/op         67 allocs/op
Benchmark_Decode_LargeStruct_Unmarshal_GoJsonNoEscapeFirstWinMode-16               30661             39387 ns/op           30760 B/op         66 allocs/op
Benchmark_Decode_LargeStruct_Stream_EncodingJson-16                                 4974            229413 ns/op           70016 B/op        201 allocs/op
Benchmark_Decode_LargeStruct_Stream_JsonIter-16                                     9038            110930 ns/op           21320 B/op       1398 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJay-16                                       25328             47193 ns/op           67680 B/op         84 allocs/op
Benchmark_Decode_LargeStruct_Stream_SegmentioJson-16                                7567            152554 ns/op           37168 B/op        133 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJson-16                                      21698             54857 ns/op           34464 B/op         74 allocs/op
Benchmark_Decode_LargeStruct_Stream_GoJsonFirstWinMode-16                          24721             48504 ns/op           34465 B/op         74 allocs/op
Benchmark_Decode_SlowReader_EncodingJson/chunksize_16384-16                         4630            259097 ns/op          114516 B/op        403 allocs/op
Benchmark_Decode_SlowReader_EncodingJson/chunksize_4096-16                          4366            255513 ns/op          110429 B/op        406 allocs/op
Benchmark_Decode_SlowReader_EncodingJson/chunksize_1024-16                          4538            261276 ns/op          110418 B/op        425 allocs/op
Benchmark_Decode_SlowReader_EncodingJson/chunksize_256-16                           4420            268734 ns/op          110428 B/op        507 allocs/op
Benchmark_Decode_SlowReader_EncodingJson/chunksize_64-16                            3378            306652 ns/op          110403 B/op        836 allocs/op
Benchmark_Decode_SlowReader_GoJson/chunksize_16384-16                              13065             93375 ns/op           79034 B/op        276 allocs/op
Benchmark_Decode_SlowReader_GoJson/chunksize_4096-16                               13022             91710 ns/op           79034 B/op        280 allocs/op
Benchmark_Decode_SlowReader_GoJson/chunksize_1024-16                               12795             92556 ns/op           75957 B/op        299 allocs/op
Benchmark_Decode_SlowReader_GoJson/chunksize_256-16                                12289             97962 ns/op           75011 B/op        381 allocs/op
Benchmark_Decode_SlowReader_GoJson/chunksize_64-16                                 10000            117662 ns/op           74938 B/op        711 allocs/op
```