### PR TITLE
Fix mapDecoder.DecodeStream() for empty objects containing whitespace

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -282,6 +282,14 @@ func Test_Decoder_DisallowUnknownFields(t *testing.T) {
 	}
 }
 
+func Test_Decoder_EmptyObjectWithSpace(t *testing.T) {
+	dec := json.NewDecoder(strings.NewReader(`{"obj":{ }}`))
+	var v struct {
+		Obj map[string]int `json:"obj"`
+	}
+	assertErr(t, dec.Decode(&v))
+}
+
 type unmarshalJSON struct {
 	v int
 }

--- a/internal/decoder/map.go
+++ b/internal/decoder/map.go
@@ -88,7 +88,7 @@ func (d *mapDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) erro
 		mapValue = makemap(d.mapType, 0)
 	}
 	s.cursor++
-	if s.equalChar('}') {
+	if s.skipWhiteSpace() == '}' {
 		*(*unsafe.Pointer)(p) = mapValue
 		s.cursor++
 		return nil


### PR DESCRIPTION
Current master breaks when encountering JSON containing an empty object containing whitespace like `{"obj":{ }}` when using the stream decoder - `Unmarshal()` behaves as expected.

This PR fixed that problem, and `NewDecoder().Decode()` will behave like `Unmarshal()`.
