### PR TITLE
feat: improves escapeString's performance

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -3859,3 +3859,22 @@ func TestIssue337(t *testing.T) {
 		t.Fatal("unexpected result", m)
 	}
 }
+
+func Benchmark306(b *testing.B) {
+	type T0 struct {
+		Str string
+	}
+	in := []byte(`{"Str":"` + strings.Repeat(`abcd\"`, 10000) + `"}`)
+	b.Run("stdjson", func(b *testing.B) {
+		var x T0
+		for i := 0; i < b.N; i++ {
+			stdjson.Unmarshal(in, &x)
+		}
+	})
+	b.Run("go-json", func(b *testing.B) {
+		var x T0
+		for i := 0; i < b.N; i++ {
+			json.Unmarshal(in, &x)
+		}
+	})
+}


### PR DESCRIPTION
fix #306 

```
name           old time/op  new time/op  delta
306/stdjson-8   314µs ± 0%   312µs ± 1%   -0.61%  (p=0.000 n=10+8)
306/go-json-8  3.36ms ± 1%  0.12ms ± 0%  -96.50%  (p=0.000 n=10+8)
```