### PR TITLE
Reset runtime context options before releasing it back into pool

### DIFF
--- a/internal/decoder/context.go
+++ b/internal/decoder/context.go
@@ -27,6 +27,7 @@ func TakeRuntimeContext() *RuntimeContext {
 }
 
 func ReleaseRuntimeContext(ctx *RuntimeContext) {
+	ctx.Option = &Option{}
 	runtimeContextPool.Put(ctx)
 }
 

--- a/internal/encoder/context.go
+++ b/internal/encoder/context.go
@@ -101,5 +101,6 @@ func TakeRuntimeContext() *RuntimeContext {
 }
 
 func ReleaseRuntimeContext(ctx *RuntimeContext) {
+	ctx.Option = &Option{}
 	runtimeContextPool.Put(ctx)
 }


### PR DESCRIPTION
This PR makes sure `RuntimeContext` options are reset before the context is returned to the pool.

Fixes #499.