### PR TITLE
Fix decoding of []byte type

### DIFF
--- a/internal/decoder/bytes.go
+++ b/internal/decoder/bytes.go
@@ -49,10 +49,11 @@ func (d *bytesDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) er
 	}
 	decodedLen := base64.StdEncoding.DecodedLen(len(bytes))
 	buf := make([]byte, decodedLen)
-	if _, err := base64.StdEncoding.Decode(buf, bytes); err != nil {
+	n, err := base64.StdEncoding.Decode(buf, bytes)
+	if err != nil {
 		return err
 	}
-	*(*[]byte)(p) = buf
+	*(*[]byte)(p) = buf[:n]
 	s.reset()
 	return nil
 }


### PR DESCRIPTION
This is very similar to the fix here: https://github.com/goccy/go-json/commit/862884892441f97c34544557b3804e9b3061c7b1

Although the earlier fix applies for Unmarshal, it doesn't fix the case where a user uses NewDecoder(r).Decode(&res)

Here's a sample test that fails
```
package json

import (
	"bytes"
	"encoding/json"
	"strings"
	"testing"

	goccy "github.com/goccy/go-json"
	"github.com/stretchr/testify/assert"
)

type structure struct {
	InnerBytes []byte `json:"inner_bytes"`
}

func Test_json_decode(t *testing.T) {
	rawData := `{"inner_bytes":"bG93ZXI="}`
	var resNative structure
	var resGoccy structure
	json.NewDecoder(bytes.NewBufferString(rawData)).Decode(&resNative)
	goccy.NewDecoder(bytes.NewBufferString(rawData)).Decode(&resGoccy)
	assert.Equal(t, []byte("lower"), resNative.InnerBytes)
	assert.Equal(t, []byte("lower"), resGoccy.InnerBytes)
}
```