### PR TITLE
path: fix godoc prefix on UsedDoubleQuotePathSelector

### DIFF
--- a/path.go
+++ b/path.go
@@ -43,7 +43,7 @@ func (p *Path) UsedSingleQuotePathSelector() bool {
 	return p.path.SingleQuotePathSelector
 }
 
-// UsedSingleQuotePathSelector whether double quote-based escaping was done when building the JSON Path.
+// UsedDoubleQuotePathSelector whether double quote-based escaping was done when building the JSON Path.
 func (p *Path) UsedDoubleQuotePathSelector() bool {
 	return p.path.DoubleQuotePathSelector
 }


### PR DESCRIPTION
Noticed while reading path.go. The godoc comment on `UsedDoubleQuotePathSelector` starts with `UsedSingleQuotePathSelector` (copy-paste from the method right above), so godoc renders the wrong identifier as the leading reference. The body of the comment already says "double quote-based escaping" correctly.