### PR TITLE
Fix test format strings for Go vet

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -2407,7 +2407,7 @@ func TestUnmarshalUnexported(t *testing.T) {
 		t.Errorf("got error %v, expected nil", err)
 	}
 	if !reflect.DeepEqual(out, want) {
-		t.Errorf("got %q, want %q", out, want)
+		t.Errorf("got %#v, want %#v", out, want)
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -991,11 +991,11 @@ func TestMarshalerError(t *testing.T) {
 		want string
 	}{
 		{
-			json.NewMarshalerError(st, fmt.Errorf(errText), ""),
+			json.NewMarshalerError(st, fmt.Errorf("%s", errText), ""),
 			"json: error calling MarshalJSON for type " + st.String() + ": " + errText,
 		},
 		{
-			json.NewMarshalerError(st, fmt.Errorf(errText), "TestMarshalerError"),
+			json.NewMarshalerError(st, fmt.Errorf("%s", errText), "TestMarshalerError"),
 			"json: error calling TestMarshalerError for type " + st.String() + ": " + errText,
 		},
 	}


### PR DESCRIPTION
Summary:
- Use value-oriented formats in tests where structs are passed to `t.Errorf`.
- This avoids invalid `%q` usage reported by current Go vet.

Testing:
- `go test ./...`