### PR TITLE
fix encoder and decoder cache slice edge case

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -2468,3 +2468,126 @@ func TestIssue374(t *testing.T) {
 		t.Errorf("unexpected result: %q != %q", got, expected)
 	}
 }
+
+func TestIssue381(t *testing.T) {
+	var v struct {
+		Field0  bool
+		Field1  bool
+		Field2  bool
+		Field3  bool
+		Field4  bool
+		Field5  bool
+		Field6  bool
+		Field7  bool
+		Field8  bool
+		Field9  bool
+		Field10 bool
+		Field11 bool
+		Field12 bool
+		Field13 bool
+		Field14 bool
+		Field15 bool
+		Field16 bool
+		Field17 bool
+		Field18 bool
+		Field19 bool
+		Field20 bool
+		Field21 bool
+		Field22 bool
+		Field23 bool
+		Field24 bool
+		Field25 bool
+		Field26 bool
+		Field27 bool
+		Field28 bool
+		Field29 bool
+		Field30 bool
+		Field31 bool
+		Field32 bool
+		Field33 bool
+		Field34 bool
+		Field35 bool
+		Field36 bool
+		Field37 bool
+		Field38 bool
+		Field39 bool
+		Field40 bool
+		Field41 bool
+		Field42 bool
+		Field43 bool
+		Field44 bool
+		Field45 bool
+		Field46 bool
+		Field47 bool
+		Field48 bool
+		Field49 bool
+		Field50 bool
+		Field51 bool
+		Field52 bool
+		Field53 bool
+		Field54 bool
+		Field55 bool
+		Field56 bool
+		Field57 bool
+		Field58 bool
+		Field59 bool
+		Field60 bool
+		Field61 bool
+		Field62 bool
+		Field63 bool
+		Field64 bool
+		Field65 bool
+		Field66 bool
+		Field67 bool
+		Field68 bool
+		Field69 bool
+		Field70 bool
+		Field71 bool
+		Field72 bool
+		Field73 bool
+		Field74 bool
+		Field75 bool
+		Field76 bool
+		Field77 bool
+		Field78 bool
+		Field79 bool
+		Field80 bool
+		Field81 bool
+		Field82 bool
+		Field83 bool
+		Field84 bool
+		Field85 bool
+		Field86 bool
+		Field87 bool
+		Field88 bool
+		Field89 bool
+		Field90 bool
+		Field91 bool
+		Field92 bool
+		Field93 bool
+		Field94 bool
+		Field95 bool
+		Field96 bool
+		Field97 bool
+		Field98 bool
+		Field99 bool
+	}
+
+	// test encoder cache issue, not related to encoder
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Errorf("failed to marshal %s", err.Error())
+		t.FailNow()
+	}
+
+	std, err := stdjson.Marshal(v)
+	if err != nil {
+		t.Errorf("failed to marshal with encoding/json %s", err.Error())
+		t.FailNow()
+	}
+
+	if !bytes.Equal(std, b) {
+		t.Errorf("encoding result not equal to encoding/json")
+		t.FailNow()
+	}
+}

--- a/internal/decoder/compile.go
+++ b/internal/decoder/compile.go
@@ -24,7 +24,7 @@ func init() {
 	if typeAddr == nil {
 		typeAddr = &runtime.TypeAddr{}
 	}
-	cachedDecoder = make([]Decoder, typeAddr.AddrRange>>typeAddr.AddrShift)
+	cachedDecoder = make([]Decoder, typeAddr.AddrRange>>typeAddr.AddrShift+1)
 }
 
 func loadDecoderMap() map[uintptr]Decoder {

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -31,7 +31,7 @@ func init() {
 	if typeAddr == nil {
 		typeAddr = &runtime.TypeAddr{}
 	}
-	cachedOpcodeSets = make([]*OpcodeSet, typeAddr.AddrRange>>typeAddr.AddrShift)
+	cachedOpcodeSets = make([]*OpcodeSet, typeAddr.AddrRange>>typeAddr.AddrShift+1)
 }
 
 func loadOpcodeMap() map[uintptr]*OpcodeSet {


### PR DESCRIPTION
`typeptr == typeAddr.MaxTypeAddr` in this case, `cachedEncoder` get item out of range.

close #381