### PR TITLE
Fix: the typ of emptyInterface does not match ptr(#519, #510)

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"reflect"
 	"unsafe"
 
 	"github.com/goccy/go-json/internal/encoder"
@@ -219,6 +220,8 @@ func encode(ctx *encoder.RuntimeContext, v interface{}) ([]byte, error) {
 		b = encoder.AppendComma(ctx, b)
 		return b, nil
 	}
+
+	v = prepareForEncode(ctx, v)
 	header := (*emptyInterface)(unsafe.Pointer(&v))
 	typ := header.typ
 
@@ -247,6 +250,8 @@ func encodeNoEscape(ctx *encoder.RuntimeContext, v interface{}) ([]byte, error) 
 		b = encoder.AppendComma(ctx, b)
 		return b, nil
 	}
+
+	v = prepareForEncode(ctx, v)
 	header := (*emptyInterface)(unsafe.Pointer(&v))
 	typ := header.typ
 
@@ -274,6 +279,8 @@ func encodeIndent(ctx *encoder.RuntimeContext, v interface{}, prefix, indent str
 		b = encoder.AppendCommaIndent(ctx, b)
 		return b, nil
 	}
+
+	v = prepareForEncode(ctx, v)
 	header := (*emptyInterface)(unsafe.Pointer(&v))
 	typ := header.typ
 
@@ -323,4 +330,15 @@ func encodeRunIndentCode(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder
 		return vm_color_indent.Run(ctx, b, codeSet)
 	}
 	return vm_indent.Run(ctx, b, codeSet)
+}
+
+func prepareForEncode(ctx *encoder.RuntimeContext, v interface{}) interface{} {
+	rv := reflect.ValueOf(v)
+	// struct to *struct，fix: https://github.com/goccy/go-json/issues/519
+	if rv.Kind() == reflect.Struct {
+		newV := reflect.New(rv.Type())
+		newV.Elem().Set(rv)
+		v = newV.Interface()
+	}
+	return v
 }

--- a/encode.go
+++ b/encode.go
@@ -2,8 +2,10 @@ package json
 
 import (
 	"context"
+	"github.com/goccy/go-json/internal/runtime"
 	"io"
 	"os"
+	"reflect"
 	"unsafe"
 
 	"github.com/goccy/go-json/internal/encoder"
@@ -219,7 +221,7 @@ func encode(ctx *encoder.RuntimeContext, v interface{}) ([]byte, error) {
 		b = encoder.AppendComma(ctx, b)
 		return b, nil
 	}
-	header := (*emptyInterface)(unsafe.Pointer(&v))
+	header := unpackEface(v)
 	typ := header.typ
 
 	typeptr := uintptr(unsafe.Pointer(typ))
@@ -247,7 +249,7 @@ func encodeNoEscape(ctx *encoder.RuntimeContext, v interface{}) ([]byte, error) 
 		b = encoder.AppendComma(ctx, b)
 		return b, nil
 	}
-	header := (*emptyInterface)(unsafe.Pointer(&v))
+	header := unpackEface(v)
 	typ := header.typ
 
 	typeptr := uintptr(unsafe.Pointer(typ))
@@ -274,7 +276,7 @@ func encodeIndent(ctx *encoder.RuntimeContext, v interface{}, prefix, indent str
 		b = encoder.AppendCommaIndent(ctx, b)
 		return b, nil
 	}
-	header := (*emptyInterface)(unsafe.Pointer(&v))
+	header := unpackEface(v)
 	typ := header.typ
 
 	typeptr := uintptr(unsafe.Pointer(typ))
@@ -323,4 +325,15 @@ func encodeRunIndentCode(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder
 		return vm_color_indent.Run(ctx, b, codeSet)
 	}
 	return vm_indent.Run(ctx, b, codeSet)
