### PR TITLE
fix: fix a bug for escaping 0xE2 0x80 0xA8 in compactString

### DIFF
--- a/internal/encoder/compact.go
+++ b/internal/encoder/compact.go
@@ -213,8 +213,8 @@ func compactString(dst, src []byte, cursor int64, escape bool) ([]byte, int64, e
 				dst = append(dst, src[start:cursor]...)
 				dst = append(dst, `\u202`...)
 				dst = append(dst, hex[src[cursor+2]&0xF])
-				cursor += 2
 				start = cursor + 3
+				cursor += 2
 			}
 		}
 		switch c {


### PR DESCRIPTION
the code below will panic
```
	v := struct {
		Type  string          `json:"type"`
		Value json.RawMessage `json:"value"`
	}{
		Type:  "pure",
		Value: json.RawMessage{0x22, 0x2e, 0xe2, 0x80, 0xa8, 0x22},
	}
	b, err := json.Marshal(&v)
	fmt.Printf("b: %s, err: %v\n", string(b), err)
```
