### PR TITLE
Decode into a non-empty interface field that already holds a value

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4057,3 +4057,60 @@ func TestIssue429(t *testing.T) {
 		}
 	}
 }
+
+type issue405Thing interface{ thing() }
+
+type issue405ThingA struct {
+	A int `json:"a"`
+}
+
+func (*issue405ThingA) thing() {}
+
+func TestIssue405(t *testing.T) {
+	type container struct {
+		Thing issue405Thing `json:"thing"`
+	}
+
+	// A non-empty interface field that already holds a concrete pointer value
+	// must be decoded into that value, matching encoding/json.
+	t.Run("Unmarshal", func(t *testing.T) {
+		v := container{Thing: &issue405ThingA{}}
+		assertErr(t, json.Unmarshal([]byte(`{"thing": {"a": 1}}`), &v))
+		got, ok := v.Thing.(*issue405ThingA)
+		if !ok {
+			t.Fatalf("unexpected type: %T", v.Thing)
+		}
+		assertEq(t, "issue405", 1, got.A)
+	})
+
+	t.Run("Decoder", func(t *testing.T) {
+		v := container{Thing: &issue405ThingA{}}
+		if err := json.NewDecoder(bytes.NewReader([]byte(`{"thing": {"a": 2}}`))).Decode(&v); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := v.Thing.(*issue405ThingA)
+		if !ok {
+			t.Fatalf("unexpected type: %T", v.Thing)
+		}
+		assertEq(t, "issue405", 2, got.A)
+	})
+
+	// null clears the field without error.
+	t.Run("null", func(t *testing.T) {
+		v := container{Thing: &issue405ThingA{A: 3}}
+		assertErr(t, json.Unmarshal([]byte(`{"thing": null}`), &v))
+		assertEq(t, "issue405", true, v.Thing == nil)
+	})
+
+	// A nil interface field cannot be decoded into, same as encoding/json.
+	t.Run("nil interface", func(t *testing.T) {
+		var v container
+		if err := json.Unmarshal([]byte(`{"thing": {"a": 1}}`), &v); err == nil {
+			t.Fatal("expected error when decoding into a nil interface field")
+		}
+		var std container
+		if err := stdjson.Unmarshal([]byte(`{"thing": {"a": 1}}`), &std); err == nil {
+			t.Fatal("expected encoding/json to also error")
+		}
+	})
+}

--- a/internal/decoder/interface.go
+++ b/internal/decoder/interface.go
@@ -309,6 +309,17 @@ func (d *interfaceDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer
 			*(*interface{})(p) = nil
 			return nil
 		}
+		// If the interface already holds a concrete pointer value (as
+		// encoding/json supports), decode into that value rather than failing.
+		iface := rv.Interface()
+		ifaceHeader := (*emptyInterface)(unsafe.Pointer(&iface))
+		if typ := ifaceHeader.typ; ifaceHeader.ptr != nil && typ != nil && typ.Kind() == reflect.Ptr {
+			decoder, err := CompileToGetDecoder(typ)
+			if err != nil {
+				return err
+			}
+			return decoder.DecodeStream(s, depth, ifaceHeader.ptr)
+		}
 		return d.errUnmarshalType(rv.Type(), s.totalOffset())
 	}
 	iface := rv.Interface()
@@ -370,6 +381,17 @@ func (d *interfaceDecoder) Decode(ctx *RuntimeContext, cursor, depth int64, p un
 			cursor += 4
 			**(**interface{})(unsafe.Pointer(&p)) = nil
 			return cursor, nil
+		}
+		// If the interface already holds a concrete pointer value (as
+		// encoding/json supports), decode into that value rather than failing.
+		iface := rv.Interface()
+		ifaceHeader := (*emptyInterface)(unsafe.Pointer(&iface))
+		if typ := ifaceHeader.typ; ifaceHeader.ptr != nil && typ != nil && typ.Kind() == reflect.Ptr {
+			decoder, err := CompileToGetDecoder(typ)
+			if err != nil {
+				return 0, err
+			}
+			return decoder.Decode(ctx, cursor, depth, ifaceHeader.ptr)
 		}
 		return 0, d.errUnmarshalType(rv.Type(), cursor)
 	}


### PR DESCRIPTION
Fixes #405.

When a struct field has a named (non-empty) interface type and already holds a concrete pointer value, `encoding/json` decodes the JSON into that value. go-json instead returns an `UnmarshalTypeError` as soon as the interface has methods and the stored value is not a json/text unmarshaler, so the field is never populated.

```go
type Thing interface{ F() }
type ThingA struct {
    A int `json:"a"`
}
func (t *ThingA) F() {}

type Something struct {
    Thing Thing `json:"thing"`
}

s := Something{Thing: &ThingA{}}
err := json.Unmarshal([]byte(`{"thing": {"a": 1}}`), &s)
// encoding/json: err == nil, s.Thing == &ThingA{A: 1}
// go-json:       err = "cannot unmarshal main.Thing into Go struct field Something.Thing of type main.Thing"
```

The interface decoder already has the logic to decode into a stored concrete pointer (it is used for the empty-interface path). This change reuses it in the method-interface branch: if the interface holds a concrete pointer value, decode into it; otherwise keep returning the error. A nil interface field still errors, matching `encoding/json`, because there is nothing to decode into. The same fix is applied to both `Decode` and `DecodeStream`.

I checked the `error`-interface case raised on the earlier attempt (#406): an `error`-typed field with no concrete value still errors, and one preset with a concrete `*T` decodes into it, both matching the standard library.

Added `TestIssue405` covering `Unmarshal`, the streaming `Decoder`, the `null` input case, and the nil-interface-still-errors case. It fails on master and passes with this change. Full `go test ./...` is green.