### PR TITLE
Fix stream decoding with error

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -200,6 +200,7 @@ func (d *Decoder) DecodeWithOption(v interface{}, optFuncs ...DecodeOptionFunc) 
 		optFunc(s.Option)
 	}
 	if err := dec.DecodeStream(s, 0, header.ptr); err != nil {
+		d.s.SkipErrorValue()
 		return err
 	}
 	s.Reset()

--- a/decode_test.go
+++ b/decode_test.go
@@ -3776,3 +3776,18 @@ func TestIssue282(t *testing.T) {
 		t.Fatalf("failed to assign map value")
 	}
 }
+
+func TestDecodeStreamWithError(t *testing.T) {
+	type Test struct {
+		Val int `json:"val"`
+	}
+	p := Test{}
+	dec := json.NewDecoder(strings.NewReader("[12,{\"val\" : 2}]"))
+	dec.Token()
+	for dec.More() {
+		_ = dec.Decode(&p) // ignore error value
+	}
+	if p.Val != 2 {
+		t.Fatal("failed to decode")
+	}
+}

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -369,6 +369,10 @@ func (s *Stream) skipArray(depth int64) error {
 	}
 }
 
+func (s *Stream) SkipErrorValue() {
+	_ = s.skipValue(0)
+}
+
 func (s *Stream) skipValue(depth int64) error {
 	_, cursor, p := s.stat()
 	for {


### PR DESCRIPTION
fix #296 
If error occurred when decoding, decoder progress the cursor position to the end of value.