### PR TITLE
fix: case-insensitive key lookup for structs with >16 fields

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4057,3 +4057,54 @@ func TestIssue429(t *testing.T) {
 		}
 	}
 }
+
+func TestUnmarshalStructMoreThan16FieldsCaseInsensitive(t *testing.T) {
+	// Regression test for https://github.com/goccy/go-json/issues/427
+	// Structs with >16 fields must support case-insensitive key matching.
+	// JSON keys in camelCase must match PascalCase struct fields (no json tags).
+	type Large struct {
+		SomeField1  string
+		SomeField2  string
+		SomeField3  string
+		SomeField4  string
+		SomeField5  string
+		SomeField6  string
+		SomeField7  string
+		SomeField8  string
+		SomeField9  string
+		SomeField10 string
+		SomeField11 string
+		SomeField12 string
+		SomeField13 string
+		SomeField14 string
+		SomeField15 string
+		SomeField16 string
+		SomeField17 string
+	}
+	const input = `{
+		"someField1":  "v1",
+		"someField2":  "v2",
+		"someField3":  "v3",
+		"someField4":  "v4",
+		"someField5":  "v5",
+		"someField6":  "v6",
+		"someField7":  "v7",
+		"someField8":  "v8",
+		"someField9":  "v9",
+		"someField10": "v10",
+		"someField11": "v11",
+		"someField12": "v12",
+		"someField13": "v13",
+		"someField14": "v14",
+		"someField15": "v15",
+		"someField16": "v16",
+		"someField17": "v17"
+	}`
+	var got Large
+	if err := json.Unmarshal([]byte(input), &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if got.SomeField1 != "v1" || got.SomeField17 != "v17" {
+		t.Errorf("case-insensitive decode failed for >16-field struct: got SomeField1=%q SomeField17=%q", got.SomeField1, got.SomeField17)
+	}
+}

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -378,7 +378,7 @@ func decodeKey(d *structDecoder, buf []byte, cursor int64) (int64, *structFieldS
 	k := *(*string)(unsafe.Pointer(&key))
 	field, exists := d.fieldMap[k]
 	if !exists {
-		return cursor, nil, nil
+		field = d.fieldMap[strings.ToLower(k)]
 	}
 	return cursor, field, nil
 }
@@ -657,7 +657,11 @@ func decodeKeyStream(d *structDecoder, s *Stream) (*structFieldSet, string, erro
 		return nil, "", err
 	}
 	k := *(*string)(unsafe.Pointer(&key))
-	return d.fieldMap[k], k, nil
+	field, exists := d.fieldMap[k]
+	if !exists {
+		field = d.fieldMap[strings.ToLower(k)]
+	}
+	return field, k, nil
 }
 
 func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) error {


### PR DESCRIPTION
Fixes #427.

When a struct has more than 16 fields, `tryOptimize` sets `isTriedOptimize = true` and
the decoder falls back to `decodeKey`/`decodeKeyStream`. These fallback functions looked
up JSON keys in `fieldMap` using an exact (case-sensitive) match.

`fieldMap` is populated with two entries per field: the original name (e.g. `SomeField1`)
and its lowercased form (`somefield1`). A camelCase JSON key such as `someField1` matches
neither, so the field is silently skipped and left at its zero value.

The optimized path (<=16 fields) uses a bitmap built from lowercased keys and converts each
incoming byte with `largeToSmallTable`, so it is case-insensitive. The fallback path lacked
the equivalent.

Fix: after an exact miss, retry with `strings.ToLower(k)`, which is guaranteed to be present
in `fieldMap` when the key maps to a known field.

The regression test uses a 17-field struct with camelCase JSON keys and no json tags,
which is the exact scenario from the issue.