### PR TITLE
fix: embedded omitempty field dropped / nil-pointer panic in nested embedded structs (#576, #581, #554)

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -2778,3 +2778,21 @@ func TestIssue581(t *testing.T) {
 	assertErr(t, err)
 	assertEq(t, "unexpected result", `{"type":"","reason":{"reasonCode":"x"}}`, string(b))
 }
+
+func TestIssue554(t *testing.T) {
+	type Son struct {
+		B string `json:"b"`
+		C string `json:"c"`
+	}
+	type Father struct {
+		Son
+		A []string `json:"a,omitempty"`
+	}
+	type Grandpa struct {
+		Father
+	}
+
+	b, err := json.Marshal(&Grandpa{})
+	assertErr(t, err)
+	assertEq(t, "unexpected result", `{"b":"","c":""}`, string(b))
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -2754,3 +2754,27 @@ func TestIssue576(t *testing.T) {
 	assertErr(t, err)
 	assertEq(t, "unexpected result", `{"error":"boom","data":"hi"}`, string(b))
 }
+
+func TestIssue581(t *testing.T) {
+	type Reason struct {
+		Code string `json:"reasonCode,omitempty"`
+	}
+	type Cov struct {
+		Type string `json:"type"`
+	}
+	type Inner struct {
+		Cov
+		R *Reason `json:"reason,omitempty"`
+	}
+	type Outer struct {
+		Inner
+	}
+
+	b, err := json.Marshal(Outer{})
+	assertErr(t, err)
+	assertEq(t, "unexpected result", `{"type":""}`, string(b))
+
+	b, err = json.Marshal(Outer{Inner{R: &Reason{Code: "x"}}})
+	assertErr(t, err)
+	assertEq(t, "unexpected result", `{"type":"","reason":{"reasonCode":"x"}}`, string(b))
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -2729,3 +2729,28 @@ func TestIssue459(t *testing.T) {
 	assertErr(t, err)
 	assertEq(t, "unexpected result", "{}", string(b))
 }
+
+func TestIssue576(t *testing.T) {
+	type ErrOmit struct {
+		Error string `json:"error,omitempty"`
+	}
+	type MyResult struct {
+		ErrOmit
+		Data string `json:"data"`
+	}
+	type Result struct {
+		MyResult
+	}
+
+	b, err := json.Marshal(Result{})
+	assertErr(t, err)
+	assertEq(t, "unexpected result", `{"data":""}`, string(b))
+
+	b, err = json.Marshal(Result{MyResult{Data: "hi"}})
+	assertErr(t, err)
+	assertEq(t, "unexpected result", `{"data":"hi"}`, string(b))
+
+	b, err = json.Marshal(Result{MyResult{ErrOmit{Error: "boom"}, "hi"}})
+	assertErr(t, err)
+	assertEq(t, "unexpected result", `{"error":"boom","data":"hi"}`, string(b))
+}

--- a/internal/encoder/code.go
+++ b/internal/encoder/code.go
@@ -515,7 +515,7 @@ func (c *StructCode) ToAnonymousOpcode(ctx *compileContext) Opcodes {
 				firstField.End = lastField
 			}
 		}
-		prevField = firstField
+		prevField = c.lastFieldCode(field, firstField)
 		codes = codes.Add(fieldCodes...)
 	}
 	ctx.structTypeToCodes[uintptr(unsafe.Pointer(c.typ))] = codes


### PR DESCRIPTION
Fixes #576. Also fixes the panic reported in #581 and #554.

When an embedded struct's first field is tagged `omitempty` and is empty, the whole containing struct serialized to `{}`, silently dropping every following field (#576). The same broken wiring also caused a nil-pointer panic for two closely related shapes (#581, #554).

The cause is in `encoder.StructCode.ToAnonymousOpcode`: `prevField` was set to `firstField` (the anonymous head opcode) rather than the last field of the embedded chain, so the omitempty field's `NextField` never linked to the next real field. `addStructEndCode` then wired that head's empty-skip jump straight to `StructEnd`. The non-anonymous `ToOpcode` path already does this correctly via `lastFieldCode`; this mirrors it.

```go
// #576: dropped fields
type ErrOmit struct {
    Error string `json:"error,omitempty"`
}
type MyResult struct {
    ErrOmit
    Data string `json:"data"`
}
type Result struct{ MyResult }
// before: {}        encoding/json: {"data":""}

// #581: panic
type Reason struct {
    Code string `json:"reasonCode,omitempty"`
}
type Cov struct {
    Type string `json:"type"`
}
type Inner struct {
    Cov
    R *Reason `json:"reason,omitempty"`
}
type Outer struct{ Inner }
// before: panic (nil pointer)   encoding/json: {"type":""}

// #554: panic
type Son struct {
    B string `json:"b"`
    C string `json:"c"`
}
type Father struct {
    Son
    A []string `json:"a,omitempty"`
}
type Grandpa struct{ Father }
// before: panic (nil pointer)   encoding/json: {"b":"","c":""}
```

Added `TestIssue576` (empty / data-only / both-fields), `TestIssue581` (nil and set pointer), and `TestIssue554` (double-nested embedded with trailing omitempty empty slice). Each was confirmed to fail before the change (`{"data":""}` -> `{}` for #576, panic for #581 and #554) and pass after. Full `go test ./...` is green, gofmt clean.

For anyone triaging the embedded-omitempty cluster: I dump-tested the neighbours against this branch. #512 is a *distinct* shape (a plain field followed by an embedded struct whose own field is omitempty, double-nested) that goes through a separate opcode path and still panics; not addressed here. #486 (nil embedded self-pointer emitting `{"id":99,null}`) and #503 (omitempty pointer child with a zero first byte) are also separate paths that survive this fix and remain open. Happy to follow those up in separate PRs.
