### PR TITLE
fix(decoder): case-insensitive key match for large structs

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -4057,3 +4057,33 @@ func TestIssue429(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue568CaseInsensitiveLargeStruct(t *testing.T) {
+	type large struct {
+		F1  string `json:"f1"`
+		F2  string `json:"f2"`
+		F3  string `json:"f3"`
+		F4  string `json:"f4"`
+		F5  string `json:"f5"`
+		F6  string `json:"f6"`
+		F7  string `json:"f7"`
+		F8  string `json:"f8"`
+		F9  string `json:"f9"`
+		F10 string `json:"f10"`
+		F11 string `json:"f11"`
+		F12 string `json:"f12"`
+		F13 string `json:"f13"`
+		F14 string `json:"f14"`
+		F15 string `json:"f15"`
+		F16 string `json:"f16"`
+		Name bool  `json:"name,omitempty"`
+	}
+	input := []byte(`{"Name":true}`)
+	var v large
+	if err := json.Unmarshal(input, &v); err != nil {
+		t.Fatal(err)
+	}
+	if !v.Name {
+		t.Fatalf("expected case-insensitive match for Name->name on 17-field struct")
+	}
+}

--- a/internal/decoder/struct.go
+++ b/internal/decoder/struct.go
@@ -378,7 +378,12 @@ func decodeKey(d *structDecoder, buf []byte, cursor int64) (int64, *structFieldS
 	k := *(*string)(unsafe.Pointer(&key))
 	field, exists := d.fieldMap[k]
 	if !exists {
-		return cursor, nil, nil
+		// encoding/json accepts case-insensitive matches. Bitmap-optimized
+		// paths already lower-case keys; the map fallback must too (#568).
+		field, exists = d.fieldMap[strings.ToLower(k)]
+		if !exists {
+			return cursor, nil, nil
+		}
 	}
 	return cursor, field, nil
 }
@@ -657,7 +662,11 @@ func decodeKeyStream(d *structDecoder, s *Stream) (*structFieldSet, string, erro
 		return nil, "", err
 	}
 	k := *(*string)(unsafe.Pointer(&key))
-	return d.fieldMap[k], k, nil
+	if field, ok := d.fieldMap[k]; ok {
+		return field, k, nil
+	}
+	// Same case-insensitive fallback as decodeKey for large structs (#568).
+	return d.fieldMap[strings.ToLower(k)], k, nil
 }
 
 func (d *structDecoder) DecodeStream(s *Stream, depth int64, p unsafe.Pointer) error {


### PR DESCRIPTION
## Summary
Structs with **more than 16 unique JSON field names** skip the bitmap key decoder (`allowOptimizeMaxFieldLen = 16`) and use plain `fieldMap` lookups.

That fallback only did exact-key matches, so case-insensitive unmarshaling broke:

```text
{"Name":true} → json:"name" on a 17-field struct stayed false
```

(16 fields still worked because the optimized path lower-cases keys.)

## Fix
In `decodeKey` / `decodeKeyStream`, if the exact key is missing, look up `strings.ToLower(key)` — matching the lower-case aliases already inserted in `compileStruct`.

## Test plan
- [x] `go test -run TestIssue568CaseInsensitiveLargeStruct .`
- [x] `go test .`
- [x] mini repro: 16 fields + 17 fields vs `encoding/json`

Fixes #568
