### PR TITLE
fix: support for embedding alias of primitive types

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -3968,3 +3968,20 @@ func TestIssue335(t *testing.T) {
 		t.Errorf("unexpected success")
 	}
 }
+
+func TestIssue372(t *testing.T) {
+	type A int
+	type T struct {
+		_ int
+		*A
+	}
+	var v T
+	err := json.Unmarshal([]byte(`{"A":7}`), &v)
+	assertErr(t, err)
+
+	got := *v.A
+	expected := A(7)
+	if got != expected {
+		t.Errorf("unexpected result: %v != %v", got, expected)
+	}
+}

--- a/internal/decoder/compile.go
+++ b/internal/decoder/compile.go
@@ -393,6 +393,15 @@ func compileStruct(typ *runtime.Type, structName, fieldName string, structTypeTo
 						}
 						allFields = append(allFields, fieldSet)
 					}
+				} else {
+					fieldSet := &structFieldSet{
+						dec:         pdec,
+						offset:      field.Offset,
+						isTaggedKey: tag.IsTaggedKey,
+						key:         field.Name,
+						keyLen:      int64(len(field.Name)),
+					}
+					allFields = append(allFields, fieldSet)
 				}
 			} else {
 				fieldSet := &structFieldSet{


### PR DESCRIPTION
fix #372