+}
+
+func unpackEface(v interface{}) *emptyInterface {
+	nv := (*emptyInterface)(unsafe.Pointer(&v))
+	// struct to *struct，fix: https://github.com/goccy/go-json/issues/519
+	if nv.typ.Kind() == reflect.Struct && nv.typ.Kind_&runtime.KindDirectIface != 0 {
+		n := &emptyInterface{typ: runtime.PtrTo(nv.typ), ptr: runtime.Unsafe_New(nv.typ)}
+		*(*unsafe.Pointer)(n.ptr) = nv.ptr
+		nv = n
+	}
+	return nv
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -1779,7 +1779,9 @@ func (v *testNullStr) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	return []byte(*v), nil
+	bs := append([]byte{'"'}, []byte(*v)...)
+	bs = append(bs, '"')
+	return bs, nil
 }
 
 func TestIssue147(t *testing.T) {
@@ -2714,4 +2716,64 @@ func TestIssue441(t *testing.T) {
 	b, err := json.Marshal(B{})
 	assertErr(t, err)
 	assertEq(t, "unexpected result", "{}", string(b))
+}
+
+func TestIssue519(t *testing.T) {
+	type Item struct {
+		A string `json:"a"`
+		B string `json:"b,omitempty"`
+	}
+
+	type Detail struct {
+		I Item `json:"i"`
+	}
+
+	type Body struct {
+		Payload *Detail `json:"p,omitempty"`
+	}
+
+	b, err := json.Marshal(Body{
+		Payload: &Detail{
+			I: Item{
+				A: "123",
+				B: "456",
+			},
+		},
+	})
+	assertErr(t, err)
+	exp, _ := stdjson.Marshal(Body{
+		Payload: &Detail{
+			I: Item{
+				A: "123",
+				B: "456",
+			},
+		},
+	})
+	assertEq(t, "unexpected result", string(exp), string(b))
+}
+
+func TestIssue510(t *testing.T) {
+	type B struct {
+		Foo *string `json:"foo"`
+		Bar *string `json:"bar"`
+	}
+
+	type A struct {
+		B *B `json:"b"`
+	}
+
+	str := "hello"
+
+	b, err := json.Marshal(A{
+		B: &B{
+			Foo: &str,
+		},
+	})
+	assertErr(t, err)
+	exp, _ := stdjson.Marshal(A{
+		B: &B{
+			Foo: &str,
+		},
+	})
+	assertEq(t, "unexpected result", string(exp), string(b))
 }

--- a/internal/runtime/rtype.go
+++ b/internal/runtime/rtype.go
@@ -5,8 +5,29 @@ import (
 	"unsafe"
 )
 
+const (
+	KindDirectIface = 1 << 5
+)
+
 // Type representing reflect.rtype for noescape trick
-type Type struct{}
+type Type struct {
+	Size_       uintptr
+	PtrBytes    uintptr // number of (prefix) bytes in the type that can contain pointers
+	Hash        uint32  // hash of type; avoids computation in hash tables
+	TFlag       uint8   // extra type information flags
+	Align_      uint8   // alignment of variable with this type
+	FieldAlign_ uint8   // alignment of struct field with this type
+	Kind_       uint8   // enumeration for C
+	// function for comparing objects of this type
+	// (ptr to object A, ptr to object B) -> ==?
+	Equal func(unsafe.Pointer, unsafe.Pointer) bool
+	// GCData stores the GC type data for the garbage collector.
+	// If the KindGCProg bit is set in kind, GCData is a GC program.
+	// Otherwise it is a ptrmask bitmap. See mbitmap.go for details.
+	GCData    *byte
+	Str       int32 // string form
+	PtrToThis int32 // type for pointer to this type, may be zero
+}
 
 //go:linkname rtype_Align reflect.(*rtype).Align
 //go:noescape
@@ -260,3 +281,7 @@ type emptyInterface struct {
 func Type2RType(t reflect.Type) *Type {
 	return (*Type)(((*emptyInterface)(unsafe.Pointer(&t))).ptr)
 }
+
+//go:linkname Unsafe_New reflect.unsafe_New
+//go:noescape
+func Unsafe_New(p *Type) unsafe.Pointer


### PR DESCRIPTION
fix: The typ of emptyInterface does not match ptr

**Issue**:
When struct A contains a single field that is a pointer to struct B (e.g., `A { B *B }`),encoding an instance of `A{}` into our custom `emptyInterface` causes a value-pointer mismatch:
- `emptyInterface.typ` points to the type descriptor of `A`
- `emptyInterface.ptr` points directly to the embedded `B` field (type `*B`)

**Solution**:
Encode `&A{}` (pointer to struct) instead of `A{}` (struct value). This ensures:
1. `EmptyInterface.typ` correctly points to `*A`
2. `EmptyInterface.ptr` holds the address of the `A` instance, which contains a valid `*B` field
3. Type assertions and reflection operations on the interface now work as expected

Fixes #519, #510