### PR TITLE
fix: to safe when got unexpected typeptr

### DIFF
--- a/internal/encoder/compiler_norace.go
+++ b/internal/encoder/compiler_norace.go
@@ -4,7 +4,7 @@
 package encoder
 
 func CompileToGetCodeSet(ctx *RuntimeContext, typeptr uintptr) (*OpcodeSet, error) {
-	if typeptr > typeAddr.MaxTypeAddr {
+	if typeptr > typeAddr.MaxTypeAddr || typeptr < typeAddr.BaseTypeAddr {
 		return compileToGetCodeSetSlowPath(typeptr)
 	}
 	index := (typeptr - typeAddr.BaseTypeAddr) >> typeAddr.AddrShift

--- a/internal/encoder/compiler_race.go
+++ b/internal/encoder/compiler_race.go
@@ -10,7 +10,7 @@ import (
 var setsMu sync.RWMutex
 
 func CompileToGetCodeSet(ctx *RuntimeContext, typeptr uintptr) (*OpcodeSet, error) {
-	if typeptr > typeAddr.MaxTypeAddr {
+	if typeptr > typeAddr.MaxTypeAddr || typeptr < typeAddr.BaseTypeAddr {
 		return compileToGetCodeSetSlowPath(typeptr)
 	}
 	index := (typeptr - typeAddr.BaseTypeAddr) >> typeAddr.AddrShift


### PR DESCRIPTION
~This patch is a workaround of #350~

EDIT:
This was not a workaround, it is a solution.
fix #350 