### PR TITLE
Add benchmark for large payloads with string escaping

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -640,3 +640,27 @@ func Benchmark_Indent_GoJson(b *testing.B) {
 		}
 	}
 }
+
+func Benchmark_EscapedStrings_GoJson(b *testing.B) {
+	payload := EscapedStringsFixture(100000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var escaped []EscapedStrings
+		if err := json.NewDecoder(bytes.NewReader(payload)).Decode(&escaped); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func Benchmark_EscapedStrings_EncodingJson(b *testing.B) {
+	payload := EscapedStringsFixture(100000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var escaped []EscapedStrings
+		if err := stdjson.NewDecoder(bytes.NewReader(payload)).Decode(&escaped); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/benchmarks/escaped_strings.go
+++ b/benchmarks/escaped_strings.go
@@ -1,0 +1,31 @@
+package benchmark
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/goccy/go-json"
+)
+
+type EscapedStrings struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+}
+
+// EscapedStringsFixture returns a serialised version of a slice of the EscapedStrings struct, with the given number of entities in it.
+func EscapedStringsFixture(n int) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		b, _ := json.Marshal(EscapedStrings{
+			ID:   strconv.Itoa(i),
+			Text: "This is\ta string\twith some escape sequences\n in it",
+		})
+		buf.Write(b)
+	}
+	buf.WriteByte(']')
+	return buf.Bytes()
+}


### PR DESCRIPTION
Illustrates the issue in #535 

Output on my machine:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 5900X 12-Core Processor            
Benchmark_EscapedStrings_GoJson-24          	      1	27586403115 ns/op	23464256 B/op	 100081 allocs/op
Benchmark_EscapedStrings_EncodingJson-24    	     13	 82155502 ns/op	47859819 B/op	 300046 allocs/op
PASS
ok  	command-line-arguments	28.829s
```
Note that the two are pretty competitive if the payload size is reduced to 1000 objects. At 1000000 (10x this PR) it may as well be hanging.