### PR TITLE
Updating libraries in a package with benchmarks to eliminate panic on go versions 1.18 and higher

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -5,18 +5,20 @@ go 1.19
 require (
 	github.com/francoispqt/gojay v1.2.13
 	github.com/goccy/go-json v0.0.0-00010101000000-000000000000
-	github.com/json-iterator/go v1.1.10
+	github.com/json-iterator/go v1.1.12
 	github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe
 	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7
-	github.com/segmentio/encoding v0.2.4
+	github.com/segmentio/encoding v0.3.4
 	github.com/valyala/fastjson v1.6.3
-	github.com/wI2L/jettison v0.7.1
+	github.com/wI2L/jettison v0.7.4
 )
 
 require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/sys v0.0.0-20220318055525-2edf467146b5 // indirect
 )
 
 replace github.com/goccy/go-json => ../

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -50,6 +50,8 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -68,6 +70,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -82,9 +86,13 @@ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.1.10/go.mod h1:RWhr02uzMB9gQC1x+MfYxedtmBibb9cZ6Vv9VxRSSbw=
 github.com/segmentio/encoding v0.2.4 h1:TQRXhTlXj4urZe3Z5QVgxs9Ad1i7GYHg9peAtjOPe28=
 github.com/segmentio/encoding v0.2.4/go.mod h1:MJjRE6bMDocliO2FyFC2Dusp+uYdBfHWh5Bw7QyExto=
+github.com/segmentio/encoding v0.3.4 h1:WM4IBnxH8B9TakiM2QD5LyNl9JSndh88QbHqVC+Pauc=
+github.com/segmentio/encoding v0.3.4/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
@@ -123,6 +131,8 @@ github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49u
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/wI2L/jettison v0.7.1 h1:XNq/WvSOAiJhFww9F5JZZcBZtKFL2Y/9WHHEHLDq9TE=
 github.com/wI2L/jettison v0.7.1/go.mod h1:dj49nOP41M7x6Jql62BqqF/+nW+XJgBaWzJR0hd6M84=
+github.com/wI2L/jettison v0.7.4 h1:ptjriu75R/k5RAZO0DJzy2t55f7g+dPiBxBY38icaKg=
+github.com/wI2L/jettison v0.7.4/go.mod h1:O+F+T7X7ZN6kTsd167Qk4aZMC8jNrH48SMedNmkfPb0=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d/go.mod h1:OWs+y06UdEOHN4y+MfF/py+xQ/tYqIWW03b70/CG9Rw=
@@ -155,6 +165,9 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181029174526-d69651ed3497/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220318055525-2edf467146b5 h1:saXMvIOKvRFwbOMicHXr0B1uwoxq9dGmLe5ExMES6c4=
+golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
When running benchmarks on version go 1.18 and higher, the tests panicked **Benchmark_Encode_MapInterface_JsonIter** and **Benchmark_Encode_MapInterface_Jettison** with the message:
```unexpected fault address 0x808085a175a75
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x808085a175a75 pc=0x757e0]

goroutine 1377 [running]:
runtime.throw({0x36e2c4?, 0x1f7f4?})
  /usr/local/go/src/runtime/panic.go:992 +0x50 fp=0x4000054ab0 sp=0x4000054a80 pc=0x46590
runtime.sigpanic()
  /usr/local/go/src/runtime/signal_unix.go:825 +0x1a4 fp=0x4000054ae0 sp=0x4000054ab0 pc=0x5d744
aeshashbody()
  /usr/local/go/src/runtime/asm_arm64.s:885 +0x2d0 fp=0x4000054af0 sp=0x4000054af0 pc=0x757e0
runtime.mapiternext(0x4000013d40)
  /usr/local/go/src/runtime/map.go:934 +0x2c4 fp=0x4000054b60 sp=0x4000054af0 pc=0x202c4
runtime.mapiterinit(0x4000054c08?, 0x1b3ec?, 0x4000054c18?)
  /usr/local/go/src/runtime/map.go:861 +0x2f4 fp=0x4000054b90 sp=0x4000054b60 pc=0x1ffc4
reflect.mapiterinit(0x4000054c48?, 0x7d3d4?, 0x4000054c98?)
  /usr/local/go/src/runtime/map.go:1373 +0x20 fp=0x4000054bc0 sp=0x4000054b90 pc=0x727a0
github.com/modern-go/reflect2.(*UnsafeMapType).UnsafeIterate(...)
  /go/pkg/mod/github.com/modern-go/reflect2@v1.0.1/unsafe_map.go:112
github.com/json-iterator/go.(*sortKeysMapEncoder).Encode(0x40004c6f90, 0x40000da338, 0x4000a40f00)
  /go/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_map.go:291 +0x244 fp=0x4000054d40 sp=0x4000054bc0 pc=0x291014
github.com/json-iterator/go.(*onePtrEncoder).Encode(0x4000c3c160, 0x40004c6ab0, 0x4000013d40?)
  /go/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect.go:219 +0x8c fp=0x4000054d80 sp=0x4000054d40 pc=0x28988c
github.com/json-iterator/go.(*Stream).WriteVal(0x4000a40f00, {0x31d600, 0x40004c6ab0})
  /go/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect.go:98 +0x174 fp=0x4000054e00 sp=0x4000054d80 pc=0x288c44
github.com/json-iterator/go.(*frozenConfig).Marshal(0x4000014be0, {0x31d600, 0x40004c6ab0})
  /go/pkg/mod/github.com/json-iterator/go@v1.1.10/config.go:299 +0x88 fp=0x4000054ea0 sp=0x4000054e00 pc=0x281028
benchmark.Benchmark_Encode_MapInterface_JsonIter(0x400014c900)
  /root/go-json/benchmarks/encode_test.go:590 +0x25c fp=0x4000054f10 sp=0x4000054ea0 pc=0x2e9a9c
testing.(*B).runN(0x400014c900, 0x1)
  /usr/local/go/src/testing/benchmark.go:193 +0x134 fp=0x4000054f90 sp=0x4000054f10 pc=0xd9504
testing.(*B).run1.func1()
  /usr/local/go/src/testing/benchmark.go:233 +0x54 fp=0x4000054fd0 sp=0x4000054f90 pc=0xd9ab4
runtime.goexit()
  /usr/local/go/src/runtime/asm_arm64.s:1270 +0x4 fp=0x4000054fd0 sp=0x4000054fd0 pc=0x78814
created by testing.(*B).run1
  /usr/local/go/src/testing/benchmark.go:226 +0x90

goroutine 1 [chan receive]:
testing.(*B).run1(0x400014c900)
  /usr/local/go/src/testing/benchmark.go:235 +0xa0
testing.(*B).Run(0x400014c240, {0x37d10a?, 0x4000105b28?}, 0x389430)
  /usr/local/go/src/testing/benchmark.go:676 +0x3d0
testing.runBenchmarks.func1(0x400014c240?)
  /usr/local/go/src/testing/benchmark.go:550 +0x74
testing.(*B).runN(0x400014c240, 0x1)
  /usr/local/go/src/testing/benchmark.go:193 +0x134
testing.runBenchmarks({0x36f47b, 0x9}, 0x6289c0?, {0x5f2660, 0xa2, 0x23540?})
  /usr/local/go/src/testing/benchmark.go:559 +0x3a8
testing.(*M).Run(0x4000014d20)
  /usr/local/go/src/testing/testing.go:1726 +0x6e0
main.main()
  _testmain.go:369 +0x1e8
exit status 2
```

Updating libraries **github.com/json-iterator/go** and **github.com/wI2L/jettison** solves the problem.