### PR TITLE
Fix MarshalIndent

### DIFF
--- a/internal/cmd/generator/vm.go.tmpl
+++ b/internal/cmd/generator/vm.go.tmpl
@@ -484,7 +484,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent
+			indentDiffFromTop := c.Indent - 1
+			ctx.BaseIndent += code.Indent - indentDiffFromTop
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/cmd/generator/vm.go.tmpl
+++ b/internal/cmd/generator/vm.go.tmpl
@@ -484,7 +484,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent - 1
+			ctx.BaseIndent += code.Indent
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -269,8 +269,8 @@ func linkRecursiveCode(c *Opcode) {
 			lastCode.Length = lastCode.Idx + 2*uintptrSize
 
 			// extend length to alloc slot for elemIdx + length
-			totalLength := uintptr(code.TotalLength() + 2)
-			nextTotalLength := uintptr(c.TotalLength() + 2)
+			totalLength := uintptr(code.TotalLength() + 3)
+			nextTotalLength := uintptr(c.TotalLength() + 3)
 
 			c.End.Next.Op = OpRecursiveEnd
 

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -484,7 +484,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent
+			indentDiffFromTop := c.Indent - 1
+			ctx.BaseIndent += code.Indent - indentDiffFromTop
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -484,7 +484,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent - 1
+			ctx.BaseIndent += code.Indent
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm_color/vm.go
+++ b/internal/encoder/vm_color/vm.go
@@ -484,7 +484,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent
+			indentDiffFromTop := c.Indent - 1
+			ctx.BaseIndent += code.Indent - indentDiffFromTop
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm_color/vm.go
+++ b/internal/encoder/vm_color/vm.go
@@ -484,7 +484,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent - 1
+			ctx.BaseIndent += code.Indent
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm_color_indent/vm.go
+++ b/internal/encoder/vm_color_indent/vm.go
@@ -484,7 +484,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent
+			indentDiffFromTop := c.Indent - 1
+			ctx.BaseIndent += code.Indent - indentDiffFromTop
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm_color_indent/vm.go
+++ b/internal/encoder/vm_color_indent/vm.go
@@ -484,7 +484,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent - 1
+			ctx.BaseIndent += code.Indent
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -484,7 +484,8 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent
+			indentDiffFromTop := c.Indent - 1
+			ctx.BaseIndent += code.Indent - indentDiffFromTop
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -484,7 +484,7 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 			oldOffset := ptrOffset
 			ptrOffset += code.Jmp.CurLen * uintptrSize
 			oldBaseIndent := ctx.BaseIndent
-			ctx.BaseIndent += code.Indent - 1
+			ctx.BaseIndent += code.Indent
 
 			newLen := offsetNum + code.Jmp.CurLen + code.Jmp.NextLen
 			if curlen < newLen {


### PR DESCRIPTION
fix #247 

fix indent number and totalLength for recursive type .

### Benchmark result

After fixed, I tried to run benchmark was introduced in #247 

```
goos: darwin
goarch: amd64
pkg: benchmark
BenchmarkMarshalIndentEncodingJson-16         24284             48370 ns/op          105041 B/op         25 allocs/op
BenchmarkMarshalIndentGoJson-16              120224              9335 ns/op           22512 B/op         22 allocs/op
```