### PR TITLE
feat: improve performance when a payload contains escape sequence

### DIFF
--- a/benchmarks/decode_test.go
+++ b/benchmarks/decode_test.go
@@ -477,3 +477,13 @@ func Benchmark_Decode_LargeStruct_Stream_GoJsonFirstWinMode(b *testing.B) {
 		}
 	}
 }
+
+func Benchmark_Decode_LargeSlice_EscapedString_GoJson(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var v []string
+		if err := gojson.Unmarshal(LargeSliceEscapedString, &v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/benchmarks/large_payload.go
+++ b/benchmarks/large_payload.go
@@ -2,6 +2,7 @@ package benchmark
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/francoispqt/gojay"
 )
@@ -208,3 +209,5 @@ func NewLargePayloadEasyJson() *LargePayloadEasyJson {
 		},
 	}
 }
+
+var LargeSliceEscapedString = []byte("[" + strings.Repeat(",\"simple plain text\\r\\n\"", 10000)[1:] + "]")


### PR DESCRIPTION
close #333 

```
name                                                        old time/op    new time/op    delta
_Decode_LargeSlice_EscapedString_GoJson-8                     38.8ms ± 1%     1.1ms ± 6%  -97.04%  (p=0.000 n=8+10)
```

```
name                                                        old time/op    new time/op    delta
_Decode_SmallStruct_Unmarshal_GoJson-8                         393ns ± 4%     399ns ± 1%     ~     (p=0.128 n=10+10)
_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-8                 329ns ± 3%     340ns ± 6%   +3.34%  (p=0.008 n=9+9)
_Decode_SmallStruct_Stream_GoJson-8                            685ns ± 2%     680ns ± 3%     ~     (p=0.780 n=9+10)
_Decode_MediumStruct_Unmarshal_GoJson-8                       2.99µs ± 6%    3.07µs ± 5%   +2.80%  (p=0.035 n=10+9)
_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-8               2.91µs ± 7%    2.92µs ± 5%     ~     (p=0.684 n=10+10)
_Decode_MediumStruct_Stream_GoJson-8                          4.65µs ± 4%    4.39µs ± 1%   -5.51%  (p=0.000 n=10+8)
_Decode_LargeStruct_Unmarshal_GoJson-8                        41.2µs ± 5%    43.1µs ± 7%   +4.69%  (p=0.001 n=9+10)
_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-8                41.6µs ± 4%    41.3µs ± 3%     ~     (p=0.780 n=10+9)
_Decode_LargeStruct_Unmarshal_GoJsonFirstWinMode-8            38.3µs ± 9%    38.8µs ± 8%     ~     (p=0.280 n=10+10)
_Decode_LargeStruct_Unmarshal_GoJsonNoEscapeFirstWinMode-8    37.8µs ± 3%    39.0µs ± 1%   +3.08%  (p=0.002 n=10+8)
_Decode_LargeStruct_Stream_GoJson-8                           57.9µs ± 6%    57.2µs ± 4%     ~     (p=0.353 n=10+10)
_Decode_LargeStruct_Stream_GoJsonFirstWinMode-8               56.2µs ± 5%    57.0µs ± 6%     ~     (p=0.529 n=10+10)
_Decode_LargeSlice_EscapedString_GoJson-8                     38.8ms ± 1%     1.1ms ± 6%  -97.04%  (p=0.000 n=8+10)
_Decode_SlowReader_GoJson/chunksize_16384-8                   80.5µs ± 1%    85.4µs ± 6%   +6.10%  (p=0.000 n=9+10)
_Decode_SlowReader_GoJson/chunksize_4096-8                    84.4µs ± 4%    81.3µs ± 1%   -3.72%  (p=0.003 n=10+9)
_Decode_SlowReader_GoJson/chunksize_1024-8                    83.3µs ± 5%    83.8µs ± 6%     ~     (p=0.720 n=9+10)
_Decode_SlowReader_GoJson/chunksize_256-8                     94.2µs ± 7%    88.0µs ± 3%   -6.49%  (p=0.000 n=9+9)
_Decode_SlowReader_GoJson/chunksize_64-8                       114µs ± 2%     107µs ± 3%   -5.90%  (p=0.000 n=9+10)

name                                                        old alloc/op   new alloc/op   delta
_Decode_SmallStruct_Unmarshal_GoJson-8                          256B ± 0%      256B ± 0%     ~     (all equal)
_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-8                  144B ± 0%      144B ± 0%     ~     (all equal)
_Decode_SmallStruct_Stream_GoJson-8                             744B ± 0%      744B ± 0%     ~     (all equal)
_Decode_MediumStruct_Unmarshal_GoJson-8                       2.42kB ± 0%    2.42kB ± 0%     ~     (all equal)
_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-8               2.40kB ± 0%    2.40kB ± 0%     ~     (all equal)
_Decode_MediumStruct_Stream_GoJson-8                          3.83kB ± 0%    3.83kB ± 0%     ~     (all equal)
_Decode_LargeStruct_Unmarshal_GoJson-8                        30.5kB ± 0%    30.5kB ± 0%   +0.00%  (p=0.043 n=10+9)
_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-8                30.5kB ± 0%    30.5kB ± 0%     ~     (p=0.294 n=10+8)
_Decode_LargeStruct_Unmarshal_GoJsonFirstWinMode-8            30.5kB ± 0%    30.5kB ± 0%     ~     (p=0.087 n=10+10)
_Decode_LargeStruct_Unmarshal_GoJsonNoEscapeFirstWinMode-8    30.5kB ± 0%    30.5kB ± 0%     ~     (all equal)
_Decode_LargeStruct_Stream_GoJson-8                           34.2kB ± 0%    34.2kB ± 0%     ~     (p=0.363 n=10+10)
_Decode_LargeStruct_Stream_GoJsonFirstWinMode-8               34.2kB ± 0%    34.2kB ± 0%   +0.00%  (p=0.023 n=8+10)
_Decode_LargeSlice_EscapedString_GoJson-8                      598kB ± 5%     601kB ± 1%     ~     (p=0.468 n=10+10)
_Decode_SlowReader_GoJson/chunksize_16384-8                   76.2kB ± 0%    76.2kB ± 0%     ~     (p=0.551 n=10+10)
_Decode_SlowReader_GoJson/chunksize_4096-8                    76.2kB ± 0%    76.2kB ± 0%   -0.00%  (p=0.036 n=10+8)
_Decode_SlowReader_GoJson/chunksize_1024-8                    73.2kB ± 0%    73.2kB ± 0%     ~     (p=0.285 n=10+10)
_Decode_SlowReader_GoJson/chunksize_256-8                     72.2kB ± 0%    72.2kB ± 0%     ~     (p=0.456 n=10+9)
_Decode_SlowReader_GoJson/chunksize_64-8                      72.1kB ± 0%    72.1kB ± 0%     ~     (p=0.080 n=9+10)

name                                                        old allocs/op  new allocs/op  delta
_Decode_SmallStruct_Unmarshal_GoJson-8                          2.00 ± 0%      2.00 ± 0%     ~     (all equal)
_Decode_SmallStruct_Unmarshal_GoJsonNoEscape-8                  1.00 ± 0%      1.00 ± 0%     ~     (all equal)
_Decode_SmallStruct_Stream_GoJson-8                             4.00 ± 0%      4.00 ± 0%     ~     (all equal)
_Decode_MediumStruct_Unmarshal_GoJson-8                         8.00 ± 0%      8.00 ± 0%     ~     (all equal)
_Decode_MediumStruct_Unmarshal_GoJsonNoEscape-8                 7.00 ± 0%      7.00 ± 0%     ~     (all equal)
_Decode_MediumStruct_Stream_GoJson-8                            12.0 ± 0%      12.0 ± 0%     ~     (all equal)
_Decode_LargeStruct_Unmarshal_GoJson-8                          67.0 ± 0%      67.0 ± 0%     ~     (all equal)
_Decode_LargeStruct_Unmarshal_GoJsonNoEscape-8                  66.0 ± 0%      66.0 ± 0%     ~     (all equal)
_Decode_LargeStruct_Unmarshal_GoJsonFirstWinMode-8              67.0 ± 0%      67.0 ± 0%     ~     (all equal)
_Decode_LargeStruct_Unmarshal_GoJsonNoEscapeFirstWinMode-8      66.0 ± 0%      66.0 ± 0%     ~     (all equal)
_Decode_LargeStruct_Stream_GoJson-8                             74.0 ± 0%      74.0 ± 0%     ~     (all equal)
_Decode_LargeStruct_Stream_GoJsonFirstWinMode-8                 74.0 ± 0%      74.0 ± 0%     ~     (all equal)
_Decode_LargeSlice_EscapedString_GoJson-8                      10.0k ± 0%     10.0k ± 0%     ~     (p=0.809 n=10+10)
_Decode_SlowReader_GoJson/chunksize_16384-8                     90.0 ± 0%      90.0 ± 0%     ~     (all equal)
_Decode_SlowReader_GoJson/chunksize_4096-8                      94.0 ± 0%      94.0 ± 0%     ~     (all equal)
_Decode_SlowReader_GoJson/chunksize_1024-8                       113 ± 0%       113 ± 0%     ~     (all equal)
_Decode_SlowReader_GoJson/chunksize_256-8                        195 ± 0%       195 ± 0%     ~     (all equal)
_Decode_SlowReader_GoJson/chunksize_64-8                         525 ± 0%       525 ± 0%     ~     (all equal)
```