### PR TITLE
Support context for MarshalJSON and UnmarshalJSON

### DIFF
--- a/internal/decoder/compile.go
+++ b/internal/decoder/compile.go
@@ -60,7 +60,7 @@ func compileToGetDecoderSlowPath(typeptr uintptr, typ *runtime.Type) (Decoder, e
 
 func compileHead(typ *runtime.Type, structTypeToDecoder map[uintptr]Decoder) (Decoder, error) {
 	switch {
-	case runtime.PtrTo(typ).Implements(unmarshalJSONType):
+	case implementsUnmarshalJSONType(runtime.PtrTo(typ)):
 		return newUnmarshalJSONDecoder(runtime.PtrTo(typ), "", ""), nil
 	case runtime.PtrTo(typ).Implements(unmarshalTextType):
 		return newUnmarshalTextDecoder(runtime.PtrTo(typ), "", ""), nil
@@ -70,7 +70,7 @@ func compileHead(typ *runtime.Type, structTypeToDecoder map[uintptr]Decoder) (De
 
 func compile(typ *runtime.Type, structName, fieldName string, structTypeToDecoder map[uintptr]Decoder) (Decoder, error) {
 	switch {
-	case runtime.PtrTo(typ).Implements(unmarshalJSONType):
+	case implementsUnmarshalJSONType(runtime.PtrTo(typ)):
 		return newUnmarshalJSONDecoder(runtime.PtrTo(typ), structName, fieldName), nil
 	case runtime.PtrTo(typ).Implements(unmarshalTextType):
 		return newUnmarshalTextDecoder(runtime.PtrTo(typ), structName, fieldName), nil
@@ -133,7 +133,7 @@ func compile(typ *runtime.Type, structName, fieldName string, structTypeToDecode
 
 func isStringTagSupportedType(typ *runtime.Type) bool {
 	switch {
-	case runtime.PtrTo(typ).Implements(unmarshalJSONType):
+	case implementsUnmarshalJSONType(runtime.PtrTo(typ)):
 		return false
 	case runtime.PtrTo(typ).Implements(unmarshalTextType):
 		return false
@@ -493,4 +493,8 @@ func compileStruct(typ *runtime.Type, structName, fieldName string, structTypeTo
 	delete(structTypeToDecoder, typeptr)
 	structDec.tryOptimize()
 	return structDec, nil
+}
+
+func implementsUnmarshalJSONType(typ *runtime.Type) bool {
+	return typ.Implements(unmarshalJSONType) || typ.Implements(unmarshalJSONContextType)
 }

--- a/internal/decoder/option.go
+++ b/internal/decoder/option.go
@@ -1,11 +1,15 @@
 package decoder
 
-type OptionFlag int
+import "context"
+
+type OptionFlags uint8
 
 const (
-	FirstWinOption OptionFlag = 1 << iota
+	FirstWinOption OptionFlags = 1 << iota
+	ContextOption
 )
 
 type Option struct {
-	Flag OptionFlag
+	Flags   OptionFlags
+	Context context.Context
 }

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -665,7 +665,7 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 		seenFields   map[int]struct{}
 		seenFieldNum int
 	)
-	firstWin := (s.Option.Flag & FirstWinOption) != 0
+	firstWin := (s.Option.Flags & FirstWinOption) != 0
 	if firstWin {
 		seenFields = make(map[int]struct{}, d.fieldUniqueNameNum)
 	}
@@ -752,7 +752,7 @@ func (d *structDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsaf
 		seenFields   map[int]struct{}
 		seenFieldNum int
 	)
-	firstWin := (ctx.Option.Flag & FirstWinOption) != 0
+	firstWin := (ctx.Option.Flags & FirstWinOption) != 0
 	if firstWin {
 		seenFields = make(map[int]struct{}, d.fieldUniqueNameNum)
 	}

--- a/internal/decoder/type.go
+++ b/internal/decoder/type.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"encoding"
 	"encoding/json"
 	"reflect"
@@ -17,7 +18,12 @@ const (
 	maxDecodeNestingDepth = 10000
 )
 
+type unmarshalerContext interface {
+	UnmarshalJSON(context.Context, []byte) error
+}
+
 var (
-	unmarshalJSONType = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
-	unmarshalTextType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	unmarshalJSONType        = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+	unmarshalJSONContextType = reflect.TypeOf((*unmarshalerContext)(nil)).Elem()
+	unmarshalTextType        = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 )

--- a/internal/decoder/unmarshal_json.go
+++ b/internal/decoder/unmarshal_json.go
@@ -46,9 +46,16 @@ func (d *unmarshalJSONDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Poi
 		typ: d.typ,
 		ptr: p,
 	}))
-	if err := v.(json.Unmarshaler).UnmarshalJSON(dst); err != nil {
-		d.annotateError(s.cursor, err)
-		return err
+	if (s.Option.Flags & ContextOption) != 0 {
+		if err := v.(unmarshalerContext).UnmarshalJSON(s.Option.Context, dst); err != nil {
+			d.annotateError(s.cursor, err)
+			return err
+		}
+	} else {
+		if err := v.(json.Unmarshaler).UnmarshalJSON(dst); err != nil {
+			d.annotateError(s.cursor, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -69,9 +76,16 @@ func (d *unmarshalJSONDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, 
 		typ: d.typ,
 		ptr: p,
 	}))
-	if err := v.(json.Unmarshaler).UnmarshalJSON(dst); err != nil {
-		d.annotateError(cursor, err)
-		return 0, err
+	if (ctx.Option.Flags & ContextOption) != 0 {
+		if err := v.(unmarshalerContext).UnmarshalJSON(ctx.Option.Context, dst); err != nil {
+			d.annotateError(cursor, err)
+			return 0, err
+		}
+	} else {
+		if err := v.(json.Unmarshaler).UnmarshalJSON(dst); err != nil {
+			d.annotateError(cursor, err)
+			return 0, err
+		}
 	}
 	return end, nil
 }

--- a/internal/encoder/context.go
+++ b/internal/encoder/context.go
@@ -1,6 +1,7 @@
 package encoder
 
 import (
+	"context"
 	"sync"
 	"unsafe"
 
@@ -104,6 +105,7 @@ var (
 )
 
 type RuntimeContext struct {
+	Context    context.Context
 	Buf        []byte
 	MarshalBuf []byte
 	Ptrs       []uintptr

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -365,13 +365,27 @@ func AppendMarshalJSON(ctx *RuntimeContext, code *Opcode, b []byte, v interface{
 		}
 	}
 	v = rv.Interface()
-	marshaler, ok := v.(json.Marshaler)
-	if !ok {
-		return AppendNull(ctx, b), nil
-	}
-	bb, err := marshaler.MarshalJSON()
-	if err != nil {
-		return nil, &errors.MarshalerError{Type: reflect.TypeOf(v), Err: err}
+	var bb []byte
+	if (code.Flags & MarshalerContextFlags) != 0 {
+		marshaler, ok := v.(marshalerContext)
+		if !ok {
+			return AppendNull(ctx, b), nil
+		}
+		b, err := marshaler.MarshalJSON(ctx.Option.Context)
+		if err != nil {
+			return nil, &errors.MarshalerError{Type: reflect.TypeOf(v), Err: err}
+		}
+		bb = b
+	} else {
+		marshaler, ok := v.(json.Marshaler)
+		if !ok {
+			return AppendNull(ctx, b), nil
+		}
+		b, err := marshaler.MarshalJSON()
+		if err != nil {
+			return nil, &errors.MarshalerError{Type: reflect.TypeOf(v), Err: err}
+		}
+		bb = b
 	}
 	marshalBuf := ctx.MarshalBuf[:0]
 	marshalBuf = append(append(marshalBuf, bb...), nul)
@@ -395,13 +409,27 @@ func AppendMarshalJSONIndent(ctx *RuntimeContext, code *Opcode, b []byte, v inte
 		}
 	}
 	v = rv.Interface()
-	marshaler, ok := v.(json.Marshaler)
-	if !ok {
-		return AppendNull(ctx, b), nil
-	}
-	bb, err := marshaler.MarshalJSON()
-	if err != nil {
-		return nil, &errors.MarshalerError{Type: reflect.TypeOf(v), Err: err}
+	var bb []byte
+	if (code.Flags & MarshalerContextFlags) != 0 {
+		marshaler, ok := v.(marshalerContext)
+		if !ok {
+			return AppendNull(ctx, b), nil
+		}
+		b, err := marshaler.MarshalJSON(ctx.Option.Context)
+		if err != nil {
+			return nil, &errors.MarshalerError{Type: reflect.TypeOf(v), Err: err}
+		}
+		bb = b
+	} else {
+		marshaler, ok := v.(json.Marshaler)
+		if !ok {
+			return AppendNull(ctx, b), nil
+		}
+		b, err := marshaler.MarshalJSON()
+		if err != nil {
+			return nil, &errors.MarshalerError{Type: reflect.TypeOf(v), Err: err}
+		}
+		bb = b
 	}
 	marshalBuf := ctx.MarshalBuf[:0]
 	marshalBuf = append(append(marshalBuf, bb...), nul)

--- a/internal/encoder/opcode.go
+++ b/internal/encoder/opcode.go
@@ -10,7 +10,7 @@ import (
 
 const uintptrSize = 4 << (^uintptr(0) >> 63)
 
-type OpFlags uint8
+type OpFlags uint16
 
 const (
 	AnonymousHeadFlags    OpFlags = 1 << 0
@@ -21,6 +21,7 @@ const (
 	AddrForMarshalerFlags OpFlags = 1 << 5
 	IsNextOpPtrTypeFlags  OpFlags = 1 << 6
 	IsNilableTypeFlags    OpFlags = 1 << 7
+	MarshalerContextFlags OpFlags = 1 << 8
 )
 
 type Opcode struct {
@@ -32,9 +33,8 @@ type Opcode struct {
 	Key        string  // struct field key
 	Offset     uint32  // offset size from struct header
 	PtrNum     uint8   // pointer number: e.g. double pointer is 2.
-	Flags      OpFlags
 	NumBitSize uint8
-	_          [1]uint8 // 1
+	Flags      OpFlags
 
 	Type       *runtime.Type // go type
 	PrevField  *Opcode       // prev struct field

--- a/internal/encoder/option.go
+++ b/internal/encoder/option.go
@@ -1,5 +1,7 @@
 package encoder
 
+import "context"
+
 type OptionFlag uint8
 
 const (
@@ -8,11 +10,13 @@ const (
 	UnorderedMapOption
 	DebugOption
 	ColorizeOption
+	ContextOption
 )
 
 type Option struct {
 	Flag        OptionFlag
 	ColorScheme *ColorScheme
+	Context     context.Context
 }
 
 type EncodeFormat struct {

--- a/json.go
+++ b/json.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	"github.com/goccy/go-json/internal/encoder"
@@ -11,6 +12,12 @@ import (
 // can marshal themselves into valid JSON.
 type Marshaler interface {
 	MarshalJSON() ([]byte, error)
+}
+
+// MarshalerContext is the interface implemented by types that
+// can marshal themselves into valid JSON with context.Context.
+type MarshalerContext interface {
+	MarshalJSON(context.Context) ([]byte, error)
 }
 
 // Unmarshaler is the interface implemented by types
@@ -23,6 +30,12 @@ type Marshaler interface {
 // Unmarshalers implement UnmarshalJSON([]byte("null")) as a no-op.
 type Unmarshaler interface {
 	UnmarshalJSON([]byte) error
+}
+
+// UnmarshalerContext is the interface implemented by types
+// that can unmarshal with context.Context a JSON description of themselves.
+type UnmarshalerContext interface {
+	UnmarshalJSON(context.Context, []byte) error
 }
 
 // Marshal returns the JSON encoding of v.
@@ -158,9 +171,14 @@ func Marshal(v interface{}) ([]byte, error) {
 	return MarshalWithOption(v)
 }
 
-// MarshalNoEscape
+// MarshalNoEscape returns the JSON encoding of v and doesn't escape v.
 func MarshalNoEscape(v interface{}) ([]byte, error) {
 	return marshalNoEscape(v)
+}
+
+// MarshalContext returns the JSON encoding of v with context.Context and EncodeOption.
+func MarshalContext(ctx context.Context, v interface{}, optFuncs ...EncodeOptionFunc) ([]byte, error) {
+	return marshalContext(ctx, v, optFuncs...)
 }
 
 // MarshalWithOption returns the JSON encoding of v with EncodeOption.
@@ -256,6 +274,13 @@ func MarshalIndentWithOption(v interface{}, prefix, indent string, optFuncs ...E
 //
 func Unmarshal(data []byte, v interface{}) error {
 	return unmarshal(data, v)
+}
+
+// UnmarshalContext parses the JSON-encoded data and stores the result
+// in the value pointed to by v. If you implement the UnmarshalerContext interface,
+// call it with ctx as an argument.
+func UnmarshalContext(ctx context.Context, data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
+	return unmarshalContext(ctx, data, v)
 }
 
 func UnmarshalWithOption(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {

--- a/option.go
+++ b/option.go
@@ -41,6 +41,6 @@ type DecodeOptionFunc func(*DecodeOption)
 // This behavior has a performance advantage as it allows the subsequent strings to be skipped if all fields have been evaluated.
 func DecodeFieldPriorityFirstWin() DecodeOptionFunc {
 	return func(opt *DecodeOption) {
-		opt.Flag |= decoder.FirstWinOption
+		opt.Flags |= decoder.FirstWinOption
 	}
 }


### PR DESCRIPTION
## `context.Context` support for `Marshaler` and `Unmarshaler` 

-  `json.MarshalContext(context.Context, interface{}, ...json.EncodeOption) ([]byte, error)`
- `json.NewEncoder(io.Writer).EncodeContext(context.Context, interface{}, ...json.EncodeOption) error`
- `json.UnmarshalContext(context.Context, []byte, interface{}, ...json.DecodeOption) error`
- `json.NewDecoder(io.Reader).DecodeContext(context.Context, interface{}) error`

Then, if we implemented the following interface, callback it.

```go
type MarshalerContext interface {
  MarshalJSON(context.Context) ([]byte, error)
}

type UnmarshalerContext interface {
  UnmarshalJSON(context.Context, []byte) error
}
```

### Why

I thought there were situations in `MarshalJSON` and `UnmashalJSON` where I wanted to use `context.Context` .

For example, we consider the situation that in MarshalJSON, you want to access external middleware, get the data, and then encode it. At this time, `context.Context` may be required when accessing middleware, we want to use the `context.Context` not created inside `MarshalJSON` but used by the caller of `json.Marshal()`. 
I show this situation's sample code the following:

```go

type User struct {
  ID int64
  Name string
  UserAddress UserAddressResolver
}

type UserAddressResolver func(ctx context.Context) (*UserAddress, error)
func (r UserAddressResolver) MarshalJSON() ([]byte, error) {
  ctx := context.Background() // we want to use parent context.Context but we can't get it.
  address, err := r(ctx) // fetch UserAddress data from external middleware
  if err != nil {
    return nil, err
  }
  return json.Marshal(address)
}

type UserAddress struct {
  ID int64
  UserID int64
  PostCode string
  Address string
}

u := &User{ID: 1, Name: "alice"}
u.UserAddress = func(ctx context.Context) (*UserAddress, error) {
  return db.FindUserAddressByUserID(ctx, u.ID)
}

json.Marshal(u)
```

In this case, there is no way to pass context.Context to MarshalJSON , so I think that an approach like json.MarshalContext is necessary.