### PR TITLE
Fix encoding of empty struct interface type

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -2134,3 +2134,17 @@ func TestImplementedMethodInterfaceType(t *testing.T) {
 		t.Fatalf("failed to encode implemented method interface type. expected:[%q] but got:[%q]", expected, got)
 	}
 }
+
+func TestEmptyStructInterface(t *testing.T) {
+	expected, err := stdjson.Marshal([]interface{}{struct{}{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := json.Marshal([]interface{}{struct{}{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(expected, got) {
+		t.Fatalf("failed to encode empty struct interface. expected:[%q] but got:[%q]", expected, got)
+	}
+}

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -1506,7 +1506,6 @@ func compileStruct(ctx *compileContext, isPtr bool) (*Opcode, error) {
 
 	structEndCode := &Opcode{
 		Op:     OpStructEnd,
-		Next:   newEndOp(ctx),
 		Type:   nil,
 		Indent: ctx.indent,
 	}
@@ -1531,6 +1530,7 @@ func compileStruct(ctx *compileContext, isPtr bool) (*Opcode, error) {
 	structEndCode.DisplayIdx = ctx.opcodeIndex
 	structEndCode.Idx = opcodeOffset(ctx.ptrIndex)
 	ctx.incIndex()
+	structEndCode.Next = newEndOp(ctx)
 
 	if prevField != nil && prevField.NextField == nil {
 		prevField.NextField = structEndCode


### PR DESCRIPTION
fix #285 

If encodes of empty struct value from interface type, go-json's compiler produces `OpStructHead - OpStructEnd - OpInterfaceEnd` operations. In this case, OpStructHead's next operation ( `OpStructEnd` ) 's index is equal `OpInterfaceEnd`'s index. So, when vm evaluated OpStructHead operation, stored value was overwritten.
Therefore, I fixed this behavior by added index number for `OpStructEnd` 's next operation .