### PR TITLE
Fix encode []*time.Time - check nil

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -426,6 +426,11 @@ func Test_Marshal(t *testing.T) {
 			assertErr(t, err)
 			assertEq(t, "[]interface{}", `[1,2.1,"hello"]`, string(bytes))
 		})
+		t.Run("[]*time.Time", func(t *testing.T) {
+			bytes, err := json.Marshal([]*time.Time{nil})
+			assertErr(t, err)
+			assertEq(t, "[]*time.Time", `[null]`, string(bytes))
+		})
 	})
 
 	t.Run("array", func(t *testing.T) {

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -406,6 +406,11 @@ func AppendMarshalJSON(ctx *RuntimeContext, code *Opcode, b []byte, v interface{
 			rv = newV
 		}
 	}
+
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return AppendNull(ctx, b), nil
+	}
+
 	v = rv.Interface()
 	var bb []byte
 	if (code.Flags & MarshalerContextFlags) != 0 {


### PR DESCRIPTION
@goccy, thank you very much for the library, it really improves performance a lot - **blazing fast!!!**
But I found incompatibility with the standard library (``encoding/json``) for Marshal []*time.Time (issue https://github.com/goccy/go-json/issues/523)
I have prepared a fix, I really hope for a prompt review my PR. 
