### PR TITLE
Add UnmarshalUnsafe and UnmarshalBYOB for reduced allocations

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -25,6 +25,62 @@ type emptyInterface struct {
 	ptr unsafe.Pointer
 }
 
+func unmarshalUnsafe(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
+	header := (*emptyInterface)(unsafe.Pointer(&v))
+	if err := validateType(header.typ, uintptr(header.ptr)); err != nil {
+		return err
+	}
+	dec, err := decoder.CompileToGetDecoder(header.typ)
+	if err != nil {
+		return err
+	}
+	ctx := decoder.TakeRuntimeContext()
+	if cap(ctx.Buf) < len(data)+1 {
+		ctx.Buf = make([]byte, len(data)+1)
+	}
+	ctx.Buf = ctx.Buf[:len(data)+1]
+	ctx.Buf[len(data)] = '\000'
+	copy(ctx.Buf, data)
+	ctx.Option.Flags = 0
+	for _, optFunc := range optFuncs {
+		optFunc(ctx.Option)
+	}
+	cursor, err := dec.Decode(ctx, 0, 0, header.ptr)
+	if err != nil {
+		decoder.ReleaseRuntimeContext(ctx)
+		return err
+	}
+	err = validateEndBuf(ctx.Buf, cursor)
+	decoder.ReleaseRuntimeContext(ctx)
+	return err
+}
+func unmarshalBYOB(buffer, data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
+	copy(buffer, data)
+
+	header := (*emptyInterface)(unsafe.Pointer(&v))
+
+	if err := validateType(header.typ, uintptr(header.ptr)); err != nil {
+		return err
+	}
+	dec, err := decoder.CompileToGetDecoder(header.typ)
+	if err != nil {
+		return err
+	}
+	ctx := decoder.TakeRuntimeContext()
+	ctx.Buf = buffer
+	ctx.Option.Flags = 0
+	for _, optFunc := range optFuncs {
+		optFunc(ctx.Option)
+	}
+	cursor, err := dec.Decode(ctx, 0, 0, header.ptr)
+	if err != nil {
+		decoder.ReleaseRuntimeContext(ctx)
+		return err
+	}
+	decoder.ReleaseRuntimeContext(ctx)
+	return validateEndBuf(buffer, cursor)
+}
+
 func unmarshal(data []byte, v interface{}, optFuncs ...DecodeOptionFunc) error {
 	src := make([]byte, len(data)+1) // append nul byte to the end
 	copy(src, data)

--- a/json.go
+++ b/json.go
@@ -276,6 +276,15 @@ func Unmarshal(data []byte, v interface{}) error {
 	return unmarshal(data, v)
 }
 
+func UnmarshalUnsafe(data []byte, v interface{}) error {
+	return unmarshalUnsafe(data, v)
+}
+
+func UnmarshalBYOB(buffer, data []byte, v interface{}) error {
+	return unmarshalBYOB(buffer, data, v)
+}
+
+
 // UnmarshalContext parses the JSON-encoded data and stores the result
 // in the value pointed to by v. If you implement the UnmarshalerContext interface,
 // call it with ctx as an argument.


### PR DESCRIPTION
- UnmarshalUnsafe: Reuses pooled context buffer to avoid allocations
- UnmarshalBYOB: Bring-Your-Own-Buffer API for caller-managed buffers
- Both optimizations reduce memory allocations in hot paths
- Useful for high-frequency WebSocket message parsing