### PR TITLE
fix: In decodeUnicode, the case that the expected buffer's state is not satisfied after reading.

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -7,12 +7,14 @@ import (
 	stdjson "encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"math/big"
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -2422,5 +2424,18 @@ func TestIssue376(t *testing.T) {
 	expected := `{"value":{"map":null}}`
 	if got != expected {
 		t.Errorf("unexpected result: %v != %v", got, expected)
+	}
+}
+
+func TestIssue374(t *testing.T) {
+	r := io.MultiReader(strings.NewReader(strings.Repeat(" ", 505)+`"\u`), strings.NewReader(`0000"`))
+	var v interface{}
+	if err := json.NewDecoder(r).Decode(&v); err != nil {
+		t.Fatal(err)
+	}
+	got := v.(string)
+	expected := "\u0000"
+	if got != expected {
+		t.Errorf("unexpected result: %q != %q", got, expected)
 	}
 }

--- a/internal/decoder/string.go
+++ b/internal/decoder/string.go
@@ -95,24 +95,30 @@ func unicodeToRune(code []byte) rune {
 	return r
 }
 
+func readAtLeast(s *Stream, n int64, p *unsafe.Pointer) bool {
+	for s.cursor+n >= s.length {
+		if !s.read() {
+			return false
+		}
+		*p = s.bufptr()
+	}
+	return true
+}
+
 func decodeUnicodeRune(s *Stream, p unsafe.Pointer) (rune, int64, unsafe.Pointer, error) {
 	const defaultOffset = 5
 	const surrogateOffset = 11
 
-	if s.cursor+defaultOffset >= s.length {
-		if !s.read() {
-			return rune(0), 0, nil, errors.ErrInvalidCharacter(s.char(), "escaped string", s.totalOffset())
-		}
-		p = s.bufptr()
+	if !readAtLeast(s, defaultOffset, &p) {
+		return rune(0), 0, nil, errors.ErrInvalidCharacter(s.char(), "escaped string", s.totalOffset())
 	}
 
 	r := unicodeToRune(s.buf[s.cursor+1 : s.cursor+defaultOffset])
 	if utf16.IsSurrogate(r) {
-		if s.cursor+surrogateOffset >= s.length {
-			s.read()
-			p = s.bufptr()
+		if !readAtLeast(s, surrogateOffset, &p) {
+			return unicode.ReplacementChar, defaultOffset, p, nil
 		}
-		if s.cursor+surrogateOffset >= s.length || s.buf[s.cursor+defaultOffset] != '\\' || s.buf[s.cursor+defaultOffset+1] != 'u' {
+		if s.buf[s.cursor+defaultOffset] != '\\' || s.buf[s.cursor+defaultOffset+1] != 'u' {
 			return unicode.ReplacementChar, defaultOffset, p, nil
 		}
 		r2 := unicodeToRune(s.buf[s.cursor+defaultOffset+2 : s.cursor+surrogateOffset])


### PR DESCRIPTION
fix #374

io.MultiReaderなどを使うケースでReadをしてもio.EOFでなく要求したバイト数取得できないケースが存在する.
その際にfilledBufferがfalseになる. filledBufferがfalseの場合, bufferを拡張する処理が動かないため再利用の処理のみが実行される.
decodeUnicodeRuneの内部においてbufferが拡張される前提で書かれている処理があり, それが原因でpanicが発生していた.
新たに readAtLeast という関数を導入し, 期待するバッファーの状態を満たすようにした.