### PR TITLE
feat: improve Decoder string unescaping performance

### DIFF
--- a/benchmarks/decode_test.go
+++ b/benchmarks/decode_test.go
@@ -479,11 +479,22 @@ func Benchmark_Decode_LargeStruct_Stream_GoJsonFirstWinMode(b *testing.B) {
 }
 
 func Benchmark_Decode_LargeSlice_EscapedString_GoJson(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		var v []string
-		if err := gojson.Unmarshal(LargeSliceEscapedString, &v); err != nil {
-			b.Fatal(err)
+	b.Run("Unmarshal", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var v []string
+			if err := gojson.Unmarshal(LargeSliceEscapedString, &v); err != nil {
+				b.Fatal(err)
+			}
 		}
-	}
+	})
+	b.Run("Decode", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var v []string
+			if err := gojson.NewDecoder(bytes.NewReader(LargeSliceEscapedString)).Decode(&v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }

--- a/internal/decoder/context.go
+++ b/internal/decoder/context.go
@@ -45,6 +45,10 @@ func char(ptr unsafe.Pointer, offset int64) byte {
 	return *(*byte)(unsafe.Pointer(uintptr(ptr) + uintptr(offset)))
 }
 
+func ptrUint16(ptr unsafe.Pointer, offset int64) *uint16 {
+	return (*uint16)(unsafe.Pointer(uintptr(ptr) + uintptr(offset)))
+}
+
 func skipWhiteSpace(buf []byte, cursor int64) int64 {
 	for isWhiteSpace[buf[cursor]] {
 		cursor++

--- a/internal/decoder/interface.go
+++ b/internal/decoder/interface.go
@@ -231,27 +231,13 @@ func (d *interfaceDecoder) decodeStreamEmptyInterface(s *Stream, depth int64, p 
 		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			return d.numDecoder(s).DecodeStream(s, depth, p)
 		case '"':
-			s.cursor++
-			start := s.cursor
-			for {
-				switch s.char() {
-				case '\\':
-					if _, err := decodeEscapeString(s, nil); err != nil {
-						return err
-					}
-				case '"':
-					literal := s.buf[start:s.cursor]
-					s.cursor++
-					*(*interface{})(p) = string(literal)
-					return nil
-				case nul:
-					if s.read() {
-						continue
-					}
-					return errors.ErrUnexpectedEndOfJSON("string", s.totalOffset())
-				}
-				s.cursor++
+			b, cursor, err := stringBytes(s)
+			s.cursor = cursor
+			if err != nil {
+				return err
 			}
+			*(*interface{})(p) = string(b)
+			return nil
 		case 't':
 			if err := trueBytes(s); err != nil {
 				return err


### PR DESCRIPTION
before
```
goos: darwin
goarch: arm64
pkg: benchmark
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2396	    501217 ns/op	  610443 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2370	    506517 ns/op	  635933 B/op	   10006 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2365	    500938 ns/op	  612078 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2216	    508809 ns/op	  643572 B/op	   10006 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2354	    505128 ns/op	  621201 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2235	    506122 ns/op	  631196 B/op	   10006 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2334	    501138 ns/op	  611282 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2360	    501009 ns/op	  609720 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2343	    505980 ns/op	  608884 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2362	    504268 ns/op	  614357 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      94	  12573430 ns/op	  586036 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      96	  12545696 ns/op	  586047 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      93	  12660176 ns/op	  591675 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      85	  12624620 ns/op	  586036 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      94	  12561482 ns/op	  591631 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      94	  12597026 ns/op	  586034 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      93	  12598319 ns/op	  586040 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      93	  12613099 ns/op	  586039 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      94	  12589107 ns/op	  597210 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	      96	  12599589 ns/op	  586044 B/op	   10014 allocs/op
```

after
```
goos: darwin
goarch: arm64
pkg: benchmark
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2396	    500616 ns/op	  615926 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2367	    508130 ns/op	  632242 B/op	   10006 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2360	    507290 ns/op	  622408 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2344	    503449 ns/op	  612675 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2325	    505496 ns/op	  617994 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2314	    504651 ns/op	  611184 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2290	    507516 ns/op	  615741 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2355	    514382 ns/op	  618502 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2136	    509533 ns/op	  617787 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12         	    2216	    507166 ns/op	  612041 B/op	   10005 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2430	    489476 ns/op	  586677 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2415	    527139 ns/op	  588856 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2358	    489797 ns/op	  586700 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2437	    487946 ns/op	  586247 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2415	    488028 ns/op	  586901 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2430	    490985 ns/op	  586895 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2421	    488670 ns/op	  586898 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2419	    487473 ns/op	  586249 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2406	    489513 ns/op	  586686 B/op	   10014 allocs/op
Benchmark_Decode_LargeSlice_EscapedString_GoJson/Decode-12            	    2380	    493454 ns/op	  586254 B/op	   10014 allocs/op
```

benchstat
```
goos: darwin
goarch: arm64
pkg: benchmark
                                                     │   ./old.txt   │              ./new.txt              │
                                                     │    sec/op     │   sec/op     vs base                │
_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12     504.7µ ± 1%   507.2µ ± 1%        ~ (p=0.123 n=10)
_Decode_LargeSlice_EscapedString_GoJson/Decode-12      12597.7µ ± 0%   489.5µ ± 1%  -96.11% (p=0.000 n=10)
geomean                                                  2.522m        498.3µ       -80.24%

                                                     │  ./old.txt   │              ./new.txt              │
                                                     │     B/op     │     B/op      vs base               │
_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12   598.8Ki ± 4%   602.4Ki ± 1%       ~ (p=0.631 n=10)
_Decode_LargeSlice_EscapedString_GoJson/Decode-12      572.3Ki ± 1%   572.9Ki ± 0%       ~ (p=0.138 n=10)
geomean                                                585.4Ki        587.5Ki       +0.35%

                                                     │  ./old.txt  │              ./new.txt               │
                                                     │  allocs/op  │  allocs/op   vs base                 │
_Decode_LargeSlice_EscapedString_GoJson/Unmarshal-12   10.01k ± 0%   10.01k ± 0%       ~ (p=0.582 n=10)
_Decode_LargeSlice_EscapedString_GoJson/Decode-12      10.01k ± 0%   10.01k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                10.01k        10.01k       +0.00%
¹ all samples are equal
```