### PR TITLE
Fix ignoring `omitempty` tag when field of custom type with pointer receiver on MarshalJSON implementation (fixes #488)

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/goccy/go-json"
 )
 
+type stringAlias string
+
+func (d *stringAlias) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", *d)), nil
+}
+
+type intAlias int
+
+func (d *intAlias) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%d", *d)), nil
+}
+
 type recursiveT struct {
 	A *recursiveT `json:"a,omitempty"`
 	B *recursiveU `json:"b,omitempty"`
@@ -382,6 +394,18 @@ func Test_Marshal(t *testing.T) {
 				bytes, err := json.Marshal(v)
 				assertErr(t, err)
 				assertEq(t, "array", `{"b":{"c":1}}`, string(bytes))
+			})
+
+			t.Run("custom type with MarshalJSON implementation with pointer receiver", func(t *testing.T) {
+				type withOmit struct {
+					A string      `json:"a,omitempty"`
+					B stringAlias `json:"b,omitempty"`
+					C intAlias    `json:"c,omitempty"`
+				}
+				w := withOmit{}
+				bytes, err := json.Marshal(&w)
+				assertErr(t, err)
+				assertEq(t, "custom type with MarshalJSON implementation with pointer receiver", `{}`, string(bytes))
 			})
 		})
 		t.Run("head_omitempty", func(t *testing.T) {

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -668,7 +668,7 @@ func (c *Compiler) structFieldCode(structCode *StructCode, tag *runtime.StructTa
 		}
 		fieldCode.value = code
 		fieldCode.isAddrForMarshaler = true
-		fieldCode.isNilCheck = false
+		fieldCode.isNilCheck = true
 	case isPtr && c.isPtrMarshalTextType(fieldType):
 		// *struct{ field T }
 		// func (*T) MarshalText() ([]byte, error)


### PR DESCRIPTION
Fixes #488.

To do this I set `fieldCode.isNilCheck` to `true` in the case statement where `isPtr && c.isPtrMarshalJSONType(fieldType):` in `Compiler`'s method `structFieldCode`.
To be honest I don't exactly know all the implications to this, but this didn't break any tests and made the new test I added for the issue pass, so maybe this is a valid fix.