### PR TITLE
fix: unexpected behavior when buffer ends with backslash

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -3994,7 +3994,7 @@ func (t *issue384) UnmarshalJSON(b []byte) error {
 
 func TestIssue384(t *testing.T) {
 	testcases := []string{
-		"{\"data\":{\"text\": \"" + strings.Repeat("-", 492) + "\\\"\"}}\n",
+		"{\"data\": \"" + strings.Repeat("-", 500) + "\\\"\"}",
 		"[\"" + strings.Repeat("-", 508) + "\\\"\"]",
 	}
 	for _, tc := range testcases {

--- a/decode_test.go
+++ b/decode_test.go
@@ -3985,3 +3985,18 @@ func TestIssue372(t *testing.T) {
 		t.Errorf("unexpected result: %v != %v", got, expected)
 	}
 }
+
+type issue384 string
+
+func (t *issue384) UnmarshalJSON(b []byte) error {
+	return nil
+}
+
+func TestIssue384(t *testing.T) {
+	in := "{\"data\":{\"text\": \"" + strings.Repeat("-", 492) + "\\\"\"}}\n"
+	dec := json.NewDecoder(strings.NewReader(in))
+	var v issue384
+	if err := dec.Decode(&v); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -3994,8 +3994,8 @@ func (t *issue384) UnmarshalJSON(b []byte) error {
 
 func TestIssue384(t *testing.T) {
 	testcases := []string{
-		"{\"data\": \"" + strings.Repeat("-", 500) + "\\\"\"}",
-		"[\"" + strings.Repeat("-", 508) + "\\\"\"]",
+		`{"data": "` + strings.Repeat("-", 500) + `\""}`,
+		`["` + strings.Repeat("-", 508) + `\""]`,
 	}
 	for _, tc := range testcases {
 		dec := json.NewDecoder(strings.NewReader(tc))

--- a/decode_test.go
+++ b/decode_test.go
@@ -3986,17 +3986,22 @@ func TestIssue372(t *testing.T) {
 	}
 }
 
-type issue384 string
+type issue384 struct{}
 
 func (t *issue384) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
 func TestIssue384(t *testing.T) {
-	in := "{\"data\":{\"text\": \"" + strings.Repeat("-", 492) + "\\\"\"}}\n"
-	dec := json.NewDecoder(strings.NewReader(in))
-	var v issue384
-	if err := dec.Decode(&v); err != nil {
-		t.Errorf("unexpected error: %v", err)
+	testcases := []string{
+		"{\"data\":{\"text\": \"" + strings.Repeat("-", 492) + "\\\"\"}}\n",
+		"[\"" + strings.Repeat("-", 508) + "\\\"\"]",
+	}
+	for _, tc := range testcases {
+		dec := json.NewDecoder(strings.NewReader(tc))
+		var v issue384
+		if err := dec.Decode(&v); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 	}
 }

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -345,6 +345,7 @@ func (s *Stream) skipArray(depth int64) error {
 						s.cursor = cursor
 						if s.read() {
 							_, cursor, p = s.statForRetry()
+							cursor++
 							continue
 						}
 						return errors.ErrUnexpectedEndOfJSON("string of object", cursor)
@@ -403,6 +404,7 @@ func (s *Stream) skipValue(depth int64) error {
 						s.cursor = cursor
 						if s.read() {
 							_, cursor, p = s.statForRetry()
+							cursor++
 							continue
 						}
 						return errors.ErrUnexpectedEndOfJSON("value of string", s.totalOffset())

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -281,6 +281,7 @@ func (s *Stream) skipObject(depth int64) error {
 						s.cursor = cursor
 						if s.read() {
 							_, cursor, p = s.statForRetry()
+							cursor++
 							continue
 						}
 						return errors.ErrUnexpectedEndOfJSON("string of object", cursor)

--- a/internal/decoder/stream.go
+++ b/internal/decoder/stream.go
@@ -280,8 +280,7 @@ func (s *Stream) skipObject(depth int64) error {
 					if char(p, cursor) == nul {
 						s.cursor = cursor
 						if s.read() {
-							_, cursor, p = s.statForRetry()
-							cursor++
+							_, cursor, p = s.stat()
 							continue
 						}
 						return errors.ErrUnexpectedEndOfJSON("string of object", cursor)
@@ -344,8 +343,7 @@ func (s *Stream) skipArray(depth int64) error {
 					if char(p, cursor) == nul {
 						s.cursor = cursor
 						if s.read() {
-							_, cursor, p = s.statForRetry()
-							cursor++
+							_, cursor, p = s.stat()
 							continue
 						}
 						return errors.ErrUnexpectedEndOfJSON("string of object", cursor)
@@ -403,8 +401,7 @@ func (s *Stream) skipValue(depth int64) error {
 					if char(p, cursor) == nul {
 						s.cursor = cursor
 						if s.read() {
-							_, cursor, p = s.statForRetry()
-							cursor++
+							_, cursor, p = s.stat()
 							continue
 						}
 						return errors.ErrUnexpectedEndOfJSON("value of string", s.totalOffset())


### PR DESCRIPTION
fix https://github.com/goccy/go-json/issues/384

by increasing cursor by 1 to escape character properly. 