### PR TITLE
fix: call MarshalJSON() for nil/zero direct-interface types

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -1457,6 +1457,81 @@ func TestNilMarshal(t *testing.T) {
 	}
 }
 
+// nilFuncMarshaler is a named function type that implements json.Marshaler with a
+// value receiver. This exercises the case where a nil func (direct-interface type)
+// is marshalled: go-json should call MarshalJSON rather than short-circuiting to null.
+type nilFuncMarshaler func(yield func(int) bool)
+
+func (f nilFuncMarshaler) MarshalJSON() ([]byte, error) {
+	if f == nil {
+		return []byte(`[]`), nil
+	}
+	return []byte(`[1]`), nil
+}
+
+// nilSingleFieldStructMarshaler is a struct with exactly one func field.
+// Such a struct is a direct-interface type (IfaceIndir=false): its single field is
+// stored directly in the interface data word, so a zero-value struct (fn==nil)
+// produces p==0 in the encoder — the same condition that triggered the bug for func
+// types. Verifying this case ensures the fix covers all direct-interface types, not
+// only named func/map/chan types.
+type nilSingleFieldStructMarshaler struct{ fn func() }
+
+func (s nilSingleFieldStructMarshaler) MarshalJSON() ([]byte, error) {
+	if s.fn == nil {
+		return []byte(`"zero"`), nil
+	}
+	return []byte(`"nonzero"`), nil
+}
+
+// TestNilFuncMarshaler checks that a nil func type implementing json.Marshaler
+// produces the output of MarshalJSON rather than "null".
+// This matches the behaviour of encoding/json (see golang.org/issue/16042).
+func TestNilFuncMarshaler(t *testing.T) {
+	var f nilFuncMarshaler // nil
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("Marshal nil nilFuncMarshaler: unexpected error: %v", err)
+	}
+	if string(b) != `[]` {
+		t.Errorf("Marshal nil nilFuncMarshaler = %s, want []", b)
+	}
+
+	// Non-nil func must still work.
+	f = func(yield func(int) bool) { yield(1) }
+	b, err = json.Marshal(f)
+	if err != nil {
+		t.Fatalf("Marshal non-nil nilFuncMarshaler: unexpected error: %v", err)
+	}
+	if string(b) != `[1]` {
+		t.Errorf("Marshal non-nil nilFuncMarshaler = %s, want [1]", b)
+	}
+}
+
+// TestNilSingleFieldStructMarshaler checks that a struct with a single pointer-shaped
+// field (a direct-interface type) calls MarshalJSON even when the field is nil/zero.
+func TestNilSingleFieldStructMarshaler(t *testing.T) {
+	// Zero value: fn == nil → p == 0 in VM → must still call MarshalJSON.
+	s := nilSingleFieldStructMarshaler{}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal zero nilSingleFieldStructMarshaler: unexpected error: %v", err)
+	}
+	if string(b) != `"zero"` {
+		t.Errorf("Marshal zero nilSingleFieldStructMarshaler = %s, want \"zero\"", b)
+	}
+
+	// Non-zero value must still work.
+	s = nilSingleFieldStructMarshaler{fn: func() {}}
+	b, err = json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal non-zero nilSingleFieldStructMarshaler: unexpected error: %v", err)
+	}
+	if string(b) != `"nonzero"` {
+		t.Errorf("Marshal non-zero nilSingleFieldStructMarshaler = %s, want \"nonzero\"", b)
+	}
+}
+
 // Issue 5245.
 func TestEmbeddedBug(t *testing.T) {
 	v := BugB{

--- a/internal/encoder/code.go
+++ b/internal/encoder/code.go
@@ -861,6 +861,7 @@ type MarshalJSONCode struct {
 	isAddrForMarshaler bool
 	isNilableType      bool
 	isMarshalerContext bool
+	isDirectIfaceMarshaler bool // func, map, chan: nil value should still invoke MarshalJSON
 }
 
 func (c *MarshalJSONCode) Kind() CodeKind {
@@ -881,6 +882,9 @@ func (c *MarshalJSONCode) ToOpcode(ctx *compileContext) Opcodes {
 	} else {
 		code.Flags &= ^IsNilableTypeFlags
 	}
+	if c.isDirectIfaceMarshaler {
+		code.Flags |= DirectIfaceMarshalerFlags
+	}
 	ctx.incIndex()
 	return Opcodes{code}
 }
@@ -892,6 +896,7 @@ func (c *MarshalJSONCode) Filter(query *FieldQuery) Code {
 		isAddrForMarshaler: c.isAddrForMarshaler,
 		isNilableType:      c.isNilableType,
 		isMarshalerContext: c.isMarshalerContext,
+		isDirectIfaceMarshaler: c.isDirectIfaceMarshaler,
 	}
 }
 

--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -412,10 +412,11 @@ func (c *Compiler) interfaceCode(typ *runtime.Type, isPtr bool) (*InterfaceCode,
 //nolint:unparam
 func (c *Compiler) marshalJSONCode(typ *runtime.Type) (*MarshalJSONCode, error) {
 	return &MarshalJSONCode{
-		typ:                typ,
-		isAddrForMarshaler: c.isPtrMarshalJSONType(typ),
-		isNilableType:      c.isNilableType(typ),
-		isMarshalerContext: typ.Implements(marshalJSONContextType) || runtime.PtrTo(typ).Implements(marshalJSONContextType),
+		typ:                    typ,
+		isAddrForMarshaler:     c.isPtrMarshalJSONType(typ),
+		isNilableType:          c.isNilableType(typ),
+		isMarshalerContext:     typ.Implements(marshalJSONContextType) || runtime.PtrTo(typ).Implements(marshalJSONContextType),
+		isDirectIfaceMarshaler: c.isDirectIfaceMarshaler(typ),
 	}, nil
 }
 
@@ -890,6 +891,10 @@ func (c *Compiler) isPtrMarshalJSONType(typ *runtime.Type) bool {
 
 func (c *Compiler) isPtrMarshalTextType(typ *runtime.Type) bool {
 	return !typ.Implements(marshalTextType) && runtime.PtrTo(typ).Implements(marshalTextType)
+}
+
+func (c *Compiler) isDirectIfaceMarshaler(typ *runtime.Type) bool {
+	return !runtime.IfaceIndir(typ) && typ.Kind() != reflect.Ptr
 }
 
 func (c *Compiler) codeToOpcode(ctx *compileContext, typ *runtime.Type, code Code) *Opcode {

--- a/internal/encoder/opcode.go
+++ b/internal/encoder/opcode.go
@@ -15,16 +15,17 @@ const uintptrSize = 4 << (^uintptr(0) >> 63)
 type OpFlags uint16
 
 const (
-	AnonymousHeadFlags     OpFlags = 1 << 0
-	AnonymousKeyFlags      OpFlags = 1 << 1
-	IndirectFlags          OpFlags = 1 << 2
-	IsTaggedKeyFlags       OpFlags = 1 << 3
-	NilCheckFlags          OpFlags = 1 << 4
-	AddrForMarshalerFlags  OpFlags = 1 << 5
-	IsNextOpPtrTypeFlags   OpFlags = 1 << 6
-	IsNilableTypeFlags     OpFlags = 1 << 7
-	MarshalerContextFlags  OpFlags = 1 << 8
-	NonEmptyInterfaceFlags OpFlags = 1 << 9
+	AnonymousHeadFlags        OpFlags = 1 << 0
+	AnonymousKeyFlags         OpFlags = 1 << 1
+	IndirectFlags             OpFlags = 1 << 2
+	IsTaggedKeyFlags          OpFlags = 1 << 3
+	NilCheckFlags             OpFlags = 1 << 4
+	AddrForMarshalerFlags     OpFlags = 1 << 5
+	IsNextOpPtrTypeFlags      OpFlags = 1 << 6
+	IsNilableTypeFlags        OpFlags = 1 << 7
+	MarshalerContextFlags     OpFlags = 1 << 8
+	NonEmptyInterfaceFlags    OpFlags = 1 << 9
+	DirectIfaceMarshalerFlags OpFlags = 1 << 10 // func, map, chan: nil value should still invoke MarshalJSON
 )
 
 type Opcode struct {

--- a/internal/encoder/vm/vm.go
+++ b/internal/encoder/vm/vm.go
@@ -261,9 +261,11 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 		case encoder.OpMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
-				b = appendNullComma(ctx, b)
-				code = code.Next
-				break
+				if (code.Flags & encoder.DirectIfaceMarshalerFlags) == 0 {
+					b = appendNullComma(ctx, b)
+					code = code.Next
+					break
+				}
 			}
 			if (code.Flags&encoder.IsNilableTypeFlags) != 0 && (code.Flags&encoder.IndirectFlags) != 0 {
 				p = ptrToPtr(p)

--- a/internal/encoder/vm_color/vm.go
+++ b/internal/encoder/vm_color/vm.go
@@ -261,9 +261,11 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 		case encoder.OpMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
-				b = appendNullComma(ctx, b)
-				code = code.Next
-				break
+				if (code.Flags & encoder.DirectIfaceMarshalerFlags) == 0 {
+					b = appendNullComma(ctx, b)
+					code = code.Next
+					break
+				}
 			}
 			if (code.Flags&encoder.IsNilableTypeFlags) != 0 && (code.Flags&encoder.IndirectFlags) != 0 {
 				p = ptrToPtr(p)

--- a/internal/encoder/vm_color_indent/vm.go
+++ b/internal/encoder/vm_color_indent/vm.go
@@ -261,9 +261,11 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 		case encoder.OpMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
-				b = appendNullComma(ctx, b)
-				code = code.Next
-				break
+				if (code.Flags & encoder.DirectIfaceMarshalerFlags) == 0 {
+					b = appendNullComma(ctx, b)
+					code = code.Next
+					break
+				}
 			}
 			if (code.Flags&encoder.IsNilableTypeFlags) != 0 && (code.Flags&encoder.IndirectFlags) != 0 {
 				p = ptrToPtr(p)

--- a/internal/encoder/vm_indent/vm.go
+++ b/internal/encoder/vm_indent/vm.go
@@ -261,9 +261,11 @@ func Run(ctx *encoder.RuntimeContext, b []byte, codeSet *encoder.OpcodeSet) ([]b
 		case encoder.OpMarshalJSON:
 			p := load(ctxptr, code.Idx)
 			if p == 0 {
-				b = appendNullComma(ctx, b)
-				code = code.Next
-				break
+				if (code.Flags & encoder.DirectIfaceMarshalerFlags) == 0 {
+					b = appendNullComma(ctx, b)
+					code = code.Next
+					break
+				}
 			}
 			if (code.Flags&encoder.IsNilableTypeFlags) != 0 && (code.Flags&encoder.IndirectFlags) != 0 {
 				p = ptrToPtr(p)


### PR DESCRIPTION
## Bug

When a named `func`, `map`, `chan`, or single-pointer-field struct implements
`json.Marshaler` with a value receiver, marshalling a nil or zero value returns
`"null"` instead of calling `MarshalJSON`.

```go
type Seq[V any] func(func(V) bool)

func (s Seq[V]) MarshalJSON() ([]byte, error) {
	if s == nil {
		return []byte("[]"), nil
	}
	// ...
}

var s Seq[int]
json.Marshal(s)      // "null"  ← bug
stdjson.Marshal(s)   // "[]"    ← correct
```

The same applies to a struct with a single pointer-shaped field (`struct{ fn func() }`).

## Why

Go stores *direct-interface* types — `func`, `map`, `chan`, and structs whose single
field is pointer-shaped — directly in the interface data word rather than behind a heap
pointer. A nil such value produces `data == nil` (i.e. `p == 0`) in the encoder.

The `OpMarshalJSON` VM handler has a `p == 0` early return that was meant for nil
pointers:

```go
case encoder.OpMarshalJSON:
    p := load(ctxptr, code.Idx)
    if p == 0 {
        b = appendNullComma(ctx, b)  // fires for nil func/map/chan too
        code = code.Next
        break
    }
```

`encoding/json` avoids this by restricting its nil check to `reflect.Pointer` only, so
`MarshalJSON` is always reached for nil funcs and maps:

```go
// encoding/json
func marshalerEncoder(e *encodeState, v reflect.Value, ...) {
    if v.Kind() == reflect.Pointer && v.IsNil() {
        e.WriteString("null")
        return
    }
    m, _ := v.Interface().(Marshaler)
    m.MarshalJSON()
}
```

## Fix

Add a `DirectIfaceMarshalerFlags` opcode bit, set by the compiler for types where
`!IfaceIndir(typ) && typ.Kind() != reflect.Ptr`. When the flag is present, the
`p == 0` branch is skipped and execution falls through to `ptrToInterface(code, 0)`,
which builds a nil-valued interface. `AppendMarshalJSON` then dispatches it normally —
`encoding/json`'s pointer-only nil check is not triggered, so `MarshalJSON` is called
on the nil receiver.

```go
case encoder.OpMarshalJSON:
    p := load(ctxptr, code.Idx)
    if p == 0 {
        if (code.Flags & encoder.DirectIfaceMarshalerFlags) == 0 {
            b = appendNullComma(ctx, b)
            code = code.Next
            break
        }
    }
```

The same change is applied to all four vm variants.
