### PR TITLE
Fix mapassign_faststr for indirect struct type

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -3732,3 +3732,46 @@ func TestDecodeBinaryTypeWithEscapedChar(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue282(t *testing.T) {
+	var J = []byte(`{
+  "a": {},
+  "b": {},
+  "c": {},
+  "d": {},
+  "e": {},
+  "f": {},
+  "g": {},
+  "h": {
+    "m": "1"
+  },
+  "i": {}
+}`)
+
+	type T4 struct {
+		F0 string
+		F1 string
+		F2 string
+		F3 string
+		F4 string
+		F5 string
+		F6 int
+	}
+	type T3 struct {
+		F0 string
+		F1 T4
+	}
+	type T2 struct {
+		F0 string `json:"m"`
+		F1 T3
+	}
+	type T0 map[string]T2
+
+	var v T0
+	if err := json.Unmarshal(J, &v); err != nil {
+		t.Fatal(err)
+	}
+	if v["h"].F0 != "1" {
+		t.Fatalf("failed to assign map value")
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -3767,6 +3767,7 @@ func TestIssue282(t *testing.T) {
 	}
 	type T0 map[string]T2
 
+	// T2 size is 136 bytes. This is indirect type.
 	var v T0
 	if err := json.Unmarshal(J, &v); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
fix #282


### Similar correspondence

https://github.com/qyl2021/go-ugorji-go is corresponded similar problem .
This project says indirect element is decided by element size ( whether more than 128 bytes or not ), and only support map_fastxxx APIs at not indirect element case ( element size is 128 bytes or less  )

- https://github.com/qyl2021/go-ugorji-go/blob/5b6462b505850ae23ec0444474b85541c85514f6/codec/helper_unsafe_compiler_gc.go#L56-L87
- https://github.com/qyl2021/go-ugorji-go/blob/5b6462b505850ae23ec0444474b85541c85514f6/codec/helper_unsafe_compiler_gc.go#L34-L42


`maxKeySize` and` maxElemSize` are also defined in the latest source code.
https://github.com/golang/go/blob/7622e41c84fd9bb003a2d905b9f0545344842c3a/src/runtime/map.go#L74-L79