### PR TITLE
Decoding into interface bug

### DIFF
--- a/internal/decoder/interface.go
+++ b/internal/decoder/interface.go
@@ -97,6 +97,7 @@ var (
 	interfaceMapType   = runtime.Type2RType(
 		reflect.TypeOf((*map[string]interface{})(nil)).Elem(),
 	)
+	errorType  = reflect.TypeOf((*error)(nil)).Elem()
 	stringType = runtime.Type2RType(
 		reflect.TypeOf(""),
 	)
@@ -308,7 +309,10 @@ func (d *interfaceDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer
 			*(*interface{})(p) = nil
 			return nil
 		}
-		return d.errUnmarshalType(rv.Type(), s.totalOffset())
+		t := rv.Type()
+		if t == errorType {
+			return d.errUnmarshalType(rv.Type(), s.totalOffset())
+		}
 	}
 	iface := rv.Interface()
 	ifaceHeader := (*emptyInterface)(unsafe.Pointer(&iface))
@@ -370,8 +374,9 @@ func (d *interfaceDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p un
 			**(**interface{})(unsafe.Pointer(&p)) = nil
 			return cursor, nil
 		}
-		if _, b := rv.Type().MethodByName("Error"); b {
-			return 0, d.errUnmarshalType(rv.Type(), cursor)
+		t := rv.Type()
+		if t == errorType {
+			return 0, d.errUnmarshalType(t, cursor)
 		}
 	}
 

--- a/internal/decoder/interface.go
+++ b/internal/decoder/interface.go
@@ -370,7 +370,9 @@ func (d *interfaceDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p un
 			**(**interface{})(unsafe.Pointer(&p)) = nil
 			return cursor, nil
 		}
-		return 0, d.errUnmarshalType(rv.Type(), cursor)
+		if _, b := rv.Type().MethodByName("Error"); b {
+			return 0, d.errUnmarshalType(rv.Type(), cursor)
+		}
 	}
 
 	iface := rv.Interface()

--- a/internal/decoder/string.go
+++ b/internal/decoder/string.go
@@ -333,7 +333,7 @@ func (d *stringDecoder) decodeByte(buf []byte, cursor int64) ([]byte, int64, err
 						}
 						for i := int64(1); i <= 4; i++ {
 							c := char(b, cursor+i)
-							if !(('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')) {
+							if (('0' > c || c > '9') && ('a' > c || c > 'f') && ('A' > c || c > 'F')) {
 								return nil, 0, errors.ErrSyntax(fmt.Sprintf("json: invalid character %c in \\u hexadecimal character escape", c), cursor+i)
 							}
 						}


### PR DESCRIPTION
Also fixed error in DecodeStream

```
package main

import (
	"fmt"
	"strings"

	"github.com/goccy/go-json"
)

type EsDocument interface {
	IndexName() string
}

type Property struct {
	Name string `json:"name"`
}

func (p Property) IndexName() string {
	return "properties"
}

func main() {
	r := strings.NewReader(`{"name":"Test Property to remove"}`)
	p := Property{}

	unmarshallInterface(r, &p)

	fmt.Println(p)
}

func unmarshallInterface(r *strings.Reader, doc EsDocument) {
	
	if err := json.NewDecoder(r).Decode(&doc); err != nil {
		panic(err)
	}
}
```
Output:

```
{Test Property to remove}

```