### PR TITLE
fix: bounds-check nul sentinel in struct key escape scan (checkptr OOB)

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4057,3 +4057,31 @@ func TestIssue429(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue577(t *testing.T) {
+	// struct key with a dangling backslash at end of input must decode
+	// error, not read past the buffer (goccy/go-json#575, #577)
+	type T struct {
+		Hash     string `json:"hash"`
+		PrevHash string `json:"prev_hash"`
+		Data     string `json:"data"`
+		Seq      int64  `json:"seq"`
+		TsNs     int64  `json:"ts_ns"`
+		Kind     uint8  `json:"kind"`
+	}
+	inputs := []string{
+		"{\"\\29\\",
+		"{\"hAs\\",
+		"{\"a\\",
+		"{\"\\",
+	}
+	for i := 0; i < 8; i++ {
+		inputs = append(inputs, `{"`+strings.Repeat("a", i)+`\`)
+	}
+	for _, b := range inputs {
+		var x T
+		if err := json.Unmarshal([]byte(b), &x); err == nil {
+			t.Errorf("input %q: expected decode error, got nil", b)
+		}
+	}
+}

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -215,6 +215,9 @@ func decodeKeyCharByEscapedChar(buf []byte, cursor int64) ([]byte, int64, error)
 		return []byte{'\t'}, cursor, nil
 	case 'u':
 		return decodeKeyCharByUnicodeRune(buf, cursor)
+	case nul:
+		// dangling backslash at end of buffer, don't step past the sentinel
+		return nil, cursor, errors.ErrUnexpectedEndOfJSON("string", cursor)
 	}
 	return nil, cursor, nil
 }


### PR DESCRIPTION
Fixes #577 (also fixes the #575 duplicate).

`decodeKeyByBitmapUint8` scans struct keys with raw unsafe.Pointer
arithmetic via `char()`. On a dangling backslash at the end of the
buffer (e.g. `{"hAs\`), `decodeKeyCharByEscapedChar` had no case for the
trailing nul sentinel, so it fell through to the unmatched-case
`return nil, cursor, nil` and handed back a cursor still pointing at
the sentinel. The caller then advances one past it, and the next
`char()` reads one byte past the backing allocation. Under `-race`
(which enables checkptr) that is a fatal, unrecoverable crash instead
of a decode error.

Handle nul as end of input and return `ErrUnexpectedEndOfJSON`, the
same error the surrounding key decoder already returns for other
truncated-input cases. Confirmed the checkptr crash on master before
the change and its absence after, under `go test -race`.

Added TestIssue577 with the reported repro plus a few more
dangling-backslash variants, in the style of TestIssue429.
