### PR TITLE
fix(decoder): add a nil check for decoder in unmarshal to prevent panic

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -38,9 +38,12 @@ func unmarshal(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
 	if err != nil {
 		return err
 	}
-	if dec == nil {
-		return errors.New("go-json: CompileToGetDecoder returned a nil decoder")
-	}
+    if err == nil && dec == nil {
+       return fmt.Errorf(
+           "go-json: CompileToGetDecoder returned a nil decoder for type %s",
+           header.typ.String(),
+       )
+    }
 	ctx := decoder.TakeRuntimeContext()
 	ctx.Buf = src
 	ctx.Option.Flags = 0

--- a/decode.go
+++ b/decode.go
@@ -38,6 +38,9 @@ func unmarshal(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
 	if err != nil {
 		return err
 	}
+	if dec == nil {
+		return errors.New("go-json: CompileToGetDecoder returned a nil decoder")
+	}
 	ctx := decoder.TakeRuntimeContext()
 	ctx.Buf = src
 	ctx.Option.Flags = 0

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -745,6 +745,9 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 }
 
 func (d *structDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
+	if d == nil {
+		return 0, errors.New("go-json: Decode called on a nil structDecoder")
+	}
 	buf := ctx.Buf
 	depth++
 	if depth > maxDecodeNestingDepth {

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -745,9 +745,6 @@ func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) e
 }
 
 func (d *structDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p unsafe.Pointer) (int64, error) {
-	if d == nil {
-		return 0, errors.New("go-json: Decode called on a nil structDecoder")
-	}
 	buf := ctx.Buf
 	depth++
 	if depth > maxDecodeNestingDepth {


### PR DESCRIPTION
**Problem:**
Our production service is experiencing panics with the error `runtime error: invalid memory address or nil pointer dereference`. The stack trace points to the `Decode` method of the `go-json` library's internal `structDecoder`.

This crash occurs when the `Decode` method is called on a `nil` `structDecoder` instance. The root cause is suspected to be a race condition in the library's internal caching mechanism, where a "poisoned" `nil` value is written to the shared decoder cache by one goroutine and then read by another, causing the panic.

**Solution:**
~~This change introduces a guard clause at the very beginning of the `structDecoder.Decode` method to check if the receiver (`d`) is `nil`.~~

~~If `d` is `nil`, the function will now immediately return a descriptive error instead of proceeding and panicking.~~

This change introduces a defensive check in the `unmarshal` function,  immediately after the call to `decoder.CompileToGetDecoder`.

It now explicitly checks if the returned decoder is `nil` even if the error is also `nil`. This correctly identifies the silent failure from the compiler and converts it into a descriptive, actionable error, preventing the panic.

**Note:**
This is a defensive hotfix for #495 , designed to improve service stability by preventing this specific panic from crashing the application