### PR TITLE
fix stream tokenizing respecting UseNumber

### DIFF
--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -138,8 +138,11 @@ func (s *Stream) Token() (interface{}, error) {
 			s.cursor++
 		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			bytes := floatBytes(s)
-			s := *(*string)(unsafe.Pointer(&bytes))
-			f64, err := strconv.ParseFloat(s, 64)
+			str := *(*string)(unsafe.Pointer(&bytes))
+			if s.UseNumber {
+				return json.Number(str), nil
+			}
+			f64, err := strconv.ParseFloat(str, 64)
 			if err != nil {
 				return nil, err
 			}

--- a/stream_test.go
+++ b/stream_test.go
@@ -7,6 +7,7 @@ package json_test
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -429,6 +430,16 @@ func TestDecodeInStream(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDecodeStreamUseNumber(t *testing.T) {
+	dec := json.NewDecoder(strings.NewReader(`3.14`))
+	dec.UseNumber()
+	v, err := dec.Token()
+	if err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
+	assertEq(t, "json.Number", "json.Number", fmt.Sprintf("%T", v))
 }
 
 // Test from golang.org/issue/11893


### PR DESCRIPTION
Currently when using a decoder stream to read a Token at a time, it does not respect the `UseNumber` setting and unconditionally returns a `float64` instead. This fixes the stream handling to properly respect the `UseNumber` setting. Also adds a unit test for the case.