### PR TITLE
Guard nil pointers in MarshalIndent / MarshalText sibling paths

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -21,6 +21,17 @@ import (
 	"github.com/goccy/go-json"
 )
 
+// ptrTextMarshaler implements encoding.TextMarshaler with a pointer receiver
+// that dereferences the receiver, so calling MarshalText on a nil
+// *ptrTextMarshaler panics. A nil element in []*ptrTextMarshaler must therefore
+// be encoded as null rather than crashing (mirrors the []*time.Time fix from
+// #524, extended to the text-marshaler and indent encode paths).
+type ptrTextMarshaler struct{ s string }
+
+func (t *ptrTextMarshaler) MarshalText() ([]byte, error) {
+	return []byte(t.s), nil
+}
+
 type recursiveT struct {
 	A *recursiveT `json:"a,omitempty"`
 	B *recursiveU `json:"b,omitempty"`
@@ -430,6 +441,21 @@ func Test_Marshal(t *testing.T) {
 			bytes, err := json.Marshal([]*time.Time{nil})
 			assertErr(t, err)
 			assertEq(t, "[]*time.Time", `[null]`, string(bytes))
+		})
+		t.Run("[]*time.Time indent", func(t *testing.T) {
+			bytes, err := json.MarshalIndent([]*time.Time{nil}, "", "  ")
+			assertErr(t, err)
+			assertEq(t, "[]*time.Time indent", "[\n  null\n]", string(bytes))
+		})
+		t.Run("[]*ptrTextMarshaler", func(t *testing.T) {
+			bytes, err := json.Marshal([]*ptrTextMarshaler{nil})
+			assertErr(t, err)
+			assertEq(t, "[]*ptrTextMarshaler", `[null]`, string(bytes))
+		})
+		t.Run("[]*ptrTextMarshaler indent", func(t *testing.T) {
+			bytes, err := json.MarshalIndent([]*ptrTextMarshaler{nil}, "", "  ")
+			assertErr(t, err)
+			assertEq(t, "[]*ptrTextMarshaler indent", "[\n  null\n]", string(bytes))
 		})
 	})
 

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -459,6 +459,11 @@ func AppendMarshalJSONIndent(ctx *RuntimeContext, code *Opcode, b []byte, v inte
 			rv = newV
 		}
 	}
+
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return AppendNull(ctx, b), nil
+	}
+
 	v = rv.Interface()
 	var bb []byte
 	if (code.Flags & MarshalerContextFlags) != 0 {
@@ -509,6 +514,11 @@ func AppendMarshalText(ctx *RuntimeContext, code *Opcode, b []byte, v interface{
 			rv = newV
 		}
 	}
+
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return AppendNull(ctx, b), nil
+	}
+
 	v = rv.Interface()
 	marshaler, ok := v.(encoding.TextMarshaler)
 	if !ok {
@@ -532,6 +542,11 @@ func AppendMarshalTextIndent(ctx *RuntimeContext, code *Opcode, b []byte, v inte
 			rv = newV
 		}
 	}
+
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return AppendNull(ctx, b), nil
+	}
+
 	v = rv.Interface()
 	marshaler, ok := v.(encoding.TextMarshaler)
 	if !ok {


### PR DESCRIPTION
Merged PR #524 added a nil-pointer guard to `AppendMarshalJSON`, but the same indirection-without-nil-check exists in three sibling helpers in `internal/encoder/encoder.go`: `AppendMarshalJSONIndent`, `AppendMarshalText`, `AppendMarshalTextIndent`. So `json.MarshalIndent([]*time.Time{nil})` and slices of nil `*T` implementing `TextMarshaler` with a value receiver panic instead of emitting `null`, diverging from stdlib `encoding/json`.

The fix ports the same guard #524 added into the three sibling paths. Verified both ways with `go test`: old panics on all three, fixed emits `null`/indented; the existing `TestNilMarshal` (nil-safe-receiver) still passes, full suite green, 0 regression